### PR TITLE
docs: add REST API conventions reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@
   4. Never bulk-ignore suggestions or skip the suggestions pass.
 - For valid product and tool names flagged by Vale, update `.styles/config/vocabularies/Project/accept.txt`.
 - Don't modify third-party Vale styles generated under `.styles/`, except `.styles/config/`.
-- Every source file needs SPDX headers. For files without comment syntax, declare them in `.reuse/dep5`; see [add-SPDX-headers.md](../docs/how-tos/add-spdx-headers.md).
+- Every source file needs SPDX headers. For files without comment syntax, declare them in `.reuse/dep5`; see [How to add SPDX headers to new files](../docs/how-tos/add-spdx-headers.md).
 - Documentation principles:
   - Prefer concise, factual, present-tense writing.
   - Keep guidance implementation-oriented, not aspirational.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,9 +1,13 @@
 <!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!-- vale Microsoft.Headings = NO -->
+
 # GitHub Copilot instructions for genshin.dungeon.studio
 
-> AI-only guidance. Keep this file short and actionable; linters and CONTRIBUTING.md handle the rest.
+<!-- vale Microsoft.Headings = YES -->
+
+> AI-only guidance. Keep this file short and practical; linters and CONTRIBUTING.md handle the remainder.
 
 ## Snapshot
 
@@ -23,26 +27,30 @@
 ## Core coding rules
 
 - Use strict TypeScript and keep components/functions focused.
-- Extract repeated patterns after the third repetition.
+- Remove repeated patterns after the third repetition.
 - Prefer runtime modules over type-only packages; emit JavaScript with declarations.
 - Workspace packages consumed by other packages must expose `types` and `default` in `exports` and include `main`.
-- Use ISO 8601 strings for timestamps (`createdAt`, `updatedAt`, and similar), not `Date` objects.
+- Use ISO 8601 strings for timestamps such as `createdAt` and `updatedAt`, not `Date` objects.
 - Maintain game-data accuracy when working with `packages/game-data`.
-- Test alongside code when possible; automated test stack is planned, so perform manual local validation now.
+- Test alongside code when possible; the team plans an automated test stack, so perform manual local validation now.
 
 ## State usage
 
 - Use zustand for UI state, TanStack Query for server state, and `@genshin/game-data` helpers for static game data.
 
+## API design rules
+
+- Use the [REST API conventions reference](../docs/reference/rest-api-conventions.md) as guidance for API route shape, methods, status codes, error format, pagination, and auth handling.
+
 ## Frontend rules
 
 - Prefer composition over inheritance and use early returns for conditional rendering.
 - Use semantic HTML: proper heading hierarchy, structural elements, and native interactive elements.
-- Use aliases (`@/components`, `@/components/ui`, `@/lib`, `@/lib/utils`).
+- Use aliases such as `@/components`, `@/components/ui`, `@/lib`, and `@/lib/utils`.
 - `shadcn/ui` gotchas:
   - Use ESM imports in Tailwind or Vite config (`import ...`), not `require()`.
-  - Ensure Vite starter CSS dark-mode defaults stay removed from `apps/web/src/index.css`; don't reintroduce `color-scheme` or `prefers-color-scheme` defaults.
-  - Keep semantic slots semantic: `CardTitle` should render heading tags (for example, `h3`) and `CardDescription` should render paragraph tags (`p`).
+  - Keep Vite starter CSS dark-mode defaults removed from `apps/web/src/index.css`; don't reintroduce `color-scheme` or `prefers-color-scheme` defaults.
+  - Keep semantic slots semantic: `CardTitle` should render heading tags such as `h3`, and `CardDescription` should render paragraph tags such as `p`.
   - `react-refresh/only-export-components` with `allowConstantExport: true` can still flag valid `shadcn` patterns that export a component and helper; targeted suppression is acceptable.
 
 ## Dependencies and linting
@@ -66,11 +74,11 @@
 - Handle Vale output in this order:
   1. Process suggestions first: review every suggestion one by one, then either apply it or make an explicit, reasoned decision not to apply it.
   2. Fix all warnings second.
