### PR TITLE
feat(terraform): add staging bootstrap and release-branch flow prep

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -6,62 +6,12 @@ name: Terraform Apply
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, 'release/**']
     paths:
-      - 'infrastructure/terraform/**'
+      - 'infrastructure/terraform/environments/**'
       - '.github/workflows/terraform-apply.yml'
 
 jobs:
-  terraform-plan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - environment: core
-            service_account_secret: GCP_RO_CORE_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
-          - environment: dev
-            service_account_secret: GCP_RO_DEV_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.9.0'
-
-      # Authenticate to GCP using Workload Identity
-      - uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ secrets.GCP_RO_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets[matrix.service_account_secret] }} # pragma: allowlist secret
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Terraform Init
-        working-directory: infrastructure/terraform/environments/${{ matrix.environment }}
-        run: terraform init
-
-      - name: Terraform Plan
-        id: plan
-        working-directory: infrastructure/terraform/environments/${{ matrix.environment }}
-        run: |
-          terraform plan -lock=false -no-color -out=tfplan
-          terraform show -no-color tfplan > plan.txt
-
-      - name: Upload Terraform Plan
-        uses: actions/upload-artifact@v6
-        with:
-          name: tfplan-${{ matrix.environment }}
-          path: |
-            infrastructure/terraform/environments/${{ matrix.environment }}/tfplan
-            infrastructure/terraform/environments/${{ matrix.environment }}/plan.txt
-
   terraform-apply-core:
     runs-on: ubuntu-latest
     environment: core
@@ -75,8 +25,6 @@ jobs:
     concurrency:
       group: terraform-apply
       cancel-in-progress: false
-
-    needs: terraform-plan
 
     steps:
       - uses: actions/checkout@v6
@@ -98,17 +46,16 @@ jobs:
         working-directory: infrastructure/terraform/environments/core
         run: terraform init
 
-      - name: Download Terraform Plan
-        uses: actions/download-artifact@v7
-        with:
-          name: tfplan-core
-          path: infrastructure/terraform/environments/core
+      - name: Terraform Plan
+        working-directory: infrastructure/terraform/environments/core
+        run: terraform plan -lock=false -no-color -out=tfplan
 
       - name: Terraform Apply
         working-directory: infrastructure/terraform/environments/core
         run: terraform apply -auto-approve tfplan
 
   terraform-apply-dev:
+    if: github.ref_name == 'develop'
     runs-on: ubuntu-latest
     environment: dev
     permissions:
@@ -144,12 +91,55 @@ jobs:
         working-directory: infrastructure/terraform/environments/dev
         run: terraform init
 
-      - name: Download Terraform Plan
-        uses: actions/download-artifact@v7
-        with:
-          name: tfplan-dev
-          path: infrastructure/terraform/environments/dev
+      - name: Terraform Plan
+        working-directory: infrastructure/terraform/environments/dev
+        run: terraform plan -lock=false -no-color -out=tfplan
 
       - name: Terraform Apply
         working-directory: infrastructure/terraform/environments/dev
