### PR TITLE
chore: configure Dependabot for automated dependency management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -581,16 +581,27 @@ We're currently in **Phase 2** - basic frontend is set up, now adding dependenci
 
 **Next steps** (in priority order):
 
-1. Issue #81: Configure Dependabot for dependency management
-2. Issue #22: Install core frontend dependencies (react-router, zustand, etc.)
-3. Issue #20: Configure Tailwind CSS
-4. Issue #21: Set up shadcn/ui
-5. Set up backend with Hono
-6. Add testing framework (Vitest)
-7. Implement authentication
-8. Build collection management
-9. Create team builder UI
-10. Integrate AI chat
+1. Issue #81: Configure Dependabot for dependency management ✅ COMPLETED
+2. Issue #82: Configure GitHub Code Scanning
+3. Issue #22: Install core frontend dependencies (react-router, zustand, etc.)
+4. Issue #20: Configure Tailwind CSS
+5. Issue #21: Set up shadcn/ui
+6. Set up backend with Hono
+7. Add testing framework (Vitest)
+8. Implement authentication
+9. Build collection management
+10. Create team builder UI
+11. Integrate AI chat
+
+### Dependabot Maintenance
+
+**Important**: When adding new workspaces/packages to the monorepo, update `.github/dependabot.yml` to include them:
+
+- **New app (e.g., `apps/api`)**: Add npm entry with directory path and appropriate semantic groups
+- **New package (e.g., `packages/utils`)**: Add npm entry under `packages/{name}`
+- **New language/ecosystem**: Add new package-ecosystem entry (e.g., Python, Go, etc.)
+
+See the maintenance section in `.github/dependabot.yml` for detailed instructions and examples. Without updating Dependabot, new workspaces won't get automated dependency updates.
 
 **When suggesting features**: Always check if dependencies/infrastructure exist first. If suggesting a feature from later phases, mention prerequisites.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -570,21 +570,7 @@ const avgDamage = calculateAverageDamage(artifacts);
 
 ---
 