-  3. Fix all errors last (commit-blocking before commit).
+  3. Fix all errors last because they're commit-blocking.
   4. Never bulk-ignore suggestions or skip the suggestions pass.
 - For valid product and tool names flagged by Vale, update `.styles/config/vocabularies/Project/accept.txt`.
-- Don't modify third-party Vale styles generated under `.styles/` (except `.styles/config/`).
-- Every source file needs SPDX headers; for files without comment syntax, declare in `.reuse/dep5` (see [add-spdx-headers.md](../docs/how-tos/add-spdx-headers.md)).
+- Don't modify third-party Vale styles generated under `.styles/`, except `.styles/config/`.
+- Every source file needs SPDX headers. For files without comment syntax, declare them in `.reuse/dep5`; see [add-SPDX-headers.md](../docs/how-tos/add-spdx-headers.md).
 - Documentation principles:
   - Prefer concise, factual, present-tense writing.
   - Keep guidance implementation-oriented, not aspirational.
@@ -99,14 +107,14 @@
 - Keep Terraform version aligned across:
   - `.github/workflows/terraform-plan.yml`
   - `.github/workflows/terraform-apply.yml`
-  - `.github/workflows/pre-commit.yml` (when Terraform is used)
+  - `.github/workflows/pre-commit.yml`, when Terraform is in use
 - Current Terraform version baseline: `1.9.0`.
 
 ## File naming
 
-- Non-React TypeScript: lowercase (`user.ts`) or camelCase compounds (`teamMember.ts`).
-- React components: PascalCase (`HomePage.tsx`).
-- `shadcn/ui` components: lowercase (`button.tsx`, `card.tsx`).
+- Non-React TypeScript: lowercase file names like `user.ts`, or camelCase compounds like `teamMember.ts`.
+- React components: PascalCase file names like `HomePage.tsx`.
+- `shadcn/ui` components: lowercase file names like `button.tsx` and `card.tsx`.
 
 ## When unsure
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@
 ## Core coding rules
 
 - Use strict TypeScript and keep components/functions focused.
-- Remove repeated patterns after the third repetition.
+- Extract reusable patterns after the third repetition.
 - Prefer runtime modules over type-only packages; emit JavaScript with declarations.
 - Workspace packages consumed by other packages must expose `types` and `default` in `exports` and include `main`.
 - Use ISO 8601 strings for timestamps such as `createdAt` and `updatedAt`, not `Date` objects.

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -95,6 +95,22 @@ Diátaxis
 UTC
 camelCase
 PascalCase
+REST
+HTTP
+URI
+URIs
+ESM
+ISO
+SPDX
+REUSE
+RFC
+IETF
+ISBN
+OAuth
+Masse
+Hardt
+Dalal
+O'Reilly
 
 # Game elements (Genshin Impact)
 Pyro

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -111,6 +111,11 @@ Masse
 Hardt
 Dalal
 O'Reilly
+DSGEP
+IAM
+SPA
+JSONC
+INI
 
 # Game elements (Genshin Impact)
 Pyro

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ To run it:
 docker run -p 8080:8080 genshin-api:local
 ```
 
-The API will be available at `http://localhost:8080`. See [apps/api/Dockerfile](apps/api/Dockerfile) for build details and [.github/workflows/](.github/workflows/) for CI/CD pipeline information.
+The API is available at `http://localhost:8080`. See [apps/api/Dockerfile](apps/api/Dockerfile) for build details and [.github/workflows/](.github/workflows/) for CI/CD pipeline information.
 
 ### Quality checks overview
 
@@ -103,8 +103,8 @@ Pre-commit enforces formatting, linting, documentation, secrets, and hygiene che
 Pre-commit hooks automatically enforce key checks, including:
 
 - **Prettier** - Code formatting
