### PR TITLE
Add CORS and error handling middleware

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,12 +3,39 @@
 
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { logger } from 'hono/logger';
 import { readFileSync } from 'node:fs';
 
 // Read version from package.json to maintain single source of truth
 const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
 
 const app = new Hono();
+
+// Request logging middleware
+app.use('*', logger());
+
+// CORS middleware - allow frontend origin
+const frontendOrigin = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
+app.use(
+  '*',
+  cors({
+    origin: frontendOrigin,
+    credentials: true,
+  }),
+);
+
+// Error handling middleware
+app.onError((err, c) => {
+  console.error('Error:', err);
+  return c.json(
+    {
+      error: err.message || 'Internal server error',
+      status: 'error',
+    },
+    500,
+  );
+});
 
 app.get('/', (c) =>
   c.json({

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -17,8 +17,9 @@ const app = new Hono();
 app.use('*', logger());
 
 // CORS middleware - allow frontend origin
-const frontendOrigin = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
-if (frontendOrigin.trim() === '' || frontendOrigin === '*') {
+const rawFrontendOrigin = process.env.FRONTEND_ORIGIN ?? 'http://localhost:5173';
+const frontendOrigin = rawFrontendOrigin.trim();
+if (frontendOrigin === '' || frontendOrigin === '*') {
   throw new Error("FRONTEND_ORIGIN must be a specific origin; '*' is not valid.");
 }
 app.use(

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -19,7 +19,7 @@ app.use('*', logger());
 // CORS middleware - allow frontend origin
 const frontendOrigin = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
 if (frontendOrigin.trim() === '' || frontendOrigin === '*') {
-  throw new Error('FRONTEND_ORIGIN must be a specific origin when credentials are enabled.');
+  throw new Error("FRONTEND_ORIGIN must be a specific origin; '*' is not valid.");
 }
 app.use(
   '*',

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { serve } from '@hono/node-server';
-import { HTTPException } from 'hono/http-exception';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 import { readFileSync } from 'node:fs';
 
@@ -49,6 +49,17 @@ app.onError((err, c) => {
     500,
   );
 });
+
+// 404 handler for unmatched routes
+app.notFound((c) =>
+  c.json(
+    {
+      error: 'Not found',
+      status: 'error',
+    },
+    404,
+  ),
+);
 
 app.get('/', (c) =>
   c.json({

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { serve } from '@hono/node-server';
+import { HTTPException } from 'hono/http-exception';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
@@ -27,10 +28,22 @@ app.use(
 
 // Error handling middleware
 app.onError((err, c) => {
-  console.error('Error:', err);
+  // Handle Hono's HTTPException (intended errors like 404, validation errors, etc.)
+  if (err instanceof HTTPException) {
+    return c.json(
+      {
+        error: err.message,
+        status: 'error',
+      },
+      err.status,
+    );
+  }
+
+  // Handle unexpected errors - log full details server-side, return generic message
+  console.error('Unexpected error:', err);
   return c.json(
     {
-      error: err.message || 'Internal server error',
+      error: 'Internal server error',
       status: 'error',
     },
     500,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,6 +18,9 @@ app.use('*', logger());
 
 // CORS middleware - allow frontend origin
 const frontendOrigin = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
+if (frontendOrigin.trim() === '' || frontendOrigin === '*') {
+  throw new Error('FRONTEND_ORIGIN must be a specific origin when credentials are enabled.');
+}
 app.use(
   '*',
   cors({


### PR DESCRIPTION
Implements CORS and error handling middleware for the Hono API.

- Add CORS middleware using hono/cors
- Add request logging with hono/logger  
- Add error handling middleware with onError handler
- Configure CORS to allow frontend origin via FRONTEND_ORIGIN env var

Closes #27