### PR TITLE
Grant dev RO SA minimal bucket IAM policy read permission

### DIFF
--- a/infrastructure/terraform/bootstrap/dev.tf
+++ b/infrastructure/terraform/bootstrap/dev.tf
@@ -45,3 +45,25 @@ resource "google_project_iam_member" "dev_rw_viewer_core" {
 
   depends_on = [module.dev, module.core]
 }
+
+# In-project: Minimal read-only permission for bucket IAM policy refresh during plan.
+resource "google_project_iam_custom_role" "dev_ro_bucket_iam_policy_reader" {
+  project     = module.dev.project_id
+  role_id     = "terraformPlanBucketIamReader"
+  title       = "Terraform Plan Bucket IAM Reader"
+  description = "Read Cloud Storage bucket IAM policies for Terraform plan refresh"
+
+  permissions = [
+    "storage.buckets.getIamPolicy"
+  ]
+
+  depends_on = [module.dev]
+}
+
+resource "google_project_iam_member" "dev_ro_bucket_iam_policy_reader" {
+  project = module.dev.project_id
+  role    = google_project_iam_custom_role.dev_ro_bucket_iam_policy_reader.name
+  member  = "serviceAccount:${module.dev.github_deployer_ro_email}"
+
+  depends_on = [module.dev, google_project_iam_custom_role.dev_ro_bucket_iam_policy_reader]
+}


### PR DESCRIPTION
## Problem

Terraform plan for the dev environment was failing with a 403 error when refreshing `google_storage_bucket_iam_binding` resources:

```
Error 403: *** does not have storage.buckets.getIamPolicy access to the Google Cloud Storage bucket.
Permission 'storage.buckets.getIamPolicy' denied on resource (or it may not exist)., forbidden
```

## Solution

Added a minimal custom IAM role in bootstrap that grants only `storage.buckets.getIamPolicy` permission to the dev read-only deployer service account. This allows Terraform plan to refresh bucket IAM policy state without granting broader write permissions.

## Changes

- Created custom role `terraformPlanBucketIamReader` in dev project
- Bound the role to `github-deployer-ro@dungeon-studio-genshin-dev.iam.gserviceaccount.com`
- Scoped to dev environment only (not applied globally)

## Testing

- ✅ Bootstrap terraform apply succeeded
- ✅ IAM propagation confirmed (2-minute wait)
- ✅ Dev terraform plan now succeeds