### PR TITLE
feat: Create shared types package

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,27 @@ When adding documentation, consider the audience and place information according
 - **apps/web**: React frontend
 - **`apps/api`**: Hono API server
 
+## Module & package patterns
+
+**Module philosophy**: Packages are runtime modules with behavior, not just type definitions. Think Haskell-style: types include methods, behavior, and encapsulation—not just interfaces. This means:
+
+- Emit JavaScript alongside declarations (no `emitDeclarationOnly`)
+- Provide both `types` and `default` exports in package.json
+- Include `main` field pointing to compiled .js entry
+- Pattern matches `@genshin/game-data` for consistency
+
+**Runtime module configuration**: Workspace packages that other packages import need:
+
+```json
+"exports": {
+  ".": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  }
+},
+"main": "./dist/index.js"
+```
+
 ## State & storage patterns
 
 - **UI state**: zustand
@@ -51,6 +72,8 @@ When adding documentation, consider the audience and place information according
 - **Persistent**: `localStorage` (Progressive Web App, planned long-term)
 - **Long-term**: Firestore (planned)
 - Game data: Import from `@genshin/game-data`, use helpers
+
+**Date serialization**: Use ISO 8601 strings (`string`), never `Date` objects, for JSON serialization compatibility. All timestamp fields (`createdAt`, `updatedAt`, etc.) should be typed as `string`.
 
 ## API & error handling
 
@@ -105,6 +128,12 @@ Local pre-commit hooks run automatically on every commit (except TypeScript chec
 - Force pushes rewrite history unnecessarily and can lose work
 
 Just commit fixes normally and push. Amend/force-push workflows are unnecessary overhead here.
+
+## File naming conventions
+
+- **Non-React TypeScript** (types, models, utilities): lowercase single words (`user.ts`, `team.ts`), camelCase compounds (`teamMember.ts`)
+- **React components**: PascalCase (`HomePage.tsx`, `Layout.tsx`, `ChatPage.tsx`)
+- **shadcn/ui components**: lowercase (`button.tsx`, `card.tsx`) - follows their convention
 
 ## When suggesting code
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -122,6 +122,12 @@ updates:
       - 'types'
       - 'automated'
     groups:
+      # Linting & formatting
+      eslint:
+        patterns:
+          - 'eslint*'
+          - '@eslint/*'
+          - 'typescript-eslint'
       # TypeScript
       typescript:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,6 +104,30 @@ updates:
           - 'prettier*'
 
   # ==========================================================================
+  # SHARED TYPES PACKAGE (packages/types)
+  # ==========================================================================
+  - package-ecosystem: 'npm'
+    directory: '/packages/types'
+    schedule:
+      interval: 'weekly'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'Europe/London'
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'types'
+      - 'automated'
+    groups:
+      # TypeScript
+      typescript:
+        patterns:
+          - 'typescript'
+
+  # ==========================================================================
   # GITHUB ACTIONS
   # ==========================================================================
   - package-ecosystem: 'github-actions'
@@ -197,6 +221,7 @@ updates:
 # Current coverage:
 #  ✓ Root workspace (weekly)
 #  ✓ apps/web (weekly)
+#  ✓ packages/types (weekly)
 #  ✓ DevContainer (weekly)
 #  ✓ Docker - apps/api (weekly)
 # ============================================================================

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -87,6 +87,8 @@ ddbeck's
 DevContainers
 Diátaxis
 UTC
+camelCase
+PascalCase
 
 # Game elements (Genshin Impact)
 Pyro

--- a/packages/types/eslint.config.js
+++ b/packages/types/eslint.config.js
@@ -2,18 +2,10 @@
 /* SPDX-License-Identifier: MIT */
 
 import js from '@eslint/js';
-import ts from 'typescript-eslint';
+import tseslint from 'typescript-eslint';
 
 export default [
   { ignores: ['dist', 'node_modules'] },
   js.configs.recommended,
-  ...ts.configs.strictTypeChecked,
-  {
-    languageOptions: {
-      parserOptions: {
-        projectService: true,
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-  },
+  ...tseslint.configs.recommended,
 ];

--- a/packages/types/eslint.config.js
+++ b/packages/types/eslint.config.js
@@ -1,0 +1,19 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+import js from '@eslint/js';
+import ts from 'typescript-eslint';
+
+export default [
+  { ignores: ['dist', 'node_modules'] },
+  js.configs.recommended,
+  ...ts.configs.strictTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+];

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./dist/index.d.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@genshin/types",
+  "version": "0.0.0",
+  "description": "Shared types for Genshin Dungeon Studio",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./types": "./dist/index.d.ts"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "typecheck": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.0"
+  }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,20 +2,24 @@
   "name": "@genshin/types",
   "version": "0.0.0",
   "description": "Shared types for Genshin Dungeon Studio",
+  "private": true,
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
-    "./types": "./dist/index.d.ts"
+    ".": "./dist/index.d.ts"
   },
-  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "typecheck": "tsc"
+    "typecheck": "tsc --noEmit",
+    "build": "tsc",
+    "lint": "eslint ."
   },
   "devDependencies": {
-    "typescript": "^5.9.0"
+    "@eslint/js": "10.0.1",
+    "eslint": "10.0.0",
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.54.0"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,6 +19,9 @@
     "build": "tsc",
     "lint": "eslint ."
   },
