### PR TITLE
fix(terraform): grant firebase.projects.update to RW deployer

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -42,6 +42,7 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "dns.resourceRecordSets.delete",
     "dns.resourceRecordSets.list",
     "dns.resourceRecordSets.update",
+    "firebase.projects.update",
     "firebaseauth.configs.create",
     "firebaseauth.configs.get",
     "firebaseauth.configs.update",


### PR DESCRIPTION
## Summary
- add firebase.projects.update to the RW bootstrap custom role used by Terraform apply
- keep scope minimal (no RO role changes)

## Why
Audit logs for github-deployer-rw@dungeon-studio-genshin-dev.iam.gserviceaccount.com show:
- service: firebase.googleapis.com
- method: google.firebase.service.v1beta1.FirebaseProjectService.AddFirebase
- denied permission: firebase.projects.update
- adjacent identitytoolkit initialize call returns INSUFFICIENT_PERMISSION

This unblocks initializing Identity Platform/Firebase auth config in dev apply runs.

## Validation
- terraform fmt -check passes for modified file
- change based on direct gcloud logging read audit evidence
