### PR TITLE
fix: update docker actions to stable v5 versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./apps/api/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/api
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=sha,prefix={{branch}}-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./apps/api/Dockerfile


### PR DESCRIPTION
Resolves the failed docker-publish workflow.

## Problem
The GitHub Actions workflow was referencing non-existent action versions:
- `docker/metadata-action@v6` 
- `docker/build-push-action@v6`

These versions don't exist; the latest stable releases are v5.

## Solution
Updated both actions to use v5, which are stable and widely available.