-## Project Phase Status
-
-We're currently in **Phase 2: Frontend Foundation** - basic frontend is set up, now adding dependencies and UI libraries.
-
-**Completed Phases**:
-- ✅ Phase 0: Prerequisites & Setup
-- ✅ Phase 1: Repository & Monorepo Foundation
-
-**Current Phase Work**:
-- ✅ Phase 2a: Basic Vite + React 19 + TypeScript setup
-- In progress: Dependabot, Code Scanning, Tailwind CSS, shadcn/ui setup
-
-See [GitHub Milestones](https://github.com/dungeon-studio/genshin.dungeon.studio/milestones) for detailed phase planning and task tracking.
-
-### Dependabot Maintenance
+## Dependabot Maintenance
 
 **Important**: When adding new workspaces/packages to the monorepo, update `.github/dependabot.yml` to include them:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -574,8 +574,8 @@ const avgDamage = calculateAverageDamage(artifacts);
 
 **Important**: When adding new workspaces/packages to the monorepo, update `.github/dependabot.yml` to include them:
 
-- **New app (e.g., `apps/api`)**: Add npm entry with directory path and appropriate semantic groups
-- **New package (e.g., `packages/utils`)**: Add npm entry under `packages/{name}`
+- **New app (e.g., `apps/api`)**: Add npm entry with directory path like `/apps/api` and appropriate semantic groups
+- **New package (e.g., `packages/utils`)**: Add npm entry with directory `/packages/{name}`
 - **New language/ecosystem**: Add new package-ecosystem entry (e.g., Python, Go, etc.)
 
 See the maintenance section in `.github/dependabot.yml` for detailed instructions and examples. Without updating Dependabot, new workspaces won't get automated dependency updates.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -570,28 +570,19 @@ const avgDamage = calculateAverageDamage(artifacts);
 
 ---
 
-## Current Phase: Frontend Dependencies
+## Project Phase Status
 
-We're currently in **Phase 2** - basic frontend is set up, now adding dependencies.
+We're currently in **Phase 2: Frontend Foundation** - basic frontend is set up, now adding dependencies and UI libraries.
 
-**Completed**:
+**Completed Phases**:
+- ✅ Phase 0: Prerequisites & Setup
+- ✅ Phase 1: Repository & Monorepo Foundation
 
-- ✅ Phase 1: Monorepo infrastructure (Turborepo + pnpm)
-- ✅ Phase 2a: Basic Vite + React 19 + TypeScript setup (PR #80)
+**Current Phase Work**:
+- ✅ Phase 2a: Basic Vite + React 19 + TypeScript setup
+- In progress: Dependabot, Code Scanning, Tailwind CSS, shadcn/ui setup
 
-**Next steps** (in priority order):
-
-1. Issue #81: Configure Dependabot for dependency management ✅ COMPLETED
-2. Issue #82: Configure GitHub Code Scanning
-3. Issue #22: Install core frontend dependencies (react-router, zustand, etc.)
-4. Issue #20: Configure Tailwind CSS
-5. Issue #21: Set up shadcn/ui
-6. Set up backend with Hono
-7. Add testing framework (Vitest)
-8. Implement authentication
-9. Build collection management
-10. Create team builder UI
-11. Integrate AI chat
+See [GitHub Milestones](https://github.com/dungeon-studio/genshin.dungeon.studio/milestones) for detailed phase planning and task tracking.
 
 ### Dependabot Maintenance
 
@@ -603,7 +594,7 @@ We're currently in **Phase 2** - basic frontend is set up, now adding dependenci
 
 See the maintenance section in `.github/dependabot.yml` for detailed instructions and examples. Without updating Dependabot, new workspaces won't get automated dependency updates.
 
-**When suggesting features**: Always check if dependencies/infrastructure exist first. If suggesting a feature from later phases, mention prerequisites.
+**When suggesting features**: Always check if dependencies/infrastructure exist first. Reference GitHub Issues/Milestones for current phase requirements and blocking dependencies.
 
 ---
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # ==========================================================================
-  # ROOT WORKSPACE - Regular Updates (Weekly)
+  # ROOT WORKSPACE
   # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/'
@@ -46,29 +46,7 @@ updates:
           - '@types/node'
 
   # ==========================================================================
-  # ROOT WORKSPACE - Security Updates (Daily)
-  # ==========================================================================
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-      time: '18:00'
-      timezone: 'Europe/London'
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 10
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
-    labels:
-      - 'dependencies'
-      - 'automated'
-      - 'security'
-
-  # ==========================================================================
-  # FRONTEND APP (apps/web) - Regular Updates (Weekly)
+  # FRONTEND APP (apps/web)
   # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/apps/web'
@@ -131,29 +109,6 @@ updates:
           - 'prettier*'
 
   # ==========================================================================
-  # FRONTEND APP (apps/web) - Security Updates (Daily)
-  # ==========================================================================
-  - package-ecosystem: 'npm'
-    directory: '/apps/web'
-    schedule:
-      interval: 'daily'
-      time: '18:00'
-      timezone: 'Europe/London'
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 10
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
-    labels:
-      - 'dependencies'
-      - 'frontend'
-      - 'automated'
-      - 'security'
-
-  # ==========================================================================
   # DEVCONTAINER
   # ==========================================================================
   - package-ecosystem: 'devcontainers'
@@ -178,11 +133,16 @@ updates:
 # ============================================================================
 # When adding new workspaces/packages to this monorepo:
 #
-# NOTE: Dependabot does NOT support YAML anchors/aliases - all config must be explicit.
+# NOTE: Dependabot does NOT support:
+#  - YAML anchors/aliases (all config must be explicit)
+#  - Duplicate package-ecosystem + directory combinations
 #
-# 1. Add TWO entries per npm workspace (regular + security):
+# Security updates are automatic and immediate (triggered by GitHub Security
+# Advisories), independent of the schedule configured here. The schedule only
+# controls version updates.
 #
-#    # Regular updates (weekly, with semantic grouping)
+# Add one entry per workspace:
+#
 #    - package-ecosystem: "npm"
 #      directory: "/apps/{name}"
 #      schedule:
@@ -204,32 +164,10 @@ updates:
 #        - "automated"
 #      groups: { ... }
 #
-#    # Security updates (daily, NO grouping for urgency)
-#    - package-ecosystem: "npm"
-#      directory: "/apps/{name}"
-#      schedule:
-#        interval: "daily"
-#        time: "18:00"
-#        timezone: "Europe/London"
-#      allow:
-#        - dependency-type: "direct"
-#        - dependency-type: "indirect"
-#      open-pull-requests-limit: 10
-#      pull-request-branch-name:
-#        separator: "/"
-#      reviewers:
-#        - "alunduil"
-#      labels:
-#        - "dependencies"
-#        - "{name}"
-#        - "automated"
-#        - "security"
-#
-# 2. Keep semantic grouping consistent across workspaces (regular updates only)
-# 3. Security updates should have higher PR limits (10 vs 5) and NO groups
+# Keep semantic grouping consistent across workspaces for clarity.
 #
 # Current coverage:
-#  ✓ Root workspace (weekly regular + daily security)
-#  ✓ apps/web (weekly regular + daily security)
-#  ✓ DevContainer (weekly only, security not applicable to images)
+#  ✓ Root workspace (weekly, limit: 5)
+#  ✓ apps/web (weekly, limit: 5)
+#  ✓ DevContainer (weekly, limit: 5)
 # ============================================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,6 @@ updates:
     labels:
       - 'dependencies'
       - 'automated'
-    # Commit message format
-    commit-message:
-      prefix: 'chore(deps)'
-      prefix-scope: 'root'
     # Group semantically by package type
     groups:
       # Linting & formatting
@@ -73,9 +69,6 @@ updates:
       - 'dependencies'
       - 'frontend'
       - 'automated'
-    commit-message:
-      prefix: 'chore(deps)'
-      prefix-scope: 'web'
     groups:
       # React & related
       react:
@@ -136,9 +129,6 @@ updates:
       - 'dependencies'
       - 'devcontainer'
       - 'automated'
-    commit-message:
-      prefix: 'chore(devcontainer)'
-      include: 'scope'
 
 # ============================================================================
 # MAINTENANCE NOTES
@@ -154,13 +144,11 @@ updates:
 #   - directory: "/apps/{name}"
 #   - Add appropriate groups (likely react + testing if frontend)
 #   - Labels: "dependencies", "{name}", "automated"
-#   - Commit prefix: "chore(deps)" with prefix-scope: "{name}"
 #
 # For packages/* additions:
 #   - package-ecosystem: "npm"
 #   - directory: "/packages/{name}"
 #   - Labels: "dependencies", "packages", "automated"
-#   - Commit prefix: "chore(deps)" with prefix-scope: "{name}"
 #
 # For GitHub Actions workflows (when added):
 #   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,48 @@
 version: 2
+
+# ============================================================================
+# YAML ANCHORS - Reusable configuration blocks
+# ============================================================================
+x-schedules:
+  weekly: &weekly-schedule
+    interval: 'weekly'
+    day: 'saturday'
+    time: '09:00'
+    timezone: 'UTC'
+
+  daily: &daily-schedule
+    interval: 'daily'
+    time: '09:00'
+    timezone: 'UTC'
+
+x-common: &common-settings
+  open-pull-requests-limit: 5
+  pull-request-branch-name:
+    separator: '/'
+  reviewers:
+    - 'alunduil'
+
+x-dependency-types: &all-dependency-types
+  - dependency-type: 'direct'
+  - dependency-type: 'indirect'
+
+x-base-labels: &base-labels
+  - 'dependencies'
+  - 'automated'
+
+# ============================================================================
+# UPDATES
+# ============================================================================
 updates:
-  # ============================================================================
-  # ROOT WORKSPACE
-  # ============================================================================
+  # ==========================================================================
+  # ROOT WORKSPACE - Regular Updates
+  # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
-    # Security updates: more frequent (hourly checks)
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 5
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
-    labels:
-      - 'dependencies'
-      - 'automated'
-    # Group semantically by package type
+    schedule: *weekly-schedule
+    <<: *common-settings
+    allow: *all-dependency-types
+    labels: *base-labels
     groups:
       # Linting & formatting
       eslint:
@@ -47,24 +67,26 @@ updates:
         patterns:
           - '@types/node'
 
-  # ============================================================================
-  # FRONTEND APP (apps/web)
-  # ============================================================================
+  # ==========================================================================
+  # ROOT WORKSPACE - Security Updates (Daily)
+  # ==========================================================================
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule: *daily-schedule
+    <<: *common-settings
+    allow: *all-dependency-types
+    labels: *base-labels
+    open-pull-requests-limit: 10
+    # Security updates bypass groups and create individual PRs
+
+  # ==========================================================================
+  # FRONTEND APP (apps/web) - Regular Updates
+  # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/apps/web'
-    schedule:
-      interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 5
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
+    schedule: *weekly-schedule
+    <<: *common-settings
+    allow: *all-dependency-types
     labels:
       - 'dependencies'
       - 'frontend'
@@ -110,21 +132,28 @@ updates:
         patterns:
           - 'prettier*'
 
-  # ============================================================================
+  # ==========================================================================
+  # FRONTEND APP (apps/web) - Security Updates (Daily)
+  # ==========================================================================
+  - package-ecosystem: 'npm'
+    directory: '/apps/web'
+    schedule: *daily-schedule
+    <<: *common-settings
+    allow: *all-dependency-types
+    labels:
+      - 'dependencies'
+      - 'frontend'
+      - 'automated'
+      - 'security'
+    open-pull-requests-limit: 10
+
+  # ==========================================================================
   # DEVCONTAINER
-  # ============================================================================
+  # ==========================================================================
   - package-ecosystem: 'devcontainers'
     directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
-    open-pull-requests-limit: 5
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
+    schedule: *weekly-schedule
+    <<: *common-settings
     labels:
       - 'dependencies'
       - 'devcontainer'
@@ -134,29 +163,32 @@ updates:
 # MAINTENANCE NOTES
 # ============================================================================
 # When adding new workspaces/packages to this monorepo:
-# 1. Add a new entry in .github/dependabot.yml following the pattern above
-# 2. Set the directory path to the workspace root (e.g., "/apps/api")
-# 3. Keep semantic grouping consistent across all entries
-# 4. Reference this comment in commit messages when making updates
 #
-# For apps/api or any new apps/:
-#   - package-ecosystem: "npm"
-#   - directory: "/apps/{name}"
-#   - Add appropriate groups (likely react + testing if frontend)
-#   - Labels: "dependencies", "{name}", "automated"
+# 1. Add TWO entries per npm workspace (regular + security):
 #
-# For packages/* additions:
-#   - package-ecosystem: "npm"
-#   - directory: "/packages/{name}"
-#   - Labels: "dependencies", "packages", "automated"
+#    # Regular updates (weekly, with groups)
+#    - package-ecosystem: "npm"
+#      directory: "/apps/{name}"
+#      schedule: *weekly-schedule
+#      <<: *common-settings
+#      allow: *all-dependency-types
+#      labels: [*base-labels, "{name}"]
+#      groups: { ... }
 #
-# For GitHub Actions workflows (when added):
-#   - package-ecosystem: "github-actions"
-#   - directory: "/"
-#   - Labels: "dependencies", "ci/cd", "automated"
+#    # Security updates (daily, no groups)
+#    - package-ecosystem: "npm"
+#      directory: "/apps/{name}"
+#      schedule: *daily-schedule
+#      <<: *common-settings
+#      allow: *all-dependency-types
+#      labels: [*base-labels, "{name}", "security"]
+#      open-pull-requests-limit: 10
+#
+# 2. Use YAML anchors (*weekly-schedule, *common-settings, etc.) to reduce duplication
+# 3. Security updates should have higher PR limits and no grouping for urgency
 #
 # Current coverage:
-#  ✓ Root workspace (root package.json)
-#  ✓ apps/web (frontend)
-#  ✓ DevContainer (Docker)
+#  ✓ Root workspace (regular + security)
+#  ✓ apps/web (regular + security)
+#  ✓ DevContainer (weekly only, no security-specific config needed)
 # ============================================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
       day: 'friday'
       time: '18:00'
       timezone: 'Europe/London'
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: '/'
     reviewers:
@@ -55,10 +51,6 @@ updates:
       day: 'friday'
       time: '18:00'
       timezone: 'Europe/London'
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: '/'
     reviewers:
@@ -118,7 +110,6 @@ updates:
       day: 'friday'
       time: '18:00'
       timezone: 'Europe/London'
-    open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: '/'
     reviewers:
@@ -150,10 +141,6 @@ updates:
 #        day: "friday"
 #        time: "18:00"
 #        timezone: "Europe/London"
-#      allow:
-#        - dependency-type: "direct"
-#        - dependency-type: "indirect"
-#      open-pull-requests-limit: 5
 #      pull-request-branch-name:
 #        separator: "/"
 #      reviewers:
@@ -167,7 +154,7 @@ updates:
 # Keep semantic grouping consistent across workspaces for clarity.
 #
 # Current coverage:
-#  ✓ Root workspace (weekly, limit: 5)
-#  ✓ apps/web (weekly, limit: 5)
-#  ✓ DevContainer (weekly, limit: 5)
+#  ✓ Root workspace (weekly)
+#  ✓ apps/web (weekly)
+#  ✓ DevContainer (weekly)
 # ============================================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,7 +104,7 @@ updates:
   # DEVCONTAINER
   # ==========================================================================
   - package-ecosystem: 'devcontainers'
-    directory: '/'
+    directory: '/.devcontainer'
     schedule:
       interval: 'weekly'
       day: 'friday'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'Europe/London'
     allow:
       - dependency-type: 'direct'
       - dependency-type: 'indirect'
@@ -52,8 +52,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-      time: '09:00'
-      timezone: 'UTC'
+      time: '18:00'
+      timezone: 'Europe/London'
     allow:
       - dependency-type: 'direct'
       - dependency-type: 'indirect'
@@ -74,9 +74,9 @@ updates:
     directory: '/apps/web'
     schedule:
       interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'Europe/London'
     allow:
       - dependency-type: 'direct'
       - dependency-type: 'indirect'
@@ -137,8 +137,8 @@ updates:
     directory: '/apps/web'
     schedule:
       interval: 'daily'
-      time: '09:00'
-      timezone: 'UTC'
+      time: '18:00'
+      timezone: 'Europe/London'
     allow:
       - dependency-type: 'direct'
       - dependency-type: 'indirect'
@@ -160,9 +160,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'Europe/London'
     open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: '/'
@@ -187,9 +187,9 @@ updates:
 #      directory: "/apps/{name}"
 #      schedule:
 #        interval: "weekly"
-#        day: "saturday"
-#        time: "09:00"
-#        timezone: "UTC"
+#        day: "friday"
+#        time: "18:00"
+#        timezone: "Europe/London"
 #      allow:
 #        - dependency-type: "direct"
 #        - dependency-type: "indirect"
@@ -209,8 +209,8 @@ updates:
 #      directory: "/apps/{name}"
 #      schedule:
 #        interval: "daily"
-#        time: "09:00"
-#        timezone: "UTC"
+#        time: "18:00"
+#        timezone: "Europe/London"
 #      allow:
 #        - dependency-type: "direct"
 #        - dependency-type: "indirect"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,48 +1,26 @@
 version: 2
-
-# ============================================================================
-# YAML ANCHORS - Reusable configuration blocks
-# ============================================================================
-x-schedules:
-  weekly: &weekly-schedule
-    interval: 'weekly'
-    day: 'saturday'
-    time: '09:00'
-    timezone: 'UTC'
-
-  daily: &daily-schedule
-    interval: 'daily'
-    time: '09:00'
-    timezone: 'UTC'
-
-x-common: &common-settings
-  open-pull-requests-limit: 5
-  pull-request-branch-name:
-    separator: '/'
-  reviewers:
-    - 'alunduil'
-
-x-dependency-types: &all-dependency-types
-  - dependency-type: 'direct'
-  - dependency-type: 'indirect'
-
-x-base-labels: &base-labels
-  - 'dependencies'
-  - 'automated'
-
-# ============================================================================
-# UPDATES
-# ============================================================================
 updates:
   # ==========================================================================
-  # ROOT WORKSPACE - Regular Updates
+  # ROOT WORKSPACE - Regular Updates (Weekly)
   # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/'
-    schedule: *weekly-schedule
-    <<: *common-settings
-    allow: *all-dependency-types
-    labels: *base-labels
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'automated'
     groups:
       # Linting & formatting
       eslint:
@@ -72,21 +50,41 @@ updates:
   # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/'
-    schedule: *daily-schedule
-    <<: *common-settings
-    allow: *all-dependency-types
-    labels: *base-labels
+    schedule:
+      interval: 'daily'
+      time: '09:00'
+      timezone: 'UTC'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
     open-pull-requests-limit: 10
-    # Security updates bypass groups and create individual PRs
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'automated'
+      - 'security'
 
   # ==========================================================================
-  # FRONTEND APP (apps/web) - Regular Updates
+  # FRONTEND APP (apps/web) - Regular Updates (Weekly)
   # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/apps/web'
-    schedule: *weekly-schedule
-    <<: *common-settings
-    allow: *all-dependency-types
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
     labels:
       - 'dependencies'
       - 'frontend'
@@ -137,23 +135,39 @@ updates:
   # ==========================================================================
   - package-ecosystem: 'npm'
     directory: '/apps/web'
-    schedule: *daily-schedule
-    <<: *common-settings
-    allow: *all-dependency-types
+    schedule:
+      interval: 'daily'
+      time: '09:00'
+      timezone: 'UTC'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
     labels:
       - 'dependencies'
       - 'frontend'
       - 'automated'
       - 'security'
-    open-pull-requests-limit: 10
 
   # ==========================================================================
   # DEVCONTAINER
   # ==========================================================================
   - package-ecosystem: 'devcontainers'
     directory: '/'
-    schedule: *weekly-schedule
-    <<: *common-settings
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
     labels:
       - 'dependencies'
       - 'devcontainer'
@@ -164,31 +178,58 @@ updates:
 # ============================================================================
 # When adding new workspaces/packages to this monorepo:
 #
+# NOTE: Dependabot does NOT support YAML anchors/aliases - all config must be explicit.
+#
 # 1. Add TWO entries per npm workspace (regular + security):
 #
-#    # Regular updates (weekly, with groups)
+#    # Regular updates (weekly, with semantic grouping)
 #    - package-ecosystem: "npm"
 #      directory: "/apps/{name}"
-#      schedule: *weekly-schedule
-#      <<: *common-settings
-#      allow: *all-dependency-types
-#      labels: [*base-labels, "{name}"]
+#      schedule:
+#        interval: "weekly"
+#        day: "saturday"
+#        time: "09:00"
+#        timezone: "UTC"
+#      allow:
+#        - dependency-type: "direct"
+#        - dependency-type: "indirect"
+#      open-pull-requests-limit: 5
+#      pull-request-branch-name:
+#        separator: "/"
+#      reviewers:
+#        - "alunduil"
+#      labels:
+#        - "dependencies"
+#        - "{name}"
+#        - "automated"
 #      groups: { ... }
 #
-#    # Security updates (daily, no groups)
+#    # Security updates (daily, NO grouping for urgency)
 #    - package-ecosystem: "npm"
 #      directory: "/apps/{name}"
-#      schedule: *daily-schedule
-#      <<: *common-settings
-#      allow: *all-dependency-types
-#      labels: [*base-labels, "{name}", "security"]
+#      schedule:
+#        interval: "daily"
+#        time: "09:00"
+#        timezone: "UTC"
+#      allow:
+#        - dependency-type: "direct"
+#        - dependency-type: "indirect"
 #      open-pull-requests-limit: 10
+#      pull-request-branch-name:
+#        separator: "/"
+#      reviewers:
+#        - "alunduil"
+#      labels:
+#        - "dependencies"
+#        - "{name}"
+#        - "automated"
+#        - "security"
 #
-# 2. Use YAML anchors (*weekly-schedule, *common-settings, etc.) to reduce duplication
-# 3. Security updates should have higher PR limits and no grouping for urgency
+# 2. Keep semantic grouping consistent across workspaces (regular updates only)
+# 3. Security updates should have higher PR limits (10 vs 5) and NO groups
 #
 # Current coverage:
-#  ✓ Root workspace (regular + security)
-#  ✓ apps/web (regular + security)
-#  ✓ DevContainer (weekly only, no security-specific config needed)
+#  ✓ Root workspace (weekly regular + daily security)
+#  ✓ apps/web (weekly regular + daily security)
+#  ✓ DevContainer (weekly only, security not applicable to images)
 # ============================================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,261 @@
+version: 2
+updates:
+  # ============================================================================
+  # ROOT WORKSPACE
+  # ============================================================================
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    # Security updates: more frequent (hourly checks)
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'automated'
+    # Commit message format
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-scope: 'root'
+    # Group semantically by package type
+    groups:
+      # Linting & formatting
+      eslint:
+        patterns:
+          - 'eslint*'
+          - '@eslint/*'
+          - 'typescript-eslint'
+      # TypeScript
+      typescript:
+        patterns:
+          - 'typescript'
+      # Turborepo
+      turborepo:
+        patterns:
+          - 'turbo'
+      # Prettier
+      prettier:
+        patterns:
+          - 'prettier*'
+      # Node types
+      types-node:
+        patterns:
+          - '@types/node'
+
+  # ============================================================================
+  # FRONTEND APP (apps/web)
+  # ============================================================================
+  - package-ecosystem: 'npm'
+    directory: '/apps/web'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'frontend'
+      - 'automated'
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-scope: 'web'
+    groups:
+      # React & related
+      react:
+        patterns:
+          - 'react*'
+          - '@react*'
+      # Types for React
+      react-types:
+        patterns:
+          - '@types/react*'
+      # Testing libraries
+      testing:
+        patterns:
+          - 'vitest'
+          - '@testing-library/*'
+          - '@vitest/*'
+      # Vite & build
+      vite:
+        patterns:
+          - 'vite*'
+          - '@vitejs/*'
+      # Linting & formatting
+      eslint:
+        patterns:
+          - 'eslint*'
+          - '@eslint/*'
+          - 'typescript-eslint'
+          - 'eslint-plugin-*'
+      # TypeScript
+      typescript:
+        patterns:
+          - 'typescript'
+      # Types packages
+      types:
+        patterns:
+          - '@types/*'
+      # Prettier
+      prettier:
+        patterns:
+          - 'prettier*'
+
+  # ============================================================================
+  # SHARED TYPES PACKAGE (packages/types)
+  # ============================================================================
+  - package-ecosystem: 'npm'
+    directory: '/packages/types'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'packages'
+      - 'automated'
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-scope: 'types'
+    groups:
+      # TypeScript
+      typescript:
+        patterns:
+          - 'typescript'
+      # Types packages
+      types:
+        patterns:
+          - '@types/*'
+
+  # ============================================================================
+  # GAME DATA PACKAGE (packages/game-data)
+  # ============================================================================
+  - package-ecosystem: 'npm'
+    directory: '/packages/game-data'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-type: 'indirect'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'packages'
+      - 'automated'
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-scope: 'game-data'
+    groups:
+      # TypeScript
+      typescript:
+        patterns:
+          - 'typescript'
+
+  # ============================================================================
+  # GITHUB ACTIONS
+  # ============================================================================
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'ci/cd'
+      - 'automated'
+    commit-message:
+      prefix: 'chore(ci)'
+      include: 'scope'
+
+  # ============================================================================
+  # DEVCONTAINER
+  # ============================================================================
+  - package-ecosystem: 'docker'
+    directory: '/.devcontainer'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '09:00'
+      timezone: 'UTC'
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'devcontainer'
+      - 'automated'
+    commit-message:
+      prefix: 'chore(devcontainer)'
+      include: 'scope'
+
+# ============================================================================
+# MAINTENANCE NOTES
+# ============================================================================
+# When adding new workspaces/packages to this monorepo:
+# 1. Add a new entry in .github/dependabot.yml following the pattern above
+# 2. Set the directory path to the workspace root (e.g., "/apps/api")
+# 3. Keep semantic grouping consistent across all entries
+# 4. Reference this comment in commit messages when making updates
+#
+# For apps/api or any new apps/:
+#   - package-ecosystem: "npm"
+#   - directory: "/apps/{name}"
+#   - Add appropriate groups (likely react + testing if frontend)
+#   - Labels: "dependencies", "{name}", "automated"
+#   - Commit prefix: "chore(deps)" with prefix-scope: "{name}"
+#
+# For packages/* additions:
+#   - package-ecosystem: "npm"
+#   - directory: "/packages/{name}"
+#   - Labels: "dependencies", "packages", "automated"
+#   - Commit prefix: "chore(deps)" with prefix-scope: "{name}"
+#
+# Current coverage:
+#  ✓ Root workspace (root package.json)
+#  ✓ apps/web (frontend)
+#  ✓ packages/types (shared types)
+#  ✓ packages/game-data (game data)
+#  ✓ GitHub Actions
+#  ✓ DevContainer
+# ============================================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -118,95 +118,6 @@ updates:
           - 'prettier*'
 
   # ============================================================================
-  # SHARED TYPES PACKAGE (packages/types)
-  # ============================================================================
-  - package-ecosystem: 'npm'
-    directory: '/packages/types'
-    schedule:
-      interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 5
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
-    labels:
-      - 'dependencies'
-      - 'packages'
-      - 'automated'
-    commit-message:
-      prefix: 'chore(deps)'
-      prefix-scope: 'types'
-    groups:
-      # TypeScript
-      typescript:
-        patterns:
-          - 'typescript'
-      # Types packages
-      types:
-        patterns:
-          - '@types/*'
-
-  # ============================================================================
-  # GAME DATA PACKAGE (packages/game-data)
-  # ============================================================================
-  - package-ecosystem: 'npm'
-    directory: '/packages/game-data'
-    schedule:
-      interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
-    allow:
-      - dependency-type: 'direct'
-      - dependency-type: 'indirect'
-    open-pull-requests-limit: 5
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
-    labels:
-      - 'dependencies'
-      - 'packages'
-      - 'automated'
-    commit-message:
-      prefix: 'chore(deps)'
-      prefix-scope: 'game-data'
-    groups:
-      # TypeScript
-      typescript:
-        patterns:
-          - 'typescript'
-
-  # ============================================================================
-  # GITHUB ACTIONS
-  # ============================================================================
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'saturday'
-      time: '09:00'
-      timezone: 'UTC'
-    open-pull-requests-limit: 5
-    pull-request-branch-name:
-      separator: '/'
-    reviewers:
-      - 'alunduil'
-    labels:
-      - 'dependencies'
-      - 'ci/cd'
-      - 'automated'
-    commit-message:
-      prefix: 'chore(ci)'
-      include: 'scope'
-
-  # ============================================================================
   # DEVCONTAINER
   # ============================================================================
   - package-ecosystem: 'docker'
@@ -251,11 +162,13 @@ updates:
 #   - Labels: "dependencies", "packages", "automated"
 #   - Commit prefix: "chore(deps)" with prefix-scope: "{name}"
 #
+# For GitHub Actions workflows (when added):
+#   - package-ecosystem: "github-actions"
+#   - directory: "/"
+#   - Labels: "dependencies", "ci/cd", "automated"
+#
 # Current coverage:
 #  ✓ Root workspace (root package.json)
 #  ✓ apps/web (frontend)
-#  ✓ packages/types (shared types)
-#  ✓ packages/game-data (game data)
-#  ✓ GitHub Actions
-#  ✓ DevContainer
+#  ✓ DevContainer (Docker)
 # ============================================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -113,8 +113,8 @@ updates:
   # ============================================================================
   # DEVCONTAINER
   # ============================================================================
-  - package-ecosystem: 'docker'
-    directory: '/.devcontainer'
+  - package-ecosystem: 'devcontainers'
+    directory: '/'
     schedule:
       interval: 'weekly'
       day: 'saturday'


### PR DESCRIPTION
Implement comprehensive Dependabot configuration to automate dependency updates across the monorepo.

## Changes

✅ Configure Dependabot for all workspaces (root, apps/web, devcontainer)
✅ Semantic grouping by package type (ESLint, @types, React, testing, etc.)
✅ Schedule: Weekly Friday 18:00 Europe/London timezone
✅ Security updates: Automatic and immediate (independent of schedule)
✅ PR management: Max 5 per workspace, 15 total
✅ DevContainer image updates via devcontainers ecosystem
✅ Maintenance instructions in config file

Closes #81