### PR TITLE
style: simplify prettier config to intentional overrides only

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,4 @@
 {
-  "semi": true,
-  "trailingComma": "es5",
   "singleQuote": true,
-  "printWidth": 100,
-  "tabWidth": 2,
-  "useTabs": false
+  "printWidth": 100
 }


### PR DESCRIPTION
Removes redundant Prettier settings that match project defaults, simplifying the configuration to only intentional overrides.

## Changes
- Removed settings matching Prettier's default values: `semi`, `trailingComma`, `tabWidth`, `useTabs`
- Kept only two intentional deviations:
  - `singleQuote: true` (aligns with JavaScript community standard)
  - `printWidth: 100` (improves readability for modern displays)

## Benefits
- Cleaner, more maintainable configuration
- Reduces noise and makes intent clear
- Still enforces consistent formatting across the project

## Testing
No functional changes - Prettier behavior remains identical.