### PR TITLE
docs: refactor README to follow ddbeck's checklist

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,12 +63,36 @@ This project follows the [Diátaxis framework](https://diataxis.fr/) for documen
 
 ### Documentation Locations
 
-- `README.md` (root): Quick start - emphasizes DevContainers as primary path
+- `README.md` (root): **For users deciding if the project fits their needs** — see README Standard below
 - `CONTRIBUTING.md` (root): Contribution workflow - focused on the "story" of contributing, not detailed tasks
 - `docs/how-tos/`: Task-specific guides (e.g., "How to set up manually without DevContainers")
 - `docs/reference/`: Technical reference material (future)
 - `docs/explanation/`: Conceptual/architectural documentation (future)
 - **GitHub Issues/Milestones**: Source of truth for planning, phases, and implementation roadmap
+
+### README Standard
+
+The README should help humans **identify, evaluate, and use** the project. Follow [ddbeck's README checklist](https://github.com/ddbeck/readme-checklist):
+
+1. **Identify**: Project name, URL, and author at top
+2. **Evaluate**: What does it do? (benefit-focused, not tech stack). Who's it for? What's the status/maturity?
+3. **Use**: Quick start (emphasize DevContainers). Prerequisites if any.
+4. **Engage**: Links to docs, support, and contributing. License.
+
+**Key principle**: README is **not** for development roadmaps, architecture details, or tech stack justification. Those belong in:
+
+- **Tech details**: copilot-instructions.md or docs/explanation/
+- **Development roadmap**: GitHub Issues/Milestones
+- **Code organization**: CONTRIBUTING.md or GitHub repo browser
+- **Setup complexity**: docs/how-tos/
+
+**What NOT to put in README**:
+
+- ❌ "Features (Planned)" checklists
+- ❌ Project structure diagrams
+- ❌ Tech stack decisions (save for architecture docs)
+- ❌ Development phase descriptions
+- ✅ Instead, link to GitHub Issues for roadmap and CONTRIBUTING.md for setup
 
 ### When Creating/Updating Documentation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,7 +81,7 @@ The README should help humans **identify, evaluate, and use** the project. Follo
 
 **Key principle**: README is **not** for development roadmaps, architecture details, or tech stack justification. Those belong in:
 
-- **Tech details**: copilot-instructions.md or docs/explanation/
+- **Tech details**: copilot-instructions.md or docs/explanation/ (future, when that directory exists)
 - **Development roadmap**: GitHub Issues/Milestones
 - **Code organization**: CONTRIBUTING.md or GitHub repo browser
 - **Setup complexity**: docs/how-tos/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,7 +91,7 @@ The README should help humans **identify, evaluate, and use** the project. Follo
 - ❌ "Features (Planned)" checklists
 - ❌ Project structure diagrams
 - ❌ Tech stack decisions (save for architecture docs)
-- ❌ Development phase descriptions
+- ❌ Detailed development phase / roadmap sections (beyond a short status like "Pre-Alpha")
 - ✅ Instead, link to GitHub Issues for roadmap and CONTRIBUTING.md for setup
 
 ### When Creating/Updating Documentation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,7 +56,7 @@ This is an AI-powered team building companion for Genshin Impact. Users can:
 
 This project follows the [Diátaxis framework](https://diataxis.fr/) for documentation organization:
 
-- **Tutorials** (learning-oriented): Step-by-step learning experiences - not yet implemented
+- **Tutorials** (learning-oriented): Step-by-step learning experiences (future)
 - **How-To Guides** (goal-oriented): Task-focused instructions → `docs/how-tos/`
 - **Reference** (information-oriented): Technical descriptions → API docs, type references (future)
 - **Explanation** (understanding-oriented): Conceptual discussion → Architecture docs (future)
@@ -81,7 +81,7 @@ The README should help humans **identify, evaluate, and use** the project. Follo
 
 **Key principle**: README is **not** for development roadmaps, architecture details, or tech stack justification. Those belong in:
 
-- **Tech details**: copilot-instructions.md or docs/explanation/ (future, when that directory exists)
+- **Tech details**: copilot-instructions.md or docs/explanation/ (future)
 - **Development roadmap**: GitHub Issues/Milestones
 - **Code organization**: CONTRIBUTING.md or GitHub repo browser
 - **Setup complexity**: docs/how-tos/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By [Alex Brandt](https://github.com/alunduil) · [Repository](https://github.com
 
 ## What is it?
 
-Experiment with team compositions without the spreadsheets. Genshin Team Builder lets you describe your character collection to an AI assistant and get personalized team recommendations instantly. Whether you're optimizing for Abyss clears or just want to try new playstyles, get instant suggestions tailored to _your_ roster.
+Experiment with team compositions without the spreadsheets. Genshin Team Builder is an early-stage project that aims to let you describe your character collection to an AI assistant and, when implemented, get personalized team recommendations. Whether you're optimizing for Abyss clears or just want to try new playstyles, the goal is to provide suggestions tailored to _your_ roster.
 
 ## Who's it for?
 
@@ -41,4 +41,4 @@ See the [Manual Setup Guide](./docs/how-tos/manual-setup.md) for Node.js 20+ and
 
 ## License
 
-MIT — You're free to copy, modify, and distribute this project with attribution. See [LICENSE](./LICENSE) for details.
+MIT — You're free to copy, modify, and distribute this project as long as you include the copyright and license notice. See [LICENSE](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,79 +1,44 @@
 # Genshin Team Builder
 
-AI-powered team building companion for Genshin Impact
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Status**: 🚧 Under active development
+By [Alex Brandt](https://github.com/alunduil) · [Repository](https://github.com/dungeon-studio/genshin.dungeon.studio)
 
-Chat with an AI assistant about YOUR collection to get personalized team recommendations.
+🚧 **Pre-Alpha** — Not yet ready for general use, but contributors are welcome!
 
-## Tech Stack
+## What is it?
 
-- **Frontend**: React 19 + TypeScript + Vite
-- **Backend**: Hono (Node.js)
-- **AI**: Claude (Anthropic) via Model Context Protocol
-- **Database**: Firestore
-- **Auth**: Firebase Authentication
-- **Hosting**: GCP (Cloud Run + Cloud Storage)
+Experiment with team compositions without the spreadsheets. Genshin Team Builder lets you describe your character collection to an AI assistant and get personalized team recommendations instantly. Whether you're optimizing for Abyss clears or just want to try new playstyles, get instant suggestions tailored to _your_ roster.
+
+## Who's it for?
+
+Anyone who plays Genshin Impact and wants to:
+
+- Discover team compositions that work for _your_ characters (not tier lists)
+- Experiment with different team combinations quickly
+- Get AI-powered suggestions based on your actual roster
+- Explore synergies without manual research
 
 ## Getting Started
 
-### Quick Start (Recommended) 🚀
+The quickest way to explore the project (or contribute) is to use VS Code with DevContainers:
 
-**Using VS Code with DevContainers** (easiest):
-
-1. Clone and open in VS Code
+1. **Clone and open** in VS Code
 2. Click **"Reopen in Container"** when prompted
-3. Done! Everything is pre-configured
+3. Run `pnpm dev` to start development servers
 
 The frontend will be available at http://localhost:5173
-The backend will be available at http://localhost:8080 (when implemented)
 
-### Manual Setup (Alternative)
+### Without DevContainers
 
-If you prefer not to use DevContainers:
+See the [Manual Setup Guide](./docs/how-tos/manual-setup.md) for Node.js 20+ and pnpm 9+ setup.
 
-- **Prerequisites**: Node.js 20+, pnpm 9+
-- **See**: [Manual Setup Guide](./docs/how-tos/manual-setup.md)
+## Learn More
 
-```bash
-# Terminal setup (no VS Code or DevContainers required)
-git clone https://github.com/dungeon-studio/genshin.dungeon.studio.git
-cd genshin.dungeon.studio
-pnpm install
-pnpm dev
-```
-
-### Project Structure
-
-```
-genshin.dungeon.studio/
-├── apps/
-│   ├── web/          # React frontend (Vite)
-│   └── api/          # Hono backend
-├── packages/
-│   ├── types/        # Shared TypeScript types
-│   └── game-data/    # Static game data
-├── docs/             # Project documentation
-└── infrastructure/   # Deployment scripts
-```
-
-## Development
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution workflow and daily development practices.
-
-## Features (Planned)
-
-- ✅ Monorepo structure with Turborepo
-- ✅ Frontend with React 19 + Vite + TypeScript
-- 🚧 Character collection management
-- 🚧 AI-powered team recommendations
-- 🚧 Team builder interface
-- 🚧 Progressive Web App support
-
-## Contributing
-
-This project follows test-driven development and conventional commits. See our [documentation](./docs/) for guidelines.
+- **Contributing**: See [CONTRIBUTING.md](./CONTRIBUTING.md) for development workflow and how to help
+- **Troubleshooting**: Check [docs/how-tos/troubleshooting.md](./docs/how-tos/troubleshooting.md) for common issues
+- **Planning & Roadmap**: See [GitHub Issues & Milestones](https://github.com/dungeon-studio/genshin.dungeon.studio/milestones) for what's next
 
 ## License
 
-MIT
+MIT — You're free to copy, modify, and distribute this project with attribution. See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Changes

Refactored README to be user-focused and benefit-driven instead of tech-stack focused.

### What changed:

- **Added License badge** — Clear legal clarity at top
- **Reordered sections** — 'What is it?' and 'Who's it for?' answer key evaluation questions first
- **Benefit-focused description** — Emphasize team building use cases, not architecture
- **Simplified Getting Started** — Removed project structure, focused on DevContainers + manual setup link
- **Removed redundant content** — Stripped 'Features (Planned)', 'Development', tech stack (belongs in docs or copilot-instructions)
- **Updated copilot-instructions.md** — Added README Standard section with explicit ddbeck's checklist guidance

### Rationale

Follows ddbeck's README checklist: Help readers **identify** (name, author, URL), **evaluate** (benefits, audience), **use** (quick start), and **engage** (links, contributing).

### Related Issues

- #96, #97, #98 — Created GitHub issues for future badge work (build status, coverage, version)

Closes: None (documentation improvement)