### PR TITLE
chore(deps): group Dependabot updates and refine labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,30 +19,13 @@ updates:
       - 'alunduil'
     labels:
       - 'dependencies'
+      - 'npm'
       - 'automated'
     groups:
-      # Linting & formatting
-      eslint:
+      # Group all root workspace dependencies together
+      npm-root:
         patterns:
-          - 'eslint*'
-          - '@eslint/*'
-          - 'typescript-eslint'
-      # TypeScript
-      typescript:
-        patterns:
-          - 'typescript'
-      # Turborepo
-      turborepo:
-        patterns:
-          - 'turbo'
-      # Prettier
-      prettier:
-        patterns:
-          - 'prettier*'
-      # Node types
-      types-node:
-        patterns:
-          - '@types/node'
+          - '*'
 
   # ==========================================================================
   # FRONTEND APP (apps/web)
@@ -60,48 +43,39 @@ updates:
       - 'alunduil'
     labels:
       - 'dependencies'
-      - 'frontend'
+      - 'npm'
+      - 'web'
       - 'automated'
     groups:
-      # React & related
-      react:
+      # Group all web app dependencies together
+      npm-web:
         patterns:
-          - 'react*'
-          - '@react*'
-      # Types for React
-      react-types:
+          - '*'
+
+  # ==========================================================================
+  # BACKEND API (apps/api)
+  # ==========================================================================
+  - package-ecosystem: 'npm'
+    directory: '/apps/api'
+    schedule:
+      interval: 'weekly'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'Europe/London'
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'npm'
+      - 'api'
+      - 'automated'
+    groups:
+      # Group all API dependencies together
+      npm-api:
         patterns:
-          - '@types/react*'
-      # Testing libraries
-      testing:
-        patterns:
-          - 'vitest'
-          - '@testing-library/*'
-          - '@vitest/*'
-      # Vite & build
-      vite:
-        patterns:
-          - 'vite*'
-          - '@vitejs/*'
-      # Linting & formatting
-      eslint:
-        patterns:
-          - 'eslint*'
-          - '@eslint/*'
-          - 'typescript-eslint'
-          - 'eslint-plugin-*'
-      # TypeScript
-      typescript:
-        patterns:
-          - 'typescript'
-      # Types packages
-      types:
-        patterns:
-          - '@types/*'
-      # Prettier
-      prettier:
-        patterns:
-          - 'prettier*'
+          - '*'
 
   # ==========================================================================
   # SHARED TYPES PACKAGE (packages/types)
@@ -119,19 +93,39 @@ updates:
       - 'alunduil'
     labels:
       - 'dependencies'
+      - 'npm'
       - 'types'
       - 'automated'
     groups:
-      # Linting & formatting
-      eslint:
+      # Group all types package dependencies together
+      npm-types:
         patterns:
-          - 'eslint*'
-          - '@eslint/*'
-          - 'typescript-eslint'
-      # TypeScript
-      typescript:
+          - '*'
+
+  # ==========================================================================
+  # GAME DATA PACKAGE (packages/game-data)
+  # ==========================================================================
+  - package-ecosystem: 'npm'
+    directory: '/packages/game-data'
+    schedule:
+      interval: 'weekly'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'Europe/London'
+    pull-request-branch-name:
+      separator: '/'
+    reviewers:
+      - 'alunduil'
+    labels:
+      - 'dependencies'
+      - 'npm'
+      - 'game-data'
+      - 'automated'
+    groups:
+      # Group all game data dependencies together
+      npm-game-data:
         patterns:
-          - 'typescript'
+          - '*'
 
   # ==========================================================================
   # GITHUB ACTIONS
@@ -149,8 +143,13 @@ updates:
       - 'alunduil'
     labels:
       - 'dependencies'
-      - 'cicd'
+      - 'actions'
       - 'automated'
+    groups:
+      # Group all GitHub Actions updates together
+      github-actions:
+        patterns:
+          - '*'
 
   # ==========================================================================
   # DEVCONTAINER