-- **ESLint** - JavaScript/TypeScript linting (fixes issues when possible)
-- CSS linting (Tailwind directives supported)
+- **ESLint** - JavaScript/TypeScript linting with automatic fixes when possible
+- CSS linting with Tailwind directives
 - Documentation and config linting for Markdown, YAML, and prose
 - Safety and repository hygiene checks for secrets, merge conflict markers, large files, trailing whitespace, line endings, and YAML/JSON validation
 
@@ -114,7 +114,7 @@ For type checking, run manually before committing:
 pnpm typecheck
 ```
 
-### SPDX headers
+### Source file headers
 
 All source files require SPDX headers per the [REUSE Specification](https://reuse.software/). Use `reuse addheader` or check [REUSE docs](https://reuse.software/tutorial/) for details.
 
@@ -137,7 +137,7 @@ Infrastructure automation follows this branch strategy:
 
 - `develop`: integration branch
 - `release/*`: release-train branches cut from `develop`
-- `main`: long-term release target branch (used when production flow is active)
+- `main`: long-term release target branch, used when production flow is active
 
 Current Terraform workflow routing:
 
@@ -166,14 +166,14 @@ When creating release branches, derive the name from the root `package.json` ver
 ### Merge strategy
 
 - **Squash and merge** - All pull request commits become one commit on develop
-- The pull request title becomes the final commit message (use conventional commit format)
+- The pull request title becomes the final commit message. Use conventional commit format.
 - Keep commit history clean - one feature equals one commit
 
 ### Addressing review comments
 
 1. Address feedback completely
 2. Batch related fixes when possible
-3. Pre-commit hooks will verify formatting and linting. For type checking, run:
+3. Pre-commit hooks verify formatting and linting. For type checking, run:
 
    ```bash
    pnpm typecheck
@@ -195,6 +195,7 @@ For step-by-step instructions and technical details:
 
 - [Manual Setup Guide](docs/how-tos/manual-setup.md): Development environment setup without DevContainers
 - [Add Terraform Environment](docs/how-tos/add-terraform-environment.md): Bootstrap, scaffold, lock file, and workflow updates for new environments
+- [REST API conventions](docs/reference/rest-api-conventions.md): Route design, method semantics, status codes, error shape, and pagination
 
 ---
 

--- a/docs/explanation/dsgep-001-wif-architecture.md
+++ b/docs/explanation/dsgep-001-wif-architecture.md
@@ -1,7 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
 <!-- SPDX-License-Identifier: MIT -->
 
-# DSGEP-001: Workload Identity Federation architecture
+# DSGEP-001: Workload identity federation architecture
 
 - **Status**: Accepted
 - **Created**: 2026-02-15
@@ -30,7 +30,7 @@ The project uses three GCP projects:
 - `dungeon-studio-genshin-core`: Common resources (Domain Name System (DNS), shared services) used across environments
 - `dungeon-studio-genshin-dev`: Development environment resources
 
-### Bootstrap vs environment Terraform
+### Bootstrap vs. environment Terraform
 
 - **Bootstrap**: Creates GCP projects, service accounts, and foundational infrastructure. Run manually with user credentials.
 - **Environments** (core, dev): Manage environment-specific resources. Run via GitHub Actions with WIF authentication.
@@ -125,7 +125,7 @@ The WIF pool lives in `dungeon-studio-genshin-shared` because:
 - Multiplies security configuration: 3 WIF pools to maintain
 - Unclear which pool should be the "source of truth" for shared authentication
 
-### Alternative 2: Workload Identity Federation in shared environment Terraform
+### Alternative 2: Workload identity federation in shared environment Terraform
 
 **Approach**: move WIF creation to `environments/shared` Terraform workspace instead of bootstrap.
 
@@ -135,7 +135,7 @@ The WIF pool lives in `dungeon-studio-genshin-shared` because:
 - Creates the same circular dependency as Alternative 1
 - Doesn't solve the "where does the first WIF come from" problem
 
-### Alternative 3: Separate bootstrap for Workload Identity Federation only
+### Alternative 3: Separate bootstrap for workload identity federation only
 
 **Approach**: create a minimal bootstrap just for WIF, then a second bootstrap for projects.
 

--- a/docs/explanation/understanding-spdx-compliance.md
+++ b/docs/explanation/understanding-spdx-compliance.md
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 
-# Understanding SPDX compliance: Headers vs .reuse/dep5
+# Understanding SPDX compliance: Headers vs `.reuse/dep5`
 
 This project uses the [REUSE Specification v3.3](https://reuse.software/spec-3.3.0/) to make copyright and licensing information machine-readable and comply with open source best practices. Both SPDX headers and the `.reuse/dep5` file serve the same goal through different mechanisms, each suited to different file types.
 
@@ -38,7 +38,7 @@ export function myFunction() { ... }
 
 ---
 
-### 2. .reuse/dep5 (for files without comment support)
+### 2. `.reuse/dep5` for files without comment support
 
 The [Debian machine-readable copyright format](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/) allows declaring copyright/license for files that **can't have comment syntax**.
 
@@ -49,9 +49,9 @@ The [Debian machine-readable copyright format](https://www.debian.org/doc/packag
 - Generated/build files (`.turbo/`, `dist/`, `node_modules/`)
 - Binary or non-standard files
 
-**Note:** Files with JSON-with-comments (JSONC) support like `.vscode/*.json` and `.devcontainer/devcontainer.json` can have SPDX headers directly using `//` comment syntax.
+**Note:** files with JSON-with-comments (JSONC) support like `.vscode/*.json` and `.devcontainer/devcontainer.json` can have SPDX headers directly using `//` comment syntax.
 
-**Example entry in .reuse/dep5:**
+**Example entry in `.reuse/dep5`:**
 
 ```text
 Files: *.json .prettierrc
@@ -70,6 +70,6 @@ License: MIT
 
 ## See also
 
-- [How to add SPDX headers to new files](../how-tos/add-spdx-headers.md) - practical steps for adding headers and troubleshooting
+- [How to add SPDX headers to new files](../how-tos/add-spdx-headers.md): practical steps for adding headers and troubleshooting
 - [REUSE Specification v3.3](https://reuse.software/spec-3.3.0/)
 - [Debian copyright format documentation](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/)

--- a/docs/explanation/understanding-spdx-compliance.md
+++ b/docs/explanation/understanding-spdx-compliance.md
@@ -49,7 +49,7 @@ The [Debian machine-readable copyright format](https://www.debian.org/doc/packag
 - Generated/build files (`.turbo/`, `dist/`, `node_modules/`)
 - Binary or non-standard files
 
-**Note:** files with JSON-with-comments (JSONC) support like `.vscode/*.json` and `.devcontainer/devcontainer.json` can have SPDX headers directly using `//` comment syntax.
+**Note** that files that support JSON-with-comments (JSONC), such as `.vscode/*.json` and `.devcontainer/devcontainer.json`, can have SPDX headers directly using `//` comment syntax.
 
 **Example entry in `.reuse/dep5`:**
 

--- a/docs/how-tos/add-spdx-headers.md
+++ b/docs/how-tos/add-spdx-headers.md
@@ -11,15 +11,15 @@ This guide shows you how to add copyright and license headers to new source file
 
 ## Quick reference by file type
 
-| File Type                                    | Header Format | Example                                                                  |
-| -------------------------------------------- | ------------- | ------------------------------------------------------------------------ |
-| TypeScript/JavaScript (.ts, .tsx, .js, .jsx) | `//`          | `// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`       |
-| CSS/SCSS (.css, .scss)                       | `/* */`       | `/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */`    |
-| Markdown (.md)                               | `<!--` HTML   | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
-| YAML/INI (.yaml, .yml, .ini)                 | `#`           | `# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`        |
-| HTML (.html)                                 | `<!--` HTML   | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
-| SVG (.svg)                                   | `<!--` XML    | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
-| Shell (.sh, .bash)                           | `#`           | `# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`        |
+| File type                                            | Header format | Example                                                                  |
+| ---------------------------------------------------- | ------------- | ------------------------------------------------------------------------ |
+| TypeScript/JavaScript (`.ts`, `.tsx`, `.js`, `.jsx`) | `//`          | `// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`       |
+| CSS/SCSS (`.css`, `.scss`)                           | `/* */`       | `/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */`    |
+| Markdown (`.md`)                                     | `<!--` HTML   | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
+| YAML/INI (`.yaml`, `.yml`, `.INI`)                   | `#`           | `# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`        |
+| HTML (`.html`)                                       | `<!--` HTML   | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
+| SVG (`.svg`)                                         | `<!--` XML    | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
+| Shell (`.sh`, `.bash`)                               | `#`           | `# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`        |
 
 ---
 
