### PR TITLE
Configure API public endpoint controls for dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,12 @@ jobs:
             FRONTEND_ORIGIN=${{ env.FRONTEND_ORIGIN }}
             APP_GIT_SHA=${{ github.sha }}
 
+      - name: Verify Public Health
+        continue-on-error: true
+        run: >-
+          curl -fsSL "${{ steps.deploy.outputs.url }}/health"
+          | jq -e '.status == "ok"'
+
       - uses: ./.github/actions/setup-node-pnpm
 
       - name: Generate Verify Token
@@ -142,7 +148,7 @@ jobs:
           token_format: id_token
           id_token_audience: ${{ steps.deploy.outputs.url }}
 
-      - name: Verify
+      - name: Verify Authenticated Health
         env:
           HEALTH_BEARER_TOKEN: ${{ steps.verify-token.outputs.id_token }}
         run: pnpm --filter @genshin/api exec tsx scripts/verify-deployment.ts "${{ steps.deploy.outputs.url }}"

--- a/infrastructure/terraform/environments/dev/api.tf
+++ b/infrastructure/terraform/environments/dev/api.tf
@@ -66,3 +66,19 @@ resource "google_cloud_run_domain_mapping" "api" {
 
   depends_on = [google_project_service.cloudrun]
 }
+
+# Cloud Run IAM policy binding for public API invocation.
+# NOTE: The Cloud Run service is created by CI/CD deploy, so this resource
+# has an external ordering dependency on a successful deploy.
+resource "google_cloud_run_service_iam_member" "api_public_invoker" {
+  count = var.enable_api_public_invoker ? 1 : 0
+
+  project  = var.gcp_dev_project_id
+  location = local.api_cloud_run_location
+  service  = local.api_route_name
+
+  role   = "roles/run.invoker"
+  member = "allUsers"
+
+  depends_on = [google_project_service.cloudrun]
+}

--- a/infrastructure/terraform/environments/dev/terraform.tfvars
+++ b/infrastructure/terraform/environments/dev/terraform.tfvars
@@ -10,3 +10,4 @@ common_labels = {
 }
 
 enable_api_domain_mapping = true
+enable_api_public_invoker = true

--- a/infrastructure/terraform/environments/dev/variables.tf
+++ b/infrastructure/terraform/environments/dev/variables.tf
@@ -21,3 +21,9 @@ variable "enable_api_domain_mapping" {
   description = "Whether to create the API Cloud Run custom domain mapping"
   default     = false
 }
+
+variable "enable_api_public_invoker" {
+  type        = bool
+  description = "Whether to grant allUsers the Cloud Run invoker role for API service"
+  default     = false
+}


### PR DESCRIPTION
## Summary
- add Terraform-managed Cloud Run public invoker IAM for the dev API service
- split API exposure controls into separate flags: domain mapping and public invoker
- set both flags enabled in dev tfvars for this rollout
- add a non-blocking public health check in deploy workflow and keep authenticated verification

## Notes
- public health verification is intentionally optional in this changeset
- follow-up can make public health verification required once propagation behavior is stable

Refs #273