### PR TITLE
Add base dev API Terraform infrastructure

### DIFF
--- a/infrastructure/terraform/environments/dev/api.tf
+++ b/infrastructure/terraform/environments/dev/api.tf
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 locals {
-  api_artifact_repository_name = "api"
-  api_artifact_repository_loc  = "europe-west1"
+  api_artifact_repository_name     = "api"
+  api_artifact_repository_location = "europe-west1"
 }
 
 # Enable APIs required for API image storage and runtime deployment
@@ -24,7 +24,7 @@ resource "google_project_service" "cloudrun" {
 # Artifact Registry repository for API container images
 resource "google_artifact_registry_repository" "api" {
   project       = var.gcp_dev_project_id
-  location      = local.api_artifact_repository_loc
+  location      = local.api_artifact_repository_location
   repository_id = local.api_artifact_repository_name
   format        = "DOCKER"
 

--- a/infrastructure/terraform/environments/dev/api.tf
+++ b/infrastructure/terraform/environments/dev/api.tf
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+locals {
+  api_artifact_repository_name = "api"
+  api_artifact_repository_loc  = "europe-west1"
+}
+
+# Enable APIs required for API image storage and runtime deployment
+resource "google_project_service" "artifactregistry" {
+  project = var.gcp_dev_project_id
+  service = "artifactregistry.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudrun" {
+  project = var.gcp_dev_project_id
+  service = "run.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Artifact Registry repository for API container images
+resource "google_artifact_registry_repository" "api" {
+  project       = var.gcp_dev_project_id
+  location      = local.api_artifact_repository_loc
+  repository_id = local.api_artifact_repository_name
+  format        = "DOCKER"
+
+  labels = var.common_labels
+
+  depends_on = [google_project_service.artifactregistry]
+}

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -6,7 +6,7 @@ output "web_bucket_name" {
   value       = google_storage_bucket.web.name
 }
 
-output "api_artifact_repository" {
-  description = "Artifact Registry repository used for API container images"
+output "api_artifact_repository_id" {
+  description = "Artifact Registry repository used for API container images (full resource ID)"
   value       = google_artifact_registry_repository.api.id
 }

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -5,3 +5,8 @@ output "web_bucket_name" {
   description = "Cloud Storage bucket hosting the web application"
   value       = google_storage_bucket.web.name
 }
+
+output "api_artifact_repository" {
+  description = "Artifact Registry repository used for API container images"
+  value       = google_artifact_registry_repository.api.id
+}


### PR DESCRIPTION
## Summary
- enable Artifact Registry and Cloud Run APIs in dev
- add Docker Artifact Registry repository for API images
- add dev output for API artifact repository

## Why
This establishes the foundational dev infrastructure required before API deployment automation can run.

## Stack Order
1. This PR (base infra)
2. API deploy automation
3. API domain routing