### PR TITLE
Grant dev Terraform RW account Cloud Run IAM permission

### DIFF
--- a/infrastructure/terraform/bootstrap/dev.tf
+++ b/infrastructure/terraform/bootstrap/dev.tf
@@ -46,6 +46,17 @@ resource "google_project_iam_member" "dev_rw_viewer_core" {
   depends_on = [module.dev, module.core]
 }
 
+# In-project: Allow dev RW SA to manage Cloud Run service IAM policies.
+# Required for environment Terraform resources such as
+# `google_cloud_run_service_iam_member` in dev.
+resource "google_project_iam_member" "dev_rw_run_admin" {
+  project = module.dev.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${module.dev.github_deployer_rw_email}"
+
+  depends_on = [module.dev]
+}
+
 # In-project: Minimal read-only permission for bucket IAM policy refresh during plan.
 resource "google_project_iam_custom_role" "dev_ro_bucket_iam_policy_reader" {
   project     = module.dev.project_id


### PR DESCRIPTION
## Summary
- grant roles/run.admin to the dev RW GitHub deployer service account in bootstrap
- unblock Terraform apply for google_cloud_run_service_iam_member on Cloud Run service api

## Why
Terraform apply for dev currently fails with:
- run.services.setIamPolicy denied when creating API public invoker binding

## Notes
- keeps enable_api_public_invoker = true in dev
- this branch is created fresh from current develop

Refs #273