### PR TITLE
docs: refine GCP strategy guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@
 - GitHub CLI, pre-commit, Vale (features)
 - pnpm 9.15.4 (via npm in postCreateCommand)
 - reuse-tool v6.2.0 (via `pipx` in postCreateCommand - Python application, installed in isolated environment)
-- Project dependencies and hooks (pnpm install, pre-commit install)
+- Project dependencies and pre-commit setup (pnpm install, pre-commit install)
 
 ## Not yet implemented
 
@@ -33,43 +33,66 @@
 
 **Current project**: `dungeon-studio-genshin-dev` (display name: `develop-genshin-dungeon-studio`) hosts all develop environment resources.
 
-Future release and production environments will be created as separate projects when needed (at the 0.1.0 and 1.0.0 milestones respectively), following the same naming pattern.
+Create future release and production environments as separate projects when needed (at the 0.1.0 and 1.0.0 milestones respectively), following the same naming pattern.
 
-**Environment labeling**: Apply project labels at creation via `gcloud alpha projects update --update-labels=KEY=VALUE`. (Note: `--update-labels` is currently alpha-only in gcloud; the stable `gcloud projects update` doesn't support incremental label updates.)
+**Environment labeling**: apply project labels at creation via `gcloud alpha projects update --update-labels=KEY=VALUE`. (Note: `--update-labels` is currently alpha-only in gcloud; the stable `gcloud projects update` doesn't support incremental label updates.)
 
 Label format: `environment=develop` (extends to `release` and `production` when those projects are created).
 
-**API activation strategy**: Don't enable APIs upfront. Defer until the service that needs them is actually being deployed.
+**API activation strategy**: don't enable APIs upfront. Defer until you deploy the service that needs them.
 
-- Issues with API dependencies are annotated with their required APIs (for example, #32 Cloud Storage → `storage.googleapis.com`).
+- Annotate issues with their required APIs (for example, #32 Cloud Storage → `storage.googleapis.com`).
 - Enable APIs only when implementing the corresponding feature (for example, "Create Firestore database" → enable `firestore.googleapis.com`).
 - If `gcloud` or Cloud Build complains about a missing API, enable it on-demand via `gcloud services enable API_NAME`.
+
+**Infrastructure as Code (Terraform)**: manage all GCP infrastructure through Terraform, never manual gcloud commands.
+
+- All infrastructure defined in `infrastructure/terraform/` with modules organized by bounded context (`web`, `api`, `firestore`)
+- Environment-specific configuration via Terraform variable files (develop.tfvars, release.tfvars, production.tfvars)
+- Store remote state in the shared GCP project's Terraform state bucket for multi-environment coordination
+- Cloud Build triggers apply Terraform automatically on infrastructure changes
+
+**Multi-environment per-resource strategy**: each environment (develop, release, production) gets its own GCP project with separate instances of all resources.
+
+- **Benefits** include data isolation (develop Firestore never touches production), independent scaling, safe schema migrations, and clear cost tracking per environment
+- **One Firestore per environment** in its respective GCP project for user data storage
+- **One Cloud Storage bucket per environment** for web assets
+- **One Cloud Run service per environment** for the API service
+- **Promotion** uses release/production GCP projects and applies the same Terraform with environment-specific variable files
+
+**Bounded context modules**: terraform modules organized by service/domain, not utility type.
+
+- **`web` module**: Cloud Storage bucket, Cloud Build pipeline, Cloud DNS record
+- **`api` module**: Cloud Run service, service account, IAM role bindings for Firestore/Storage access
+- **`firestore` module**: Firestore database instances with environment-specific settings
+- Each module encapsulates its infrastructure contract and security model
+- Benefits: Cohesion (related resources stay together), clear ownership, reuse across environments
 
 ## Documentation audiences
 
 - **CONTRIBUTING.md**: For human contributors. High-level workflow, links to how-tos for details. Skip CI architecture and technical internals. Keep lean and linked—prefer links to existing guides over duplicating content to avoid bloat.
-- **`copilot-instructions.md`** (this file): For AI decision-making. Include technical details, CI architecture, hook behavior, dependencies, constraints.
+- **`copilot-instructions.md`** (this file): For AI decision-making. Include technical details, CI architecture, check behavior, dependencies, constraints.
 - **docs/**: Task-specific guides organized by the [Diátaxis framework](https://diataxis.fr/). Currently contains how-tos; tutorials, reference, and explanation sections planned.
 
 When adding documentation, consider the audience and place information accordingly.
 
 ## Repository structure
 
-- **packages/types**: Shared types across apps
-- **packages/game-data**: Static game data (characters, artifacts, reactions, weapons). Source of truth: wiki. Version = game version. Use exported helpers (for example, `getCharacterById()`), never hard-code. Accuracy validated via manual local development; add automated tests when a test suite exists.
+- **packages/types**: shared types across apps
+- **packages/game-data**: static game data (characters, artifacts, reactions, weapons). Source of truth: wiki. Version = game version. Use exported helpers (for example, `getCharacterById()`), never hard-code. Accuracy validated via manual local development; add automated tests when a test suite exists.
 - **apps/web**: React frontend
 - **`apps/api`**: Hono API server
 
 ## Module & package patterns
 
-**Module philosophy**: Packages are runtime modules with behavior, not just type definitions. Think Haskell-style: types include methods, behavior, and encapsulation—not just interfaces. This means:
+**Module philosophy**: packages are runtime modules with behavior, not just type definitions. Think Haskell-style: types include methods, behavior, and encapsulation—not just interfaces. This means:
 
 - Emit JavaScript alongside declarations (no `emitDeclarationOnly`)
 - Provide both `types` and `default` exports in package.json
 - Include `main` field pointing to compiled .js entry
 - Pattern matches `@genshin/game-data` for consistency
 
-**Runtime module configuration**: Workspace packages that other packages import need:
+**Runtime module configuration**: workspace packages that other packages import need:
 
 ```json
 "exports": {
@@ -83,13 +106,13 @@ When adding documentation, consider the audience and place information according
 
 ## State & storage patterns
 
-- **UI state**: zustand
-- **Server state**: TanStack Query
-- **Persistent**: `localStorage` (Progressive Web App, planned long-term)
-- **Long-term**: Firestore (planned)
-- Game data: Import from `@genshin/game-data`, use helpers
+- **UI state** uses zustand
+- **Server state** uses TanStack Query
+- **Persistent** storage uses `localStorage` (Progressive Web App, planned long-term)
+- **Long-term** storage uses Firestore (planned)
+- Game data: import from `@genshin/game-data`, use helpers
 
-**Date serialization**: Use ISO 8601 strings (`string`), never `Date` objects, for JSON serialization compatibility. All timestamp fields (`createdAt`, `updatedAt`, etc.) should be typed as `string`.
+**Date serialization**: use ISO 8601 strings (`string`), never `Date` objects, for JSON serialization compatibility. All timestamp fields (`createdAt`, `updatedAt`, etc.) should be typed as `string`.
 
 ## API & error handling
 
@@ -117,31 +140,31 @@ When adding documentation, consider the audience and place information according
 
 - Fix prose for Vale errors
 - Rerun linters with `--fix`
-- Resolve TypeScript errors properly
+- Resolve TypeScript errors
 - Move secrets to environment variables
 
-Local pre-commit hooks run automatically on every commit (except TypeScript check, which requires manual invocation via `pnpm typecheck`). When pre-commit.ci runs on PRs, it skips ESLint, Stylelint, and TypeScript checks (GitHub Actions handles these). Bypassing hooks masks problems that CI will catch.
+Local pre-commit hooks run automatically on every commit (except TypeScript check, which requires manual invocation via `pnpm typecheck`). When pre-commit.ci runs on PRs, it skips ESLint, Stylelint, and TypeScript checks (GitHub Actions handles these). Bypassing hooks masks problems that CI catches.
 
 **Vale accept list**: for legitimate tool/package names that Vale flags as spelling errors (for example, Stylelint, Markdownlint), add them to `.styles/config/vocabularies/Project/accept.txt` rather than rewording documentation. This maintains accuracy.
 
-**Vale error handling**: Vale fails only on errors. However, handle warnings and suggestions as best as is practical:
+**Vale error handling**: vale fails only on errors. However, handle warnings and suggestions as best as is practical:
 
 - Fix all **errors** (non-negotiable: contractions, passive voice, profanity flags, etc.)
 - Fix **warnings** when doing documentation work (important: adverbs, sentence length, acronyms, voice issues)
 - Address **suggestions** if they improve readability without excessive effort
 
-**Third-party Vale styles**: everything in `.styles/` except `.styles/config/` is generated by `vale sync` and will be overwritten. Don't modify these files.
+**Third-party Vale styles**: everything in `.styles/` except `.styles/config/` is generated by `vale sync` and is overwritten. Don't modify these files.
 
-**SPDX headers**: all source files require SPDX headers (see [add-spdx-headers.md](../../docs/how-tos/add-spdx-headers.md)). Files without comment syntax should be declared in `.reuse/dep5`. The reuse pre-commit hook enforces compliance. Don't remove `.reuse/` from `.prettierignore`.
+**SPDX headers**: all source files require SPDX headers (see [add-spdx-headers.md](../../docs/how-tos/add-spdx-headers.md)). Files without comment syntax should be declared in `.reuse/dep5`. The reuse pre-commit check enforces compliance. Don't remove `.reuse/` from `.prettierignore`.
 
 ## Git workflow
 
 **Never use `git commit --amend` or `git push --force`**. This repository uses squash merge, so:
 
-- Each commit can be rough; pre-commit hooks will catch issues
+- Each commit can be rough; pre-commit hooks catch issues
 - If hooks fail, make a new commit with fixes rather than amending
 - All commits become one on merge anyway
-- Force pushes rewrite history unnecessarily and can lose work
+- Force pushes rewrite history and can lose work
 
 Just commit fixes normally and push. Amend/force-push workflows are unnecessary overhead here.
 
@@ -159,11 +182,11 @@ Test alongside code; strict TypeScript; domain-driven design; maintain game-data
 
 All bash scripts should follow these standards for reliability and safety:
 
-- **Error handling**: Use `set -euo pipefail` at the start to catch errors in piped commands, fail on undefined variables, and exit on first error
-- **Debugging output**: Enable `set -x` for visibility during development and debugging. Don't embed secrets in scripts; use environment variables instead.
-- **Network resilience**: Use `curl -fsSL` to fail on HTTP errors and network issues
-- **Security**: Don't include credentials, API keys, or sensitive data directly in scripts. Pass these via environment variables or secure configuration.
-- **Example**:
+- **Error handling**: use `set -euo pipefail` at the start to catch errors in piped commands, fail on undefined variables, and exit on first error
+- **Debugging output**: enable `set -x` for visibility during development and debugging. Don't embed secrets in scripts; use environment variables instead.
+- **Network resilience**: use `curl -fsSL` to fail on HTTP errors and network issues
+- **Security**: don't include credentials, API keys, or sensitive data directly in scripts. Pass these via environment variables or secure configuration.
+- **Example**: use this template:
 
   ```bash
   #!/bin/bash
@@ -187,7 +210,7 @@ When explaining decisions or complex patterns, prefer this order:
 
 <!-- vale alex.Condescending = NO -->
 
-Rationale: Comments stay with code through refactors. Long form documentation gets stale and duplicates linter-enforced rules.
+Rationale: comments stay with code through refactors. Long form documentation gets stale and duplicates linter-enforced rules.
 
 <!-- vale alex.Condescending = YES -->
 
@@ -195,10 +218,10 @@ Rationale: Comments stay with code through refactors. Long form documentation ge
 
 Documentation must reflect the current repository state (HEAD), not aspirations:
 
-- **Verify existence**: Check package.json dependencies before documenting a tool as "installed" or "configured"
-- **Use accurate names**: Package names should match actual imports (for example, "TanStack Query" for `@tanstack/react-query`, not "react-query")
-- **Mark future plans**: Explicitly note unimplemented features as "planned" or "not yet installed" rather than documenting as if they exist
-- **Test commands**: Verify that documented commands (`pnpm test`, `pnpm dev`) actually work in the current codebase
+- **Verify existence**: check package.json dependencies before documenting a tool as "installed" or "configured"
+- **Use accurate names**: package names should match actual imports (for example, "TanStack Query" for `@tanstack/react-query`, not "react-query")
+- **Mark future plans**: explicitly note unimplemented features as "planned" or "not yet installed" rather than documenting as if they exist
+- **Test commands**: verify that documented commands (`pnpm test`, `pnpm dev`) actually work in the current codebase
 
 When in doubt, grep the codebase or check package files rather than assuming.
 


### PR DESCRIPTION
## Summary
- document Terraform-only GCP infrastructure management
- align bounded-context module naming with app structure (web, api, firestore)
- clarify multi-environment strategy and promotion language
- adjust wording to satisfy Vale warnings

## Testing
- vale .github/copilot-instructions.md