@@ -27,7 +27,7 @@ This guide shows you how to add copyright and license headers to new source file
 
 ### 1. Add to top of file
 
-Place the SPDX header at the very beginning of the file (line 1), before any code or other comments.
+Place the SPDX header at the beginning of the file (line 1), before any code or other comments.
 
 For YAML files, keep `---` on line 1 if present, and place the SPDX header immediately after.
 
@@ -56,7 +56,7 @@ SPDX-License-Identifier: MIT
 -->
 ```
 
-### 3. Verify with reuse lint
+### 3. Verify with REUSE lint
 
 After adding headers, verify compliance:
 

--- a/docs/how-tos/add-spdx-headers.md
+++ b/docs/how-tos/add-spdx-headers.md
@@ -16,7 +16,7 @@ This guide shows you how to add copyright and license headers to new source file
 | TypeScript/JavaScript (`.ts`, `.tsx`, `.js`, `.jsx`) | `//`          | `// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`       |
 | CSS/SCSS (`.css`, `.scss`)                           | `/* */`       | `/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */`    |
 | Markdown (`.md`)                                     | `<!--` HTML   | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
-| YAML/INI (`.yaml`, `.yml`, `.INI`)                   | `#`           | `# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`        |
+| YAML/INI (`.yaml`, `.yml`, `.ini`)                   | `#`           | `# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`        |
 | HTML (`.html`)                                       | `<!--` HTML   | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
 | SVG (`.svg`)                                         | `<!--` XML    | `<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->` |
 | Shell (`.sh`, `.bash`)                               | `#`           | `# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>`        |