+  "dependencies": {
+    "@genshin/game-data": "workspace:*"
+  },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "eslint": "10.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,9 +6,11 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,5 +2,5 @@
 /* SPDX-License-Identifier: MIT */
 
 export type { User } from './user';
-export type { TeamMember } from './teamMember';
+export type { TeamMember, ArtifactPlan } from './teamMember';
 export type { Team, TeamSlot } from './team';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+export type { User } from './user';
+export type { TeamMember } from './teamMember';
+export type { Team, TeamSlot } from './team';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,5 @@
-/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
-/* SPDX-License-Identifier: MIT */
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
 
 export type { Team, TeamSlot } from './team.js';
 export type { ArtifactPlan, TeamMember } from './teamMember.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,6 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
-export type { User } from './user';
-export type { TeamMember, ArtifactPlan } from './teamMember';
-export type { Team, TeamSlot } from './team';
+export type { Team, TeamSlot } from './team.js';
+export type { ArtifactPlan, TeamMember } from './teamMember.js';
+export type { User } from './user.js';

--- a/packages/types/src/team.ts
+++ b/packages/types/src/team.ts
@@ -1,7 +1,7 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
-import type { TeamMember } from './teamMember';
+import type { TeamMember } from './teamMember.js';
 
 /**
  * Team loadout slot index for a user (0-indexed, 0-3).

--- a/packages/types/src/team.ts
+++ b/packages/types/src/team.ts
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+import type { TeamMember } from './teamMember';
+
+/**
+ * Slot number for team slots (0-indexed, 0-3)
+ */
+export type TeamSlot = 0 | 1 | 2 | 3;
+
+/**
+ * Team represents a party composition of 4 Genshin Impact characters
+ * Each user has exactly 4 team slots
+ * Character and weapon data are sourced from @genshin/game-data
+ */
+export interface Team {
+  slot: TeamSlot;
+  name: string;
+  members: [TeamMember, TeamMember, TeamMember, TeamMember];
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/packages/types/src/team.ts
+++ b/packages/types/src/team.ts
@@ -29,6 +29,12 @@ export interface Team {
    */
   members: [TeamMember, TeamMember, TeamMember, TeamMember];
   description?: string;
-  createdAt: Date;
-  updatedAt: Date;
+  /**
+   * ISO 8601 timestamp string representing when the team was created.
+   */
+  createdAt: string;
+  /**
+   * ISO 8601 timestamp string representing when the team was last updated.
+   */
+  updatedAt: string;
 }

--- a/packages/types/src/team.ts
+++ b/packages/types/src/team.ts
@@ -4,18 +4,29 @@
 import type { TeamMember } from './teamMember';
 
 /**
- * Slot number for team slots (0-indexed, 0-3)
+ * Team loadout slot index for a user (0-indexed, 0-3).
+ *
+ * This identifies which team loadout in a user's collection this team
+ * corresponds to, not the index of an individual party member.
  */
 export type TeamSlot = 0 | 1 | 2 | 3;
 
 /**
- * Team represents a party composition of 4 Genshin Impact characters
- * Each user has exactly 4 team slots
- * Character and weapon data are sourced from @genshin/game-data
+ * Team represents a party composition of 4 Genshin Impact characters.
+ *
+ * Each user has exactly 4 team loadout slots, identified by {@link TeamSlot}.
+ * Each team in a loadout slot contains exactly 4 party members.
+ * Character and weapon data are sourced from @genshin/game-data.
  */
 export interface Team {
+  /**
+   * The user's team loadout slot this team is assigned to (0-3).
+   */
   slot: TeamSlot;
   name: string;
+  /**
+   * The 4 party members (characters plus their configuration) in this team.
+   */
   members: [TeamMember, TeamMember, TeamMember, TeamMember];
   description?: string;
   createdAt: Date;

--- a/packages/types/src/teamMember.ts
+++ b/packages/types/src/teamMember.ts
@@ -2,8 +2,11 @@
 /* SPDX-License-Identifier: MIT */
 
 /**
- * TeamMember represents a single character slot in a team with equipped weapon and artifacts
- * Character and weapon data are sourced from @genshin/game-data
+ * TeamMember represents a single character slot in a team with equipped weapon and artifacts.
+ *
+ * Character and weapon details should be looked up from @genshin/game-data
+ * using the characterId and weaponId. The specific artifact plan configuration
+ * (set pieces, main/sub stats) is stored separately.
  */
 export interface TeamMember {
   characterId: string;

--- a/packages/types/src/teamMember.ts
+++ b/packages/types/src/teamMember.ts
@@ -1,8 +1,7 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
-import type { Character } from '@genshin/game-data';
-import type { Weapon } from '@genshin/game-data';
+import type { Character, Weapon } from '@genshin/game-data';
 
 /**
  * Placeholder for artifact plan configuration.

--- a/packages/types/src/teamMember.ts
+++ b/packages/types/src/teamMember.ts
@@ -1,0 +1,12 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+/**
+ * TeamMember represents a single character slot in a team with equipped weapon and artifacts
+ * Character and weapon data are sourced from @genshin/game-data
+ */
+export interface TeamMember {
+  characterId: string;
+  weaponId: string;
+  artifactPlan?: unknown; // TODO: Define artifact plan structure
+}

--- a/packages/types/src/teamMember.ts
+++ b/packages/types/src/teamMember.ts
@@ -1,6 +1,15 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
+import type { Character } from '@genshin/game-data';
+import type { Weapon } from '@genshin/game-data';
+
+/**
+ * Placeholder for artifact plan configuration.
+ * TODO: Define full artifact plan structure (set pieces, main/sub stats)
+ */
+export type ArtifactPlan = Record<string, unknown>;
+
 /**
  * TeamMember represents a single character slot in a team with equipped weapon and artifacts.
  *
@@ -9,7 +18,7 @@
  * (set pieces, main/sub stats) is stored separately.
  */
 export interface TeamMember {
-  characterId: string;
-  weaponId: string;
-  artifactPlan?: unknown; // TODO: Define artifact plan structure
+  characterId: Character['id'];
+  weaponId: Weapon['id'];
+  artifactPlan?: ArtifactPlan;
 }

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -12,6 +12,6 @@ export interface User {
   emailVerified: boolean;
   provider: string;
   providerUserId: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string; // ISO 8601 timestamp
+  updatedAt: string; // ISO 8601 timestamp
 }

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+/**
+ * User represents a Genshin Impact player authenticated via OIDC
+ */
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  picture?: string;
+  emailVerified: boolean;
+  provider: string;
+  providerUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
-    "emitDeclarationOnly": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -9,10 +9,12 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "emitDeclarationOnly": true
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,9 +187,18 @@ importers:
 
   packages/types:
     devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.0.0(jiti@1.21.7))
+      eslint:
+        specifier: 10.0.0
+        version: 10.0.0(jiti@1.21.7)
       typescript:
-        specifier: ^5.9.0
+        specifier: 5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: 8.54.0
+        version: 8.54.0(eslint@10.0.0(jiti@1.21.7))(typescript@5.9.3)
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,10 @@ importers:
         version: 8.54.0(eslint@10.0.0(jiti@1.21.7))(typescript@5.9.3)
 
   packages/types:
+    dependencies:
+      '@genshin/game-data':
+        specifier: workspace:*
+        version: link:../game-data
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,12 @@ importers:
         specifier: 8.54.0
         version: 8.54.0(eslint@10.0.0(jiti@1.21.7))(typescript@5.9.3)
 
+  packages/types:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,7 @@
       "inputs": ["src/**", "package.json", "vite.config.*", "vitest.config.*", "tsconfig*.json"]
     },
     "typecheck": {
+      "dependsOn": ["^build"],
       "inputs": ["src/**/*.{ts,tsx}", "package.json", "vite.config.*", "tsconfig*.json"]
     },
     "clean": {


### PR DESCRIPTION
Creates the @genshin/types shared package with:

- **User** type with OIDC authentication fields (provider, providerUserId, emailVerified, picture)
- **Team** type with exactly 4 team slots using TeamSlot type (0-3)
- **TeamMember** type for character setup (characterId, weaponId, artifactPlan)

Character and weapon data are sourced from @genshin/game-data to maintain single source of truth.

Fixes #28