### PR TITLE
feat(#8): Install and authenticate gcloud CLI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,7 +63,7 @@
     }
   },
 
-  "postCreateCommand": "npm install -g pnpm@9.15.4 && pnpm install && pre-commit install && pipx install reuse==6.2.0",
+  "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   "updateContentCommand": "pnpm install",
   "postAttachCommand": "echo '✅ Ready | Node $(node --version) | pnpm $(pnpm --version)'",
 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-set -e
+set -euo pipefail
 set -x
 
 # Install pnpm globally
 npm install -g pnpm@9.15.4
 
 # Install gcloud CLI
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
 sudo apt-get update && sudo apt-get install -y google-cloud-sdk
 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+set -e
+set -x
+
+# Install pnpm globally
+npm install -g pnpm@9.15.4
+
+# Install gcloud CLI
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
+sudo apt-get update && sudo apt-get install -y google-cloud-sdk
+
+# Install project dependencies
+pnpm install
+
+# Install pre-commit hooks
+pre-commit install
+
+# Install reuse-tool (SPDX license compliance checker)
+pipx install reuse==6.2.0

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -139,6 +139,27 @@ Just commit fixes normally and push. Amend/force-push workflows are unnecessary 
 
 Test alongside code; strict TypeScript; domain-driven design; maintain game-data accuracy; verify docs match code; cross-platform compatible; include SPDX headers in new files.
 
+## Shell script standards
+
+All bash scripts should follow these standards for reliability and safety:
+
+- **Error handling**: Use `set -euo pipefail` at the start to catch errors in piped commands, fail on undefined variables, and exit on first error
+- **Debugging output**: Enable `set -x` for visibility during development and debugging. Don't embed secrets in scripts; use environment variables instead.
+- **Network resilience**: Use `curl -fsSL` to fail on HTTP errors and network issues
+- **Security**: Don't include credentials, API keys, or sensitive data directly in scripts. Pass these via environment variables or secure configuration.
+- **Example**:
+
+  ```bash
+  #!/bin/bash
+  # SPDX-FileCopyrightText: 2026 Your Name
+  # SPDX-License-Identifier: MIT
+  set -euo pipefail
+  set -x
+  # Your commands here
+  ```
+
+The `.devcontainer/postCreateCommand.sh` script serves as the centralized location for all DevContainers provisioning. Add new tools and setup steps there. See issue #219 for extension patterns.
+
 ## Documentation preference hierarchy
 
 When explaining decisions or complex patterns, prefer this order:

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,14 @@ vite.config.ts.timestamp-*
 .DS_Store
 
 # ===================================
+# Google Cloud Platform (GCP)
+# ===================================
+
+# GCP service account keys and credentials
+.gcp/
+service-account*.json
+
+# ===================================
 # Temporary Files
 # ===================================
 


### PR DESCRIPTION
## Overview
Implements issue #8 by installing gcloud CLI in the devcontainer, making it available for developers who need to work with GCP resources.

## Changes
- Create `.devcontainer/postCreateCommand.sh` script to centralize devcontainer setup
- Install gcloud CLI via apt package manager with modern GPG key handling (using `gpg --dearmor`)
- Update devcontainer.json to invoke the new postCreateCommand.sh
- Add .gcp/ and service-account*.json to .gitignore for credential safety

## Notes
- gcloud CLI is now available on PATH in the devcontainer
- Authentication (`gcloud auth login`) is optional and only needed if you're working with GCP resources
- Most developers working on code won't need to authenticate

## Closes
Closes #8