### PR TITLE
feat(terraform): extract reusable apply workflow

### DIFF
--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -1,0 +1,58 @@
+---
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Terraform Apply Reusable
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      service_account_secret:
+        required: true
+        type: string
+
+jobs:
+  terraform-apply:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    # Shared concurrency group prevents state lock contention on the GCS bucket.
+    # All environments write to dungeon-studio-genshin-tfstate, so only one apply
+    # can run at a time across ALL workflow runs to prevent conflicts.
+    # The 'needs' keyword only orders jobs within a single workflow run.
+    concurrency:
+      group: terraform-apply
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.9.0'
+
+      # Authenticate to GCP using Workload Identity
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
+          service_account: ${{ secrets[inputs.service_account_secret] }} # pragma: allowlist secret
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Terraform Init
+        working-directory: infrastructure/terraform/environments/${{ inputs.environment }}
+        run: terraform init
+
+      - name: Terraform Plan
+        working-directory: infrastructure/terraform/environments/${{ inputs.environment }}
+        run: terraform plan -lock=false -no-color -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: infrastructure/terraform/environments/${{ inputs.environment }}
+        run: terraform apply -auto-approve tfplan

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/terraform-apply.yml'
       - '.github/workflows/terraform-apply-reusable.yml'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   core:
     uses: ./.github/workflows/terraform-apply-reusable.yml

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -10,136 +10,30 @@ on:
     paths:
       - 'infrastructure/terraform/environments/**'
       - '.github/workflows/terraform-apply.yml'
+      - '.github/workflows/terraform-apply-reusable.yml'
 
 jobs:
-  terraform-apply-core:
-    runs-on: ubuntu-latest
-    environment: core
-    permissions:
-      contents: read
-      id-token: write
-    # Shared concurrency group prevents state lock contention on the GCS bucket.
-    # All environments write to dungeon-studio-genshin-tfstate, so only one apply
-    # can run at a time across ALL workflow runs to prevent conflicts.
-    # The 'needs' keyword only orders jobs within a single workflow run.
-    concurrency:
-      group: terraform-apply
-      cancel-in-progress: false
+  core:
+    uses: ./.github/workflows/terraform-apply-reusable.yml
+    with:
+      environment: core
+      service_account_secret: GCP_RW_CORE_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
+    secrets: inherit # pragma: allowlist secret
 
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.9.0'
-
-      # Authenticate to GCP using Workload Identity
-      - uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets.GCP_RW_CORE_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Terraform Init
-        working-directory: infrastructure/terraform/environments/core
-        run: terraform init
-
-      - name: Terraform Plan
-        working-directory: infrastructure/terraform/environments/core
-        run: terraform plan -lock=false -no-color -out=tfplan
-
-      - name: Terraform Apply
-        working-directory: infrastructure/terraform/environments/core
-        run: terraform apply -auto-approve tfplan
-
-  terraform-apply-dev:
+  dev:
     if: github.ref_name == 'develop'
-    runs-on: ubuntu-latest
-    environment: dev
-    permissions:
-      contents: read
-      id-token: write
-    # Shared concurrency group prevents state lock contention on the GCS bucket.
-    # All environments write to dungeon-studio-genshin-tfstate, so only one apply
-    # can run at a time across ALL workflow runs to prevent conflicts.
-    # The 'needs' keyword only orders jobs within a single workflow run.
-    concurrency:
-      group: terraform-apply
-      cancel-in-progress: false
+    needs: core
+    uses: ./.github/workflows/terraform-apply-reusable.yml
+    with:
+      environment: dev
+      service_account_secret: GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
+    secrets: inherit # pragma: allowlist secret
 
-    needs: terraform-apply-core
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.9.0'
-
-      # Authenticate to GCP using Workload Identity
-      - uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Terraform Init
-        working-directory: infrastructure/terraform/environments/dev
-        run: terraform init
-
-      - name: Terraform Plan
-        working-directory: infrastructure/terraform/environments/dev
-        run: terraform plan -lock=false -no-color -out=tfplan
-
-      - name: Terraform Apply
-        working-directory: infrastructure/terraform/environments/dev
-        run: terraform apply -auto-approve tfplan
-
-  terraform-apply-staging:
+  staging:
     if: startsWith(github.ref_name, 'release/')
-    runs-on: ubuntu-latest
-    environment: staging
-    permissions:
-      contents: read
-      id-token: write
-    # Shared concurrency group prevents state lock contention on the GCS bucket.
-    # All environments write to dungeon-studio-genshin-tfstate, so only one apply
-    # can run at a time across ALL workflow runs to prevent conflicts.
-    # The 'needs' keyword only orders jobs within a single workflow run.
-    concurrency:
-      group: terraform-apply
-      cancel-in-progress: false
-
-    needs: terraform-apply-core
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.9.0'
-
-      # Authenticate to GCP using Workload Identity
-      - uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets.GCP_RW_STAGING_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Terraform Init
-        working-directory: infrastructure/terraform/environments/staging
-        run: terraform init
-
-      - name: Terraform Plan
-        working-directory: infrastructure/terraform/environments/staging
-        run: terraform plan -lock=false -no-color -out=tfplan
-
-      - name: Terraform Apply
-        working-directory: infrastructure/terraform/environments/staging
-        run: terraform apply -auto-approve tfplan
+    needs: core
+    uses: ./.github/workflows/terraform-apply-reusable.yml
+    with:
+      environment: staging
+      service_account_secret: GCP_RW_STAGING_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   terraform-plan:
+    name: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/how-tos/add-terraform-environment.md
+++ b/docs/how-tos/add-terraform-environment.md
@@ -71,7 +71,7 @@ Don't commit `.terraform/` directories.
 ## 5) Align GitHub workflows
 
 - In `.github/workflows/terraform-plan.yml`, copy one matrix entry and set `<environment>` + RO secret.
