### PR TITLE
fix(ci): correct devcontainer path in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -123,7 +123,7 @@ updates:
   # DEVCONTAINER
   # ==========================================================================
   - package-ecosystem: 'devcontainers'
-    directory: '/.devcontainer'
+    directory: '/'
     schedule:
       interval: 'weekly'
       day: 'friday'


### PR DESCRIPTION
Fixes the Dependabot validation failure that was blocking PR #22.

The devcontainers package-ecosystem was configured with directory '/.devcontainer', which caused Dependabot to look for .devcontainer/devcontainer.json inside /.devcontainer. The correct path is '/' so it searches from the repository root.

Error that was occurring:
```
dependency_file_not_found: Neither .devcontainer.json nor .devcontainer/devcontainer.json nor .devcontainer/<anything>/devcontainer.json found in /.devcontainer
```