--- a/docs/how-tos/add-terraform-environment.md
+++ b/docs/how-tos/add-terraform-environment.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Add a Terraform environment
 
-This guide explains how to add a new infrastructure environment (for example `staging`) to this repository.
+This guide explains how to add a new infrastructure environment such as `staging` to this repository.
 
 ---
 
@@ -19,7 +19,7 @@ Copy `infrastructure/terraform/bootstrap/dev.tf` to `infrastructure/terraform/bo
 - Keep cross-project viewer access to `module.core` for RO and RW service accounts
 - Keep any environment-scoped IAM needed for plan/apply
 
-Use naming based on infrastructure environment names (`dev`, `staging`, `production`), not branch names or release-train names (for example `release/*`).
+Use naming based on infrastructure environment names such as `dev`, `staging`, and `production`, not branch names or release-train names such as `release/*`.
 
 ---
 
@@ -76,7 +76,7 @@ Don't commit `.terraform/` directories.
 
 ---
 
-## 6) Apply bootstrap before expecting CI success
+## 6) Apply bootstrap before expecting continuous integration success
 
 After merge, apply bootstrap so the new project, service accounts, and IAM bindings exist before relying on CI plan/apply jobs.
 

--- a/docs/how-tos/update-game-artifacts.md
+++ b/docs/how-tos/update-game-artifacts.md
@@ -81,7 +81,7 @@ Use exact text from the in-game artifact descriptions or wiki:
 
 ### 4. Update version comment
 
-Update the version comment near the top of `artifacts.ts` (for example, the `Last updated: Version ...` line) with the latest game version and a brief description of the changes.
+Update the version comment near the top of `artifacts.ts`, such as the `Last updated: Version ...` line, with the latest game version and a brief description of the changes.
 
 ### 5. Keep array organized
 

--- a/docs/how-tos/update-game-characters.md
+++ b/docs/how-tos/update-game-characters.md
@@ -68,7 +68,7 @@ Maintain the `CHARACTERS` array in a logical order:
 
 ### 4. Update version comment
 
-Update the version comment at the top of `characters.ts` (for example, the line noting "as of version ...") with the latest game version and a brief description of the changes you made.
+Update the version comment at the top of `characters.ts`, such as the line noting "as of version," with the latest game version and a brief description of the changes you made.
 
 ### 5. Verify and test
 

--- a/docs/how-tos/update-game-characters.md
+++ b/docs/how-tos/update-game-characters.md
@@ -68,7 +68,7 @@ Maintain the `CHARACTERS` array in a logical order:
 
 ### 4. Update version comment
 
-Update the version comment at the top of `characters.ts`, such as the line noting "as of version," with the latest game version and a brief description of the changes you made.
+Update the version comment at the top of `characters.ts`, such as a line noting "as of version X," with the latest game version and a brief description of the changes you made.
 
 ### 5. Verify and test
 

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -27,23 +27,23 @@ Use each method by protocol intent in Hypertext Transfer Protocol (HTTP): `GET` 
 
 Return meaningful status codes for both success and failure. Don't collapse errors into generic success responses.
 
-See RFC 9110, Section 15: <https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes>
+See [RFC9110], Section 15: <https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes>
 
 ### 4. Predictable representation shapes
 
-Representations should be explicit and negotiable through media types. Use content negotiation with `Accept` and `Content-Type`, and define schemas that provide stable semantic structure for clients.
+Representations should be explicit and negotiable through media types. Use content negotiation with `Accept` and `Content-Type`, align media type usage with [RFC6838], and define schemas that provide stable semantic structure for clients.
 
 For `application/json` representations, provide a published JSON Schema for each request and response shape so semantics are discoverable.
 
-See RFC 9110, Section 12: <https://www.rfc-editor.org/rfc/rfc9110.html#name-content-negotiation>
+See [RFC9110], Section 12: <https://www.rfc-editor.org/rfc/rfc9110.html#name-content-negotiation>
 
-See JSON Schema Draft 2020-12: <https://json-schema.org/draft/2020-12>
+See [JSONSchema2020-12]: <https://json-schema.org/draft/2020-12>
 
 ### 5. Consistent error contract
 
 Use the Problem Details standard for machine-readable error responses. Return `application/problem+json` with stable fields and consistent extension members where needed.
 
-See RFC 9457: <https://www.rfc-editor.org/rfc/rfc9457>
+See [RFC9457]: <https://www.rfc-editor.org/rfc/rfc9457>
 
 ### 6. Consistent list behavior
 
@@ -55,7 +55,7 @@ When using cursor pagination, the response representation must explicitly define
 
 When authentication is active, use bearer tokens in the `Authorization` header and distinguish authentication `401` failures from authorization `403` failures.
 
-See RFC 6750: <https://www.rfc-editor.org/rfc/rfc6750>
+See [RFC6750]: <https://www.rfc-editor.org/rfc/rfc6750>
 
 ### 8. Timestamp format
 

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -1,0 +1,79 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- vale Microsoft.HeadingAcronyms = NO -->
+
+# REST API design conventions
+
+<!-- vale Microsoft.HeadingAcronyms = YES -->
+
+Use these conventions for `apps/api` routes to keep behavior predictable across endpoints.
+
+## Source and scope
+
+This reference defines the project's API design principles for representational state transfer (REST), informed by Mark Masse in [Masse2011].
+
+## Principles
+
+### 1. Resource-oriented paths
+
+Model endpoints as resource nouns with stable, hierarchical paths. Use plural resource names and avoid action verbs in path segments.
+
+### 2. Method semantics
+
+Use each method by protocol intent in Hypertext Transfer Protocol (HTTP): `GET` for retrieval, `POST` for creation, `PUT` for full replacement, `PATCH` for partial update, and `DELETE` for removal.
+
+### 3. Consistent status code semantics
+
+Return meaningful status codes for both success and failure. Don't collapse errors into generic success responses.
+
+See RFC 9110, Section 15: <https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes>
+
+### 4. Predictable representation shapes
+
+Representations should be explicit and negotiable through media types. Use content negotiation with `Accept` and `Content-Type`, and define schemas that provide stable semantic structure for clients.
+
+For `application/json` representations, provide a published JSON Schema for each request and response shape so semantics are discoverable.
+
+See RFC 9110, Section 12: <https://www.rfc-editor.org/rfc/rfc9110.html#name-content-negotiation>
+
+See JSON Schema Draft 2020-12: <https://json-schema.org/draft/2020-12>
+
+### 5. Consistent error contract
+
+Use the Problem Details standard for machine-readable error responses. Return `application/problem+json` with stable fields and consistent extension members where needed.
+
+See RFC 9457: <https://www.rfc-editor.org/rfc/rfc9457>
+
+### 6. Consistent list behavior
+
+Use explicit filtering parameters and cursor-based pagination with consistent query parameter names `limit` and `cursor`.
+
+When using cursor pagination, the response representation must explicitly define cursor fields such as next and previous cursor tokens in its media type contract and published schema.
+
+### 7. Authentication header convention
+
+When authentication is active, use bearer tokens in the `Authorization` header and distinguish authentication `401` failures from authorization `403` failures.
+
+See RFC 6750: <https://www.rfc-editor.org/rfc/rfc6750>
+
+### 8. Timestamp format
+
+Encode API timestamps as ISO 8601 UTC strings.
+
+## Repository scope
+
+These principles guide route design, method semantics, status code usage, error shape, pagination, authentication header handling, and timestamp format for `apps/api`.
+
+### References
+
+<!-- vale Vale.Spelling = NO -->
+
+- [Masse2011] Mark Masse. _REST API Design Rulebook_. O'Reilly Media, 2011. ISBN 978-1-4493-1050-9. <https://www.amazon.co.uk/REST-Design-Rulebook-Mark-Masse/dp/1449310508>
+<!-- vale Vale.Spelling = YES -->
+- [RFC9110] Nottingham, M., et al. _RFC 9110: HTTP Semantics_. IETF, 2022. Status codes: Section 15. <https://www.rfc-editor.org/rfc/rfc9110>
+- [RFC6838] Freed, N., et al. _RFC 6838: Media Type Specifications and Registration Procedures_. IETF, 2013. <https://www.rfc-editor.org/rfc/rfc6838>
+- [RFC9457] Nottingham, M., Wilde, E., and Dalal, S. _RFC 9457: Problem Details for HTTP APIs_. IETF, 2023. <https://www.rfc-editor.org/rfc/rfc9457>
+- [RFC6750] Jones, M. and Hardt, D. _RFC 6750: The OAuth 2.0 Authorization Framework: Bearer Token Usage_. IETF, 2012. <https://www.rfc-editor.org/rfc/rfc6750>
+- [JSONSchema2020-12] JSON Schema. _Draft 2020-12_. <https://json-schema.org/draft/2020-12>
+- Supporting context: Richardson Maturity Model: <https://martinfowler.com/articles/richardsonMaturityModel.html>


### PR DESCRIPTION
## Summary

This PR documents REST API design guidance for backend work and connects it to contributor and Copilot guidance.

## Changes

- Add REST API conventions reference in `docs/reference/rest-api-conventions.md`
- Link API design guidance from `.github/copilot-instructions.md`
- Link REST API conventions from `CONTRIBUTING.md`
- Align wording and vocabulary with Vale requirements

## Validation

- `vale .github/copilot-instructions.md CONTRIBUTING.md docs/reference/rest-api-conventions.md`

## Issue

Closes #138
