### PR TITLE
chore: configure pnpm workspace tooling versions and engines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,7 @@ This is an AI-powered team building companion for Genshin Impact. Users can:
 
 **Important**:
 
+- **Canonical Version Source**: Tool versions are declared in [package.json](../package.json) devDependencies, not pnpm-workspace.yaml. Refer to `package.json` as the source of truth for TypeScript, ESLint, and Prettier versions.
 - Do NOT suggest Bun-specific code yet. It's listed in plans but not implemented.
 - ESLint 9.x uses flat config format - no `extends` property, use array spreading instead.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ This is an AI-powered team building companion for Genshin Impact. Users can:
 
 **Important**:
 
-- **Canonical Version Source**: Tool versions are declared in [package.json](../package.json) devDependencies, not pnpm-workspace.yaml. Refer to `package.json` as the source of truth for TypeScript, ESLint, and Prettier versions.
+- **Canonical Version Source**: Tool versions are pinned to exact versions in [package.json](../package.json) devDependencies for hermetic deployments. Dependabot manages updates automatically. Refer to `package.json` as the source of truth.
 - Do NOT suggest Bun-specific code yet. It's listed in plans but not implemented.
 - ESLint 9.x uses flat config format - no `extends` property, use array spreading instead.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,13 +17,16 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@eslint/js": "9.39.2",
     "@types/node": "22.12.0",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "eslint": "9.39.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4"
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,16 +17,13 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.1",
-    "@types/node": "^24.10.1",
+    "@types/node": "22.12.0",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
-    "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4"
   }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "clean": "turbo run clean"
   },
   "devDependencies": {
-    "@types/node": "^22.10.5",
-    "eslint": "^9.39.1",
-    "prettier": "^3.4.2",
-    "turbo": "^2.3.3",
-    "typescript": "^5.7.3"
+    "@types/node": "22.10.5",
+    "eslint": "9.39.2",
+    "prettier": "3.8.1",
+    "turbo": "2.3.3",
+    "typescript": "5.9.3"
   },
   "packageManager": "pnpm@9.15.4",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "clean": "turbo run clean"
   },
   "devDependencies": {
-    "@types/node": "22.10.5",
+    "@eslint/js": "9.39.2",
+    "@types/node": "22.12.0",
     "eslint": "9.39.2",
     "prettier": "3.8.1",
     "turbo": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.5",
+    "eslint": "^9.39.1",
     "prettier": "^3.4.2",
     "turbo": "^2.3.3",
     "typescript": "^5.7.3"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - 'apps/*'
+  - 'packages/*'
+# Lock critical tool versions across all workspaces
+overrides:
+  typescript: '5.9.3'
+  prettier: '3.8'
+  eslint: '9.39'
+
+# Ensure pnpm version compatibility
+engines:
+  pnpm: '>=9.15.4'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,6 @@
 packages:
   - 'apps/*'
   - 'packages/*'
-# Lock critical tool versions across all workspaces
-overrides:
-  typescript: '5.9.3'
-  prettier: '3.8'
-  eslint: '9.39'
 
 # Ensure pnpm version compatibility
 engines:


### PR DESCRIPTION
Ensures consistent tooling across all monorepo packages.

**Changes:**
- Lock TypeScript 5.9.3, ESLint 9.39, Prettier 3.8 across workspaces
- Enforce pnpm >=9.15.4 to ensure version consistency
- Prevents inconsistent tool behavior and linting/formatting discrepancies

**Why:** Tooling versions can drift between packages without these constraints, causing inconsistent code quality and build issues.