### PR TITLE
feat: Set up Cloud DNS zone for genshin.dungeon.studio

### DIFF
--- a/infrastructure/terraform/environments/core/dns_zone_genshin_dungeon_studio.tf
+++ b/infrastructure/terraform/environments/core/dns_zone_genshin_dungeon_studio.tf
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+resource "google_project_service" "dns" {
+  project = var.gcp_core_project_id
+  service = "dns.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_dns_managed_zone" "genshin_dungeon_studio" {
+  name        = "genshin-dungeon-studio"
+  dns_name    = "genshin.dungeon.studio."
+  description = "DNS zone for genshin.dungeon.studio domain"
+  project     = var.gcp_core_project_id
+
+  dnssec_config {
+    state = "on"
+  }
+
+  visibility = "public"
+
+  labels = {
+    managed_by  = "terraform"
+    environment = "production"
+  }
+
+  depends_on = [google_project_service.dns]
+}

--- a/infrastructure/terraform/environments/core/outputs.tf
+++ b/infrastructure/terraform/environments/core/outputs.tf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+output "dns_zone_nameservers" {
+  value       = google_dns_managed_zone.genshin_dungeon_studio.name_servers
+  description = "Cloud DNS nameservers for genshin.dungeon.studio zone - update these at your domain registrar"
+}


### PR DESCRIPTION
## Summary
Sets up Cloud DNS zone for `genshin.dungeon.studio` domain in the core GCP project.

## Changes
- Created Cloud DNS managed zone resource in `infrastructure/terraform/environments/core/`
- Enabled `dns.googleapis.com` API via Terraform
- Configured DNSSEC for enhanced security
- Added Terraform output for nameserver addresses
- Added resource labels: `managed_by=terraform`, `environment=production`

## DNS Nameservers
```
ns-cloud-c1.googledomains.com.
ns-cloud-c2.googledomains.com.
ns-cloud-c3.googledomains.com.
ns-cloud-c4.googledomains.com.
```

## Post-Apply Steps
✅ Subdomain delegation configured in Squarespace DNS (NS records added for `genshin` subdomain)
✅ DNS delegation verified with `dig` and `nslookup`

## Testing
- ✅ `terraform validate` passed
- ✅ `terraform fmt -check` passed
- ✅ Pre-commit hooks passed
- ✅ DNS delegation confirmed working

Resolves #257