@@ -170,6 +169,11 @@ updates:
       - 'dependencies'
       - 'devcontainer'
       - 'automated'
+    groups:
+      # Group all DevContainer updates together
+      devcontainers:
+        patterns:
+          - '*'
 
   # ==========================================================================
   # DOCKER
@@ -188,8 +192,13 @@ updates:
     labels:
       - 'dependencies'
       - 'docker'
-      - 'backend'
+      - 'api'
       - 'automated'
+    groups:
+      # Group all Docker updates together
+      docker-api:
+        patterns:
+          - '*'
 
   # ==========================================================================
   # TERRAFORM - BOOTSTRAP
@@ -211,6 +220,11 @@ updates:
       - 'infrastructure'
       - 'bootstrap'
       - 'automated'
+    groups:
+      # Group all Terraform bootstrap updates together
+      terraform-bootstrap:
+        patterns:
+          - '*'
 
   # ==========================================================================
   # TERRAFORM - CORE ENVIRONMENT
@@ -232,6 +246,11 @@ updates:
       - 'infrastructure'
       - 'core'
       - 'automated'
+    groups:
+      # Group all Terraform core updates together
+      terraform-core:
+        patterns:
+          - '*'
 
   # ==========================================================================
   # TERRAFORM - DEV ENVIRONMENT
@@ -253,6 +272,11 @@ updates:
       - 'infrastructure'
       - 'dev'
       - 'automated'
+    groups:
+      # Group all Terraform dev updates together
+      terraform-dev:
+        patterns:
+          - '*'
 # ============================================================================
 # MAINTENANCE NOTES
 # ============================================================================
@@ -290,7 +314,10 @@ updates:
 # Current coverage:
 #  ✓ Root workspace (weekly)
 #  ✓ apps/web (weekly)
+#  ✓ apps/api (weekly)
 #  ✓ packages/types (weekly)
+#  ✓ packages/game-data (weekly)
+#  ✓ GitHub Actions (weekly)
 #  ✓ DevContainer (weekly)
 #  ✓ Docker - apps/api (weekly)
 #  ✓ Terraform - bootstrap (weekly)


### PR DESCRIPTION
## Summary

This PR consolidates Dependabot updates and refines the label system for better organization and reduced PR volume.

## Changes

### Grouping Configuration
- Added wildcard grouping () to all package ecosystems
- Reduces Dependabot PRs from dozens per week to max 11 grouped PRs
- One PR per location: each package.json, each Terraform environment, GitHub Actions, DevContainers, Docker

### Missing Configurations Added
- `apps/api` npm dependencies → `npm-api` group
- `packages/game-data` npm dependencies → `npm-game-data` group

### Label Refinements
**New labels created:**
- `npm` - For all npm ecosystem updates
- `actions` - For GitHub Actions (replaces `cicd`)
- `web` - For apps/web (replaces `frontend`)
- `api` - For apps/api (replaces `backend`)
- `types`, `game-data`, `docker`, `terraform`, `bootstrap`, `core`, `dev`

**Labels renamed and migrated:**
- `frontend` → `web` (24 issues, 22 PRs migrated)
- `backend` → `api` (13 issues, 2 PRs migrated)
- `cicd` → `actions` (4 issues, 8 PRs migrated)

**Old labels removed:** `frontend`, `backend`, `cicd`

### Group Name Standardization
All groups now follow the pattern `{package-ecosystem}-{unique-directory-part}`:
- `npm-root`, `npm-web`, `npm-api`, `npm-types`, `npm-game-data`
- `github-actions`, `devcontainers`, `docker-api`
- `terraform-bootstrap`, `terraform-core`, `terraform-dev`

## Expected Behavior

Going forward, Dependabot will create:
- One PR per week per location instead of one PR per dependency
- PR titles like: `chore(deps): bump the npm-web group in /apps/web with X updates`
- All PRs properly labeled with ecosystem and location-specific labels

## Testing

- ✅ All pre-commit hooks passed
- ✅ YAML validation passed
- ✅ All existing issues/PRs migrated to new labels
- ✅ Old unused labels removed