### PR TITLE
fix(dependabot): align GitHub Actions label with existing cicd label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,7 +116,7 @@ updates:
       - 'alunduil'
     labels:
       - 'dependencies'
-      - 'ci-cd'
+      - 'cicd'
       - 'automated'
 
   # ==========================================================================


### PR DESCRIPTION
## Summary
Fixes Dependabot error about missing labels by aligning the label name in dependabot.yml with the existing repository label.

## Changes
- Changed `ci-cd` to `cicd` in GitHub Actions update configuration to match existing repository label
- Created missing repository labels:
  - `dependencies` - Dependency updates (blue #0366d6)
  - `automated` - Automated updates from bots/CI (gray #ededed)
  - `devcontainer` - Development container configuration (blue #1d76db)

## Impact
- Resolves: "Labels could not be found: automated, dependencies" error in Dependabot PRs
- Dependabot can now properly apply labels to pull requests
- Aligns with existing label naming convention (`cicd` not `ci-cd`)

## Testing
- Verified all referenced labels exist using `gh label list`
- Validated dependabot.yml syntax