### PR TITLE
feat(terraform): initialize Firebase Auth via Terraform

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -60,6 +60,9 @@ resource "google_project_iam_member" "github_deployer_ro_sa_viewer" {
   member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
 }
 
+# Required for Terraform plan refresh of `google_firestore_database`.
+# The equivalent least-privilege custom permission set is currently insufficient
+# for provider read behavior; track tightening in a follow-up issue.
 resource "google_project_iam_member" "github_deployer_ro_datastore_viewer" {
   project = google_project.env.project_id
   role    = "roles/datastore.viewer"

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -60,6 +60,18 @@ resource "google_project_iam_member" "github_deployer_ro_sa_viewer" {
   member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
 }
 
+resource "google_project_iam_member" "github_deployer_ro_run_viewer" {
+  project = google_project.env.project_id
+  role    = "roles/run.viewer"
+  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+}
+
+resource "google_project_iam_member" "github_deployer_ro_datastore_viewer" {
+  project = google_project.env.project_id
+  role    = "roles/datastore.viewer"
+  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+}
+
 resource "google_storage_bucket_iam_member" "github_deployer_ro_state_bucket" {
   bucket = var.state_bucket_name
   role   = "roles/storage.objectViewer"

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -25,7 +25,6 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
   permissions = [
     "artifactregistry.repositories.get",
     "artifactregistry.repositories.list",
-    "datastore.databases.getIamPolicy",
     "datastore.databases.get",
     "datastore.databases.list",
     "dns.managedZones.get",

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -25,6 +25,7 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
   permissions = [
     "artifactregistry.repositories.get",
     "artifactregistry.repositories.list",
+    "datastore.databases.getIamPolicy",
     "datastore.databases.get",
     "datastore.databases.list",
     "dns.managedZones.get",
@@ -57,18 +58,6 @@ resource "google_project_iam_member" "github_deployer_ro_planner" {
 resource "google_project_iam_member" "github_deployer_ro_sa_viewer" {
   project = google_project.env.project_id
   role    = "roles/iam.serviceAccountViewer"
-  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
-}
-
-resource "google_project_iam_member" "github_deployer_ro_run_viewer" {
-  project = google_project.env.project_id
-  role    = "roles/run.viewer"
-  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
-}
-
-resource "google_project_iam_member" "github_deployer_ro_datastore_viewer" {
-  project = google_project.env.project_id
-  role    = "roles/datastore.viewer"
   member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
 }
 

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -60,6 +60,12 @@ resource "google_project_iam_member" "github_deployer_ro_sa_viewer" {
   member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
 }
 
+resource "google_project_iam_member" "github_deployer_ro_datastore_viewer" {
+  project = google_project.env.project_id
+  role    = "roles/datastore.viewer"
+  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+}
+
 resource "google_storage_bucket_iam_member" "github_deployer_ro_state_bucket" {
   bucket = var.state_bucket_name
   role   = "roles/storage.objectViewer"

--- a/infrastructure/terraform/environments/dev/firebase_auth.tf
+++ b/infrastructure/terraform/environments/dev/firebase_auth.tf
@@ -21,7 +21,7 @@ resource "google_project_service" "identitytoolkit" {
 resource "google_identity_platform_config" "default" {
   project = var.gcp_dev_project_id
 
-  autodelete_anonymous_users = false
+  autodelete_anonymous_users = true
 
   depends_on = [
     google_project_service.firebase,

--- a/infrastructure/terraform/environments/dev/firebase_auth.tf
+++ b/infrastructure/terraform/environments/dev/firebase_auth.tf
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Enable Firebase Management API for the project.
+resource "google_project_service" "firebase" {
+  project = var.gcp_dev_project_id
+  service = "firebase.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Enable Identity Toolkit API for Firebase Authentication.
+resource "google_project_service" "identitytoolkit" {
+  project = var.gcp_dev_project_id
+  service = "identitytoolkit.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Initialize Identity Platform (Firebase Authentication) project config.
+resource "google_identity_platform_config" "default" {
+  project = var.gcp_dev_project_id
+
+  autodelete_anonymous_users = false
+
+  depends_on = [
+    google_project_service.firebase,
+    google_project_service.identitytoolkit,
+  ]
+}

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -24,3 +24,9 @@ output "firestore_location_id" {
   value       = google_firestore_database.default.location_id
   sensitive   = false
 }
+
+output "firebase_auth_config_name" {
+  description = "Identity Platform config resource name for the development environment"
+  value       = google_identity_platform_config.default.name
+  sensitive   = false
+}


### PR DESCRIPTION
## Summary
- add Terraform-managed Firebase and Identity Platform bootstrap for dev
- enable firebase.googleapis.com and identitytoolkit.googleapis.com APIs
- add google_identity_platform_config resource
- expose auth config output for downstream use

## Why
- keeps infrastructure managed by Terraform instead of Firebase CLI/manual setup
- unblocks dependent auth/provider/frontend issues

Closes #35