### PR TITLE
docs: refactor CONTRIBUTING.md to follow Diátaxis framework

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -453,6 +453,76 @@ export function CharacterCard({ character, onClick }: CharacterCardProps) {
 
 ---
 
+## Code Comments and Local Documentation
+
+**Philosophy**: Prefer inline comments in code over external documentation for explaining decisions, trade-offs, and non-obvious logic. Documentation should live close to the code it describes.
+
+### When to Comment
+
+Comment liberally for:
+
+- **Decisions and trade-offs**: Explain why you chose one approach over another
+- **Non-obvious logic**: Complex algorithms, business rules, or unintuitive implementations
+- **Workarounds**: Temporary fixes or browser quirks with issue/ticket references
+- **Performance considerations**: Why certain patterns are used (memoization, lazy loading, etc.)
+- **External dependencies**: Integration points or third-party API quirks
+
+**Examples**:
+
+```typescript
+// Memoize to prevent unnecessary re-renders since characters array changes frequently
+// from Firebase updates. This is a known bottleneck for large collections (100+ chars).
+const memoizedCharacters = useMemo(() => characters.map((c) => new Character(c)), [characters]);
+
+// Firebase listener doesn't trigger on subcollection changes, so we need to
+// manually refetch when teams change. See: https://github.com/firebase/firebase-js-sdk/issues/1234
+const handleTeamUpdate = useCallback(async () => {
+  await refetchCharacters();
+}, []);
+
+// Work around Vite's CommonJS plugin limitation with dynamic imports.
+// Can be removed once we upgrade to Vite 6+
+const config = await import('./config.js').then((m) => m.default);
+```
+
+### When NOT to Comment
+
+Don't comment for:
+
+- **Self-documenting code**: `const isValidEmail = email.includes('@')` needs no comment
+- **Simple iterations or assignments**: `teams.map(t => t.characters)` is clear
+- **Obvious type information**: TypeScript types already document intent
+- **Trivial error handling**: Standard try-catch patterns don't need explanation
+
+**Bad examples** (unnecessary comments):
+
+```typescript
+// ❌ Loop through teams
+teams.forEach(team => {
+  // ❌ Render team card
+  return <TeamCard key={team.id} />;
+});
+
+// ❌ Set loading state
+setLoading(true);
+```
+
+### Comment Format
+
+Use clear, conversational English:
+
+```typescript
+// Bad: Too terse
+// calc avg dmg from artifacts
+
+// Good: Explains the why and what clearly
+// Calculate average damage across all artifacts to handle Firestore
+// pagination limit of 20 docs. See performanceTests.md for benchmarks.
+const avgDamage = calculateAverageDamage(artifacts);
+```
+
+---
+
 ## When Suggesting Code
 
 ### Do

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,7 +75,7 @@ This project follows the [Diátaxis framework](https://diataxis.fr/) for documen
 2. **Place accordingly**: Use the Diátaxis structure
 3. **Link, don't duplicate**: Reference external docs (like Diátaxis itself) rather than summarizing
 4. **Keep CONTRIBUTING.md focused**: Extract detailed tasks to how-tos, link back
-5. **Planning vs. Documentation**: 
+5. **Planning vs. Documentation**:
    - ❌ Don't document development phases, implementation plans, or future features in markdown docs
    - ✅ Track phases and planning in GitHub Issues and Milestones
    - ✅ Documentation should describe what **exists now**, not what's planned
@@ -182,19 +182,66 @@ describe('ComponentName', () => {
 
 ---
 
-## Commit Message Convention
+## Detailed Contribution Workflow
+
+This section provides technical guidance for implementing features and fixes.
+
+### 1. Feature Development Process
+
+**Branch Creation**
+
+```bash
+git checkout -b feature/description  # Use kebab-case
+```
+
+**Test-Driven Development (TDD)**
+Write tests before or alongside implementation:
+
+```typescript
+// apps/web/src/features/[feature]/ComponentName.test.tsx
+describe('ComponentName', () => {
+  it('expected behavior description', () => {
+    // Arrange
+    const data = { /* test data */ };
+    // Act
+    render(<ComponentName {...data} />);
+    // Assert
+    expect(screen.getByRole('heading', { name: /name/i })).toBeInTheDocument();
+  });
+});
+```
+
+Then implement to make the test pass:
+
+```typescript
+// apps/web/src/features/[feature]/ComponentName.tsx
+export function ComponentName(props: ComponentNameProps) {
+  return <div>{/* implementation */}</div>;
+}
+```
+
+**Quality Checks** (before committing)
+
+```bash
+pnpm format                # Auto-format code with Prettier
+pnpm tsc --noEmit         # Type check without emitting
+pnpm test                 # Run all tests
+pnpm lint                 # Run ESLint
+```
+
+### 2. Commit Message Convention
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
 <type>(<scope>): <description>
 
-[optional body]
+[optional body explaining why]
 
-[optional footer]
+[optional footer: Closes #123]
 ```
 
-### Types
+**Types**:
 
 - `feat:` - New feature
 - `fix:` - Bug fix
@@ -204,13 +251,70 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `style:` - Formatting, no code change
 - `chore:` - Maintenance tasks, dependencies
 
-### Examples
+**Examples**:
 
 ```
 feat(collection): add character card component
+
+- Creates reusable CharacterCard component
+- Styled with Tailwind CSS
+- Includes test coverage
+
+Closes #42
+```
+
+```
 fix(api): handle missing Firebase credentials gracefully
-test(teams): add tests for team validation logic
-docs: update setup guide with testing phase
+
+Throws helpful error message instead of crashing.
+```
+
+### 3. Pull Request Workflow
+
+**Push and Create PR**
+
+```bash
+git push -u origin feature/description
+gh pr create --title "feat: Add character card component" \
+  --body "Addresses #42
+
+Changes:
+- ComponentName component
+- Tests for user interactions
+- Integration with existing code"
+```
+
+**PR Title Format**: Should match commit message format (becomes squash merge commit on merge)
+
+**Merge Strategy**: Repository uses squash merge (all PR commits become one commit)
+
+**Before Merge Checklist**:
+
+- ✅ All tests passing
+- ✅ No TypeScript errors
+- ✅ No linting errors
+- ✅ Code formatted with Prettier
+- ✅ Tests cover critical paths (80%+)
+- ✅ PR description is accurate
+
+### 4. Testing Standards
+
+**Coverage Targets**:
+
+- **Critical paths** (core business logic): 80%+ coverage
+- **Utilities/helpers**: 90%+ coverage
+- **UI components**: Test user interactions and accessibility, not implementation details
+
+**Testing Philosophy**: Use [React Testing Library](https://testing-library.com/) — query by how users interact, not by internal structure
+
+```typescript
+// ❌ Bad: testing implementation details
+container.querySelector('.character-card');
+getByTestId('card-wrapper');
+
+// ✅ Good: testing user experience
+screen.getByRole('heading', { name: /character name/i });
+screen.getByText('Pyro');
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,8 @@ Once your environment is set up:
 
 ```bash
 # Ensure you're on develop and pull latest
-git checkout develop && git pull origin develop
+git checkout develop
+git pull origin develop
 
 # Install dependencies
 pnpm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,153 +26,65 @@ We are committed to providing a welcoming and inclusive environment. Please be r
 
 ---
 
-## Daily Development Flow
+## Development Workflow Overview
 
-### Starting Work
+Our contribution process follows these principles:
+
+1. **Check Issues First** — Browse [existing issues](https://github.com/dungeon-studio/genshin.dungeon.studio/issues) to see what needs work
+2. **Create a Feature Branch** — Use naming convention: `feature/description` or `fix/description`
+3. **Develop with TDD** — Write tests alongside (or before) implementation
+4. **Commit with Conventional Commits** — Follow the standard format
+5. **Open a PR** — Reference the issue it addresses
+6. **Iterate** — Address review feedback, tests pass, merge when ready
+
+### Quick Start Commands
+
+Once your environment is set up:
 
 ```bash
-# 1. Ensure you're on develop
-git checkout develop
+# Ensure you're on develop and pull latest
+git checkout develop && git pull origin develop
 
-# 2. Pull latest changes
-git pull origin develop
-
-# 3. Install any new dependencies
+# Install dependencies
 pnpm install
 
-# 4. Start dev servers (from root)
+# Start dev servers
 pnpm dev
-# Frontend: http://localhost:5173
-# Backend: http://localhost:8080
 ```
 
----
+### Code Quality Standards
 
-## Feature Development Workflow
-
-### 1. Create Feature Branch
+Before committing:
 
 ```bash
-# Naming convention: feature/description or fix/description
-git checkout -b feature/character-collection
+pnpm format   # Format code with Prettier
+pnpm tsc --noEmit  # Type check without emitting
+pnpm test     # Run tests
+pnpm lint     # Check for linting issues
 ```
 
-### 2. Develop with TDD
+**Test coverage targets:**
 
-Write test first, then implement:
+- Critical paths: 80%+
+- Utilities: 90%+
+- UI components: Focus on user interactions, not implementation details
 
-```typescript
-// apps/web/src/features/collection/CharacterCard.test.tsx
-describe('CharacterCard', () => {
-  it('displays character name', () => {
-    const character = { name: 'Hu Tao', element: 'Pyro' };
-    render(<CharacterCard character={character} />);
-    expect(screen.getByText('Hu Tao')).toBeInTheDocument();
-  });
-});
-```
+**Commit types** (use these prefixes in your commit messages):
 
-Then implement:
+- `feat:` — New feature
+- `fix:` — Bug fix
+- `docs:` — Documentation
+- `test:` — Adding/updating tests
+- `refactor:` — Code restructuring
+- `style:` — Formatting
+- `chore:` — Maintenance
 
-```typescript
-// apps/web/src/features/collection/CharacterCard.tsx
-export function CharacterCard({ character }) {
-  return <div>{character.name}</div>;
-}
-```
+### Detailed Guides
 
-Run tests:
+For step-by-step instructions and technical details:
 
-```bash
-pnpm test
-```
-
-### 3. Commit with Conventional Commits
-
-```bash
-git add .
-git commit -m "feat(collection): add character card component
-
-- Create CharacterCard component
-- Add tests for character display
-- Style with Tailwind CSS"
-```
-
-**Commit types:**
-
-- `feat:` - New feature
-- `fix:` - Bug fix
-- `docs:` - Documentation changes
-- `test:` - Adding or updating tests
-- `refactor:` - Code restructuring
-- `style:` - Formatting, no code change
-- `chore:` - Maintenance tasks
-
-### 4. Push and Create PR
-
-```bash
-# Push branch
-git push -u origin feature/character-collection
-
-# Create PR via CLI
-gh pr create --title "feat: Add character collection grid" \
-  --body "Implements character collection view with:
-  - CharacterCard component
-  - Grid layout with Tailwind
-  - Tests for rendering
-
-  Closes #5"
-
-# Or create PR in GitHub UI
-```
-
-### 5. Review and Merge
-
-Once tests pass and code is reviewed:
-
-```bash
-# Merge via CLI
-gh pr merge
-# Note: Repository is configured to enforce squash merge automatically
-
-# Or use GitHub UI merge button
-```
-
-### 6. Update Local
-
-```bash
-git checkout develop
-git pull origin develop
-git branch -d feature/character-collection
-```
-
----
-
-## Code Quality
-
-### Before Committing
-
-```bash
-# Format code
-pnpm format
-
-# Type check
-pnpm tsc --noEmit
-
-# Run tests
-pnpm test
-
-# Lint (if configured)
-pnpm lint
-```
-
-### Test Coverage
-
-Aim for:
-
-- **Critical paths**: 80%+ coverage
-- **Utilities**: 90%+ coverage
-- **UI components**: Test user interactions, not implementation details
+- [Manual Setup Guide](docs/how-tos/manual-setup.md) — Development environment setup without DevContainers
+- [Troubleshooting Guide](docs/how-tos/troubleshooting.md) — Solutions for common issues
 
 ---
 
@@ -183,8 +95,6 @@ Aim for:
 - Review [Troubleshooting Guide](docs/how-tos/troubleshooting.md) for common problems
 - Open a [GitHub Discussion](https://github.com/dungeon-studio/genshin.dungeon.studio/discussions) for questions
 - Report bugs via [GitHub Issues](https://github.com/dungeon-studio/genshin.dungeon.studio/issues)
-
-**Task-specific guides will be added as features are implemented.**
 
 ---
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -40,15 +40,15 @@ export default defineConfig([
       // other options...
     },
   },
-])
+]);
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import reactX from 'eslint-plugin-react-x';
+import reactDom from 'eslint-plugin-react-dom';
 
 export default defineConfig([
   globalIgnores(['dist']),
@@ -69,5 +69,5 @@ export default defineConfig([
       // other options...
     },
   },
-])
+]);
 ```

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,8 +1,8 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default [
   {
@@ -18,14 +18,11 @@ export default [
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
   },
-]
+];

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,5 +12,5 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 );

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Simplifies CONTRIBUTING.md to be more of a high-level overview while moving detailed technical guidance to appropriate locations.

## Changes

- **CONTRIBUTING.md**: Simplified to overview-level documentation following Diátaxis principles
  - Removed detailed step-by-step workflow instructions (less patronising)
  - Kept the 'story' of contributing as the focus
  - Links to how-to guides for specific tasks

- **.github/copilot-instructions.md**: Now contains all detailed workflow guidance
  - Full commit message conventions with examples
  - Detailed PR workflow and merge strategy
  - Testing standards and patterns
  - Kept as AI-only documentation (not linked from user docs)

## Why This Matters

- **Better Diátaxis separation**: CONTRIBUTING.md focuses on understanding, copilot-instructions provides detailed how-tos for AI
- **Respects reader intelligence**: Assumes contributors can follow the 5-step overview without hand-holding
- **AI documentation stays isolated**: Removes internal links that would confuse human contributors about the AI-only instructions file