### PR TITLE
fix(terraform): restore RW deployer permissions for deploy workflow

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -27,6 +27,7 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "artifactregistry.repositories.delete",
     "artifactregistry.repositories.get",
     "artifactregistry.repositories.list",
+    "artifactregistry.repositories.uploadArtifacts",
     "artifactregistry.repositories.update",
     "datastore.databases.get",
     "datastore.databases.list",
@@ -57,7 +58,12 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "storage.buckets.getIamPolicy",
     "storage.buckets.list",
     "storage.buckets.setIamPolicy",
-    "storage.buckets.update"
+    "storage.buckets.update",
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+    "storage.objects.list",
+    "storage.objects.update"
   ]
 
   depends_on = [google_project_service.serviceusage]


### PR DESCRIPTION
## Summary
- restore missing Artifact Registry upload permission in RW deployer custom role
- restore missing Cloud Storage object permissions used by web deploy (`gsutil rsync`/`setmeta`)

## Why
GitHub Actions run `22519390545` failed in both deploy jobs due to IAM denials:
- API: `artifactregistry.repositories.uploadArtifacts` denied when pushing image
- Web: `storage.objects.create` / `storage.objects.delete` denied during bucket sync

## Changes
- update `githubDeployerApplier` custom role in Terraform bootstrap module:
  - add `artifactregistry.repositories.uploadArtifacts`
  - add `storage.objects.create`, `storage.objects.delete`, `storage.objects.get`, `storage.objects.list`, `storage.objects.update`

## Validation
- `terraform fmt -check` passes for the changed file
- manual `terraform apply` in `infrastructure/terraform/bootstrap` completed successfully

## Scope
- one Terraform file changed
- no workflow or application code changes