+        run: terraform apply -auto-approve tfplan
+
+  terraform-apply-staging:
+    if: startsWith(github.ref_name, 'release/')
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    # Shared concurrency group prevents state lock contention on the GCS bucket.
+    # All environments write to dungeon-studio-genshin-tfstate, so only one apply
+    # can run at a time across ALL workflow runs to prevent conflicts.
+    # The 'needs' keyword only orders jobs within a single workflow run.
+    concurrency:
+      group: terraform-apply
+      cancel-in-progress: false
+
+    needs: terraform-apply-core
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.9.0'
+
+      # Authenticate to GCP using Workload Identity
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
+          service_account: ${{ secrets.GCP_RW_STAGING_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Terraform Init
+        working-directory: infrastructure/terraform/environments/staging
+        run: terraform init
+
+      - name: Terraform Plan
+        working-directory: infrastructure/terraform/environments/staging
+        run: terraform plan -lock=false -no-color -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: infrastructure/terraform/environments/staging
         run: terraform apply -auto-approve tfplan

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -6,9 +6,9 @@ name: Terraform Plan
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main, 'release/**']
     paths:
-      - 'infrastructure/terraform/**'
+      - 'infrastructure/terraform/environments/**'
       - '.github/workflows/terraform-plan.yml'
 
 jobs:
@@ -27,6 +27,8 @@ jobs:
             service_account_secret: GCP_RO_CORE_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
           - environment: dev
             service_account_secret: GCP_RO_DEV_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
+          - environment: staging
+            service_account_secret: GCP_RO_STAGING_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
 
     steps:
       - uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,24 @@ For complex logic, decisions, or subtle patterns:
 
 ## Pull request workflow
 
+### Branch flow for infrastructure
+
+Infrastructure automation follows this branch strategy:
+
+- `develop`: integration branch
+- `release/*`: release-train branches cut from `develop`
+- `main`: long-term release target branch (used when production flow is active)
+
+Current Terraform workflow routing:
+
+- push to `develop`: applies `core` then `dev`
+- push to `release/*`: applies `core` then `staging`
+- pull requests to `develop`, `release/*`, and `main`: run Terraform plan checks
+
+When creating release branches, derive the name from the root `package.json` version using SemVer2 context and always include both the release date and short hash token, for example:
+
+- `release/0.1.0-20260221.d24af0f`
+
 ### Branch naming
 
 - `feature/description` - New features
@@ -176,6 +194,7 @@ This project runs on Windows, macOS, and Linux.
 For step-by-step instructions and technical details:
 
 - [Manual Setup Guide](docs/how-tos/manual-setup.md): Development environment setup without DevContainers
+- [Add Terraform Environment](docs/how-tos/add-terraform-environment.md): Bootstrap, scaffold, lock file, and workflow updates for new environments
 
 ---
 

--- a/docs/how-tos/add-terraform-environment.md
+++ b/docs/how-tos/add-terraform-environment.md
@@ -1,0 +1,95 @@
+<!--
+SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Add a Terraform environment
+
+This guide explains how to add a new infrastructure environment (for example `staging`) to this repository.
+
+---
+
+## 1) Add bootstrap configuration
+
+Create `infrastructure/terraform/bootstrap/<environment>.tf` by following the same pattern used in `dev.tf`:
+
+- Create a `module "<environment>"` block using `./modules/project_bootstrap`
+- Set `environment`, `project_id`, and `project_name`
+- Add a `github_oidc_bindings_<environment>` module
+- Add cross-project viewer access to `module.core` for RO and RW service accounts
+- Add environment-scoped IAM needed for planning and applies
+
+Use naming based on infrastructure environment names (`dev`, `staging`, `production`), not branch names or release-train names (for example `release/*`).
+
+---
+
+## 2) Update bootstrap outputs
+
+Update `infrastructure/terraform/bootstrap/outputs.tf`:
+
+- Add project and service-account outputs for the new environment
+- Update `github_secrets_setup` with:
+  - repository/Dependabot RO secret mapping
+  - environment-level RW secret mapping
+
+Keep secret names aligned with infrastructure environment names.
+
+---
+
+## 3) Scaffold the environment folder
+
+Create `infrastructure/terraform/environments/<environment>/` with:
+
+- `backend.tf`
+- `main.tf`
+- `variables.tf`
+- `terraform.tfvars`
+- `outputs.tf`
+
+For early scaffolding, `outputs.tf` can remain empty except SPDX headers until useful outputs exist.
+
+---
+
+## 4) Initialize and commit lock file
+
+From the new environment folder, run:
+
+```bash
+terraform init
+```
+
+Commit `.terraform.lock.hcl` for the new environment.
+
+Don't commit `.terraform/` directories.
+
+---
+
+## 5) Align GitHub workflows
+
+Update workflow routing in:
+
+- `.github/workflows/terraform-plan.yml`
+- `.github/workflows/terraform-apply.yml`
+
+Ensure:
+
+- plan coverage includes the target branch pattern (for example `release/**`)
+- apply routing is branch-specific for the new environment
+
+---
+
+## 6) Apply bootstrap before expecting CI success
+
+After merge, apply bootstrap so the new project, service accounts, and IAM bindings exist before relying on CI plan/apply jobs.
+
+Then set/update GitHub secrets from `github_secrets_setup` output.
+
+---
+
+## 7) Validate and open pull request
+
+After making changes:
+
+1. Run `terraform fmt -recursive` in changed Terraform directories
+2. Run `terraform init -backend=false && terraform validate` where relevant
+3. Commit updates and open a pull request to `develop`

--- a/infrastructure/terraform/bootstrap/outputs.tf
+++ b/infrastructure/terraform/bootstrap/outputs.tf
@@ -19,6 +19,12 @@ output "dev_project_id" {
   sensitive   = false
 }
 
+output "staging_project_id" {
+  value       = module.staging.project_id
+  description = "Staging project ID"
+  sensitive   = false
+}
+
 output "workload_identity_provider" {
   value       = google_iam_workload_identity_pool_provider.github.name
   description = "Workload Identity Provider resource name for GitHub Actions"
@@ -49,6 +55,18 @@ output "github_deployer_ro_dev_service_account_email" {
   sensitive   = false
 }
 
+output "github_deployer_rw_staging_service_account_email" {
+  value       = module.staging.github_deployer_rw_email
+  description = "GitHub Applier service account email for staging environment"
+  sensitive   = false
+}
+
+output "github_deployer_ro_staging_service_account_email" {
+  value       = module.staging.github_deployer_ro_email
+  description = "GitHub Planner service account email for staging environment"
+  sensitive   = false
+}
+
 # Copy-pastable GitHub secrets configuration
 output "github_secrets_setup" {
   value       = <<-EOT
@@ -60,12 +78,14 @@ output "github_secrets_setup" {
     GCP_RO_WORKLOAD_IDENTITY_PROVIDER = ${google_iam_workload_identity_pool_provider.github.name}
     GCP_RO_CORE_SERVICE_ACCOUNT_EMAIL = ${module.core.github_deployer_ro_email}
     GCP_RO_DEV_SERVICE_ACCOUNT_EMAIL = ${module.dev.github_deployer_ro_email}
+    GCP_RO_STAGING_SERVICE_ACCOUNT_EMAIL = ${module.staging.github_deployer_ro_email}
 
     == Dependabot secrets (Settings → Secrets and variables → Dependabot): ==
 
     GCP_RO_WORKLOAD_IDENTITY_PROVIDER = ${google_iam_workload_identity_pool_provider.github.name}
     GCP_RO_CORE_SERVICE_ACCOUNT_EMAIL = ${module.core.github_deployer_ro_email}
     GCP_RO_DEV_SERVICE_ACCOUNT_EMAIL = ${module.dev.github_deployer_ro_email}
+    GCP_RO_STAGING_SERVICE_ACCOUNT_EMAIL = ${module.staging.github_deployer_ro_email}
 
     == Environment-level secrets for 'core' (Settings → Environments → core → Secrets): ==
 
@@ -76,6 +96,11 @@ output "github_secrets_setup" {
 
     GCP_RW_WORKLOAD_IDENTITY_PROVIDER = ${google_iam_workload_identity_pool_provider.github.name}
     GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL = ${module.dev.github_deployer_rw_email}
+
+    == Environment-level secrets for 'staging' (Settings → Environments → staging → Secrets): ==
+
+    GCP_RW_WORKLOAD_IDENTITY_PROVIDER = ${google_iam_workload_identity_pool_provider.github.name}
+    GCP_RW_STAGING_SERVICE_ACCOUNT_EMAIL = ${module.staging.github_deployer_rw_email}
   EOT
   description = "Copy-pastable guide for setting up GitHub secrets"
   sensitive   = false

--- a/infrastructure/terraform/bootstrap/staging.tf
+++ b/infrastructure/terraform/bootstrap/staging.tf
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+# Staging project: pre-production infrastructure environment
+
+# Bootstrap staging environment
+module "staging" {
+  source = "./modules/project_bootstrap"
+
+  environment        = "staging"
+  project_id         = "dungeon-studio-genshin-staging"
+  project_name       = "DS Genshin Staging"
+  billing_account_id = var.billing_account_id
+  state_bucket_name  = data.google_storage_bucket.state.name
+
+  depends_on = [module.shared, module.core]
+}
+
+# Create WIF bindings for staging service accounts
+module "github_oidc_bindings_staging" {
+  source = "./modules/github_oidc_bindings"
+
+  service_account_rw_email = module.staging.github_deployer_rw_email
+  service_account_ro_email = module.staging.github_deployer_ro_email
+  wif_pool_project_number  = module.shared.project_number
+
+  depends_on = [google_iam_workload_identity_pool_provider.github, module.staging]
+}
+
+# Cross-project: Grant staging RO SA permission to read core resources
+# Allows staging terraform to use data sources for core resources (DNS zones, etc.)
+resource "google_project_iam_member" "staging_ro_viewer_core" {
+  project = module.core.project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${module.staging.github_deployer_ro_email}"
+
+  depends_on = [module.staging, module.core]
+}
+
+# Cross-project: Grant staging RW SA permission to read core resources
+# Needed during apply to access the same data sources used in plan
+resource "google_project_iam_member" "staging_rw_viewer_core" {
+  project = module.core.project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${module.staging.github_deployer_rw_email}"
+
+  depends_on = [module.staging, module.core]
+}
+
+# In-project: Allow staging RW SA to manage Cloud Run service IAM policies.
+# Required for environment Terraform resources such as
+# `google_cloud_run_service_iam_member` in staging.
+resource "google_project_iam_member" "staging_rw_run_admin" {
+  project = module.staging.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${module.staging.github_deployer_rw_email}"
+
+  depends_on = [module.staging]
+}
+
+# In-project: Minimal read-only permission for bucket IAM policy refresh during plan.
+resource "google_project_iam_custom_role" "staging_ro_bucket_iam_policy_reader" {
+  project     = module.staging.project_id
+  role_id     = "terraformPlanBucketIamReader"
+  title       = "Terraform Plan Bucket IAM Reader"
+  description = "Read Cloud Storage bucket IAM policies for Terraform plan refresh"
+
+  permissions = [
+    "storage.buckets.getIamPolicy"
+  ]
+
+  depends_on = [module.staging]
+}
+
+resource "google_project_iam_member" "staging_ro_bucket_iam_policy_reader" {
+  project = module.staging.project_id
+  role    = google_project_iam_custom_role.staging_ro_bucket_iam_policy_reader.name
+  member  = "serviceAccount:${module.staging.github_deployer_ro_email}"
+
+  depends_on = [module.staging, google_project_iam_custom_role.staging_ro_bucket_iam_policy_reader]
+}

--- a/infrastructure/terraform/environments/staging/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/staging/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.20.0"
+  constraints = "~> 7.19"
+  hashes = [
+    "h1:r5TTY7rmNJcKZhnv32yWTfDE7T9/LdtLUpmIiX3I2UQ=",
+    "zh:0476beff4009352c52e4595c20beb21b0d5e20ebf3d86753df1ea4b655fdb000",
+    "zh:25e2657deb9f518607193c48673270fbb40e1ae70c022737f4fb1f10d697fc2e",
+    "zh:3e522fd06c0f8757510e39939d5b00dbc9c0712c9f25373ff89770501df5dd93",
+    "zh:4fe718731a615a78a38a9485d21817f3168a311338e3ae31f0de86c0f5a53c40",
+    "zh:64326e8fb391ac269361f0cabb929e842273781b082abba782d088f31e6a0250",
+    "zh:71b95eff24ed205c18f756acb4e8da6a60a9406267271ac40a5a41516e4ed376",
+    "zh:7e4db76bad642721b67cee2e13f4c52f4b38ac15ea3fbe7bbb267e15abf793ed",
+    "zh:a8251fdef80c407e7e63cf24a815b3b6d6a15c27618a379d0344c61aaf48b552",
+    "zh:bc37e63accc2d65fa37934c8dc56317ef39f1e269ef56603a94f74c7b4fd564d",
+    "zh:dbe4c17db018637d1e6ffd3c1090edd6a0ea89c2859e535b9a9ce99da0b054ab",
+    "zh:e52f3708c9c97b7113c61a00567fdb7de70a2ac870016fa6761d0794cc191900",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/terraform/environments/staging/backend.tf
+++ b/infrastructure/terraform/environments/staging/backend.tf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# State is stored in GCS bucket created during bootstrap
+terraform {
+  backend "gcs" {
+    bucket = "dungeon-studio-genshin-tfstate"
+    prefix = "environments/staging"
+  }
+}

--- a/infrastructure/terraform/environments/staging/main.tf
+++ b/infrastructure/terraform/environments/staging/main.tf
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.19"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcp_staging_project_id
+}
+
+data "google_project" "staging" {
+  project_id = var.gcp_staging_project_id
+}

--- a/infrastructure/terraform/environments/staging/outputs.tf
+++ b/infrastructure/terraform/environments/staging/outputs.tf
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT

--- a/infrastructure/terraform/environments/staging/terraform.tfvars
+++ b/infrastructure/terraform/environments/staging/terraform.tfvars
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+# Non-sensitive values for staging environment
+
+gcp_staging_project_id = "dungeon-studio-genshin-staging"
+
+common_labels = {
+  environment = "staging"
+  managed_by  = "terraform"
+}

--- a/infrastructure/terraform/environments/staging/variables.tf
+++ b/infrastructure/terraform/environments/staging/variables.tf
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+variable "gcp_staging_project_id" {
+  type        = string
+  description = "GCP Project ID for staging environment"
+
+  validation {
+    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.gcp_staging_project_id)) && length(var.gcp_staging_project_id) >= 6 && length(var.gcp_staging_project_id) <= 30
+    error_message = "Project ID must be 6-30 characters, start with lowercase letter, contain only lowercase letters/digits/hyphens, and not end with hyphen."
+  }
+}
+
+variable "common_labels" {
+  type        = map(string)
+  description = "Common labels applied to all resources"
+}


### PR DESCRIPTION
## Summary
- add bootstrap configuration for the staging GCP project and related IAM/WIF bindings
- add scaffolded staging Terraform environment configuration files
- update bootstrap outputs and GitHub secret setup guidance for staging
- update Terraform plan/apply workflows for release-train branch support (release/**) and environment-specific apply routing
- inline terraform plan steps into apply jobs and narrow workflow path triggers to environment files

## Notes
- staging environment resources remain scaffold-only for now (no app infra resources yet)
- deploy workflow remains unchanged in this PR per scope

Closes #221
