### PR TITLE
docs: require native issue dependency relationships

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,6 +91,7 @@
 - Run `pnpm typecheck` manually because it's not part of local pre-commit hooks.
 - Never use `git commit --amend` or `git push --force`.
 - Fixes after hook failures should be new commits; squash merge handles cleanup.
+- For GitHub issues, track dependencies only with native issue relationships (`blocked by` / `is blocking`), not issue body text or comments.
 
 ## Shell script rules
 


### PR DESCRIPTION
## Summary
- add a Copilot instruction to track GitHub issue dependencies with native relationships only
- clarify that dependency tracking must use blocked-by / is-blocking relationships, not issue body text or comments

## Testing
- pre-commit hooks passed during commit