-- In `.github/workflows/terraform-apply.yml`, copy one job and set job name, `environment`, and RW secret.
+- In `.github/workflows/terraform-apply.yml`, copy one job and set job id, `with.environment`, and RW secret.
 - Keep `.github/workflows/terraform-apply-reusable.yml` unchanged.
 
 ---

--- a/docs/how-tos/add-terraform-environment.md
+++ b/docs/how-tos/add-terraform-environment.md
@@ -11,13 +11,13 @@ This guide explains how to add a new infrastructure environment (for example `st
 
 ## 1) Add bootstrap configuration
 
-Create `infrastructure/terraform/bootstrap/<environment>.tf` by following the same pattern used in `dev.tf`:
+Copy `infrastructure/terraform/bootstrap/dev.tf` to `infrastructure/terraform/bootstrap/<environment>.tf`, then update names and references.
 
-- Create a `module "<environment>"` block using `./modules/project_bootstrap`
+- Rename module blocks and resource names from `dev` to `<environment>`
 - Set `environment`, `project_id`, and `project_name`
-- Add a `github_oidc_bindings_<environment>` module
-- Add cross-project viewer access to `module.core` for RO and RW service accounts
-- Add environment-scoped IAM needed for planning and applies
+- Keep the same `github_oidc_bindings_<environment>` pattern
+- Keep cross-project viewer access to `module.core` for RO and RW service accounts
+- Keep any environment-scoped IAM needed for plan/apply
 
 Use naming based on infrastructure environment names (`dev`, `staging`, `production`), not branch names or release-train names (for example `release/*`).
 
@@ -38,13 +38,17 @@ Keep secret names aligned with infrastructure environment names.
 
 ## 3) Scaffold the environment folder
 
-Create `infrastructure/terraform/environments/<environment>/` with:
+Copy `infrastructure/terraform/environments/dev/` to `infrastructure/terraform/environments/<environment>/`, then update values.
+
+Keep these files in the new folder:
 
 - `backend.tf`
 - `main.tf`
 - `variables.tf`
 - `terraform.tfvars`
 - `outputs.tf`
+
+Update project IDs, project numbers, and any environment-specific variable values.
 
 For early scaffolding, `outputs.tf` can remain empty except SPDX headers until useful outputs exist.
 
@@ -66,15 +70,9 @@ Don't commit `.terraform/` directories.
 
 ## 5) Align GitHub workflows
 
-Update workflow routing in:
-
-- `.github/workflows/terraform-plan.yml`
-- `.github/workflows/terraform-apply.yml`
-
-Ensure:
-
-- plan coverage includes the target branch pattern (for example `release/**`)
-- apply routing is branch-specific for the new environment
+- In `.github/workflows/terraform-plan.yml`, copy one matrix entry and set `<environment>` + RO secret.
+- In `.github/workflows/terraform-apply.yml`, copy one job and set job name, `environment`, and RW secret.
+- Keep `.github/workflows/terraform-apply-reusable.yml` unchanged.
 
 ---
 


### PR DESCRIPTION
## Summary
- Extract shared Terraform apply steps into a reusable workflow: `.github/workflows/terraform-apply-reusable.yml`
- Keep Terraform plan inline in `.github/workflows/terraform-plan.yml` (matrix-based, clearer than adding another abstraction layer)
- Simplify workflow job naming to environment labels (`core`, `dev`, `staging`)
- Tighten `docs/how-tos/add-terraform-environment.md` to copy-and-adapt steps with minimal how-to exposition

## Why this shape
- Apply logic had high duplication across environments and benefits from reusable extraction
- Plan already uses a matrix and was kept inline for readability/debuggability
- This gives a hybrid model: **plan inline**, **apply reusable**

## What changed
- Added: `.github/workflows/terraform-apply-reusable.yml`
- Updated: `.github/workflows/terraform-apply.yml`
  - Calls reusable apply workflow per environment
  - Keeps branch routing and sequencing (`core` before env-specific apply)
  - Uses environment job names
- Updated: `.github/workflows/terraform-plan.yml`
  - Keeps plan logic inline
  - Uses environment display names for matrix jobs
- Updated: `docs/how-tos/add-terraform-environment.md`
  - Short procedural copy/adapt instructions for workflow updates

## Behavior impact
- No intended behavior change for current branch routing:
  - `develop`: `core` then `dev`
  - `release/**`: `core` then `staging`

## Validation
- Local pre-commit hooks passed on commit
- CI checks passed on this PR
- Terraform plan checks on this PR reported no infrastructure changes (`core`, `dev`, `staging`)

## Related
- Refs #228
