### PR TITLE
feat(terraform): provision Firestore in dev

### DIFF
--- a/infrastructure/terraform/environments/dev/firestore.tf
+++ b/infrastructure/terraform/environments/dev/firestore.tf
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+locals {
+  firestore_database_name = "(default)"
+}
+
+# Enable Firestore API
+resource "google_project_service" "firestore" {
+  project = var.gcp_dev_project_id
+  service = "firestore.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Firestore database for application persistence
+resource "google_firestore_database" "default" {
+  project     = var.gcp_dev_project_id
+  name        = local.firestore_database_name
+  location_id = var.firestore_location_id
+  type        = "FIRESTORE_NATIVE"
+
+  # Dev environment should not block teardown workflows.
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+
+  depends_on = [google_project_service.firestore]
+}

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -12,3 +12,15 @@ output "api_artifact_repository_id" {
   value       = google_artifact_registry_repository.api.id
   sensitive   = false
 }
+
+output "firestore_database_name" {
+  description = "Firestore database name for the development environment"
+  value       = google_firestore_database.default.name
+  sensitive   = false
+}
+
+output "firestore_location_id" {
+  description = "Firestore location ID for the development environment"
+  value       = google_firestore_database.default.location_id
+  sensitive   = false
+}

--- a/infrastructure/terraform/environments/dev/terraform.tfvars
+++ b/infrastructure/terraform/environments/dev/terraform.tfvars
@@ -11,3 +11,5 @@ common_labels = {
 
 enable_api_domain_mapping = true
 enable_api_public_invoker = true
+
+firestore_location_id = "eur3"

--- a/infrastructure/terraform/environments/dev/variables.tf
+++ b/infrastructure/terraform/environments/dev/variables.tf
@@ -27,3 +27,14 @@ variable "enable_api_public_invoker" {
   description = "Whether to grant allUsers the Cloud Run invoker role for API service"
   default     = false
 }
+
+variable "firestore_location_id" {
+  type        = string
+  description = "Firestore location for the dev database"
+  default     = "eur3"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.firestore_location_id)) && length(var.firestore_location_id) >= 3 && length(var.firestore_location_id) <= 32
+    error_message = "firestore_location_id must be a valid Google Cloud location ID format (lowercase letters, digits, hyphens; 3-32 chars; must start with a letter)."
+  }
+}


### PR DESCRIPTION
## Summary
Add Firestore persistence infrastructure for the dev environment to support ongoing API/application work.

## What changed
- Enable Firestore API in dev project
- Create Firestore default database (`(default)`) in native mode
- Add validated Firestore location input for dev
- Expose Firestore database/location outputs for downstream integration

## Validation
- `terraform validate` passes in `infrastructure/terraform/environments/dev`
- `terraform plan` shows expected Firestore resources
- Apply intentionally deferred to CI to validate deployment automation path

## Scope notes
- This PR targets **dev only** (per updated Issue #33 scope)
- Follow-ups are tracked separately for release/production/security/API integration

Closes #33
