### PR TITLE
fix(terraform): grant Firestore create permission to GitHub RW deployer

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -25,6 +25,13 @@ resource "google_project_iam_member" "github_deployer_rw_sa_admin" {
   member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
 }
 
+# Required for google_firestore_database (datastore.databases.create)
+resource "google_project_iam_member" "github_deployer_rw_datastore_owner" {
+  project = google_project.env.project_id
+  role    = "roles/datastore.owner"
+  member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
+}
+
 resource "google_storage_bucket_iam_member" "github_deployer_rw_state_bucket" {
   bucket = var.state_bucket_name
   role   = "roles/storage.objectAdmin"


### PR DESCRIPTION
## Summary
- grant \ to the GitHub RW deployer service account in bootstrap
- fix Terraform apply failure when creating \ in dev

## Why
Terraform apply in dev failed with \ because creating the default Firestore database requires Datastore create permissions.

## Validation
- bootstrap IAM change applied manually via \
- local formatting check run: \