### PR TITLE
docs: Add Copilot instruction and prompt files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,7 @@
   - `docs/` for task-specific how-tos and deeper explanations.
 - Prefer this order when documenting decisions: inline comments, documentation strings, updates to existing docs, then new long-form docs.
 - Keep docs accurate to `HEAD`: verify dependencies, command availability, and feature status.
+- Run Vale through pre-commit (`pre-commit run vale --all-files`), not `vale .`. Vale has no directory-ignore mechanism and scans everything, including `node_modules`.
 - Handle Vale output in this order:
   1. Process suggestions first: review every suggestion one by one, then either apply it or make an explicit, reasoned decision not to apply it.
   2. Fix all warnings second.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,6 +79,7 @@
 - For valid product and tool names flagged by Vale, update `.styles/config/vocabularies/Project/accept.txt`.
 - Don't modify third-party Vale styles generated under `.styles/`, except `.styles/config/`.
 - Every source file needs SPDX headers. For files without comment syntax, declare them in `.reuse/dep5`; see [How to add SPDX headers to new files](../docs/how-tos/add-spdx-headers.md).
+- Wrap file and directory paths in backticks when they appear in prose (for example, `apps/web`, `packages/game-data/src/index.ts`). Markdown link targets don't need backticks.
 - Documentation principles:
   - Prefer concise, factual, present-tense writing.
   - Keep guidance implementation-oriented, not aspirational.

--- a/.github/copilot/add-shadcn-component.prompt.md
+++ b/.github/copilot/add-shadcn-component.prompt.md
@@ -17,7 +17,7 @@ Install and configure a new `shadcn/ui` component.
 
 ## Steps
 
-1. Run: `cd apps/web && pnpm dlx shadcn@latest add ${input:componentName}`
+1. Run: `cd apps/web && pnpm dlx shadcn@3.8.5 add ${input:componentName}`
 2. Verify the component was created at
    `apps/web/src/components/ui/${input:componentName}.tsx`.
 3. Add the SPDX header to the generated file if missing:

--- a/.github/copilot/add-shadcn-component.prompt.md
+++ b/.github/copilot/add-shadcn-component.prompt.md
@@ -1,0 +1,33 @@
+---
+description: Add a new shadcn/ui component to `apps/web`
+agent: agent
+argument-hint: Component name (for example, accordion, tabs, or tooltip)
+tools: ['editFiles', 'runInTerminal', 'codebase']
+---
+
+# Add shadcn/ui component
+
+Follow the conventions in [code-generation.instructions.md](code-generation.instructions.md).
+
+Use [button.tsx](../../apps/web/src/components/ui/button.tsx) and
+[card.tsx](../../apps/web/src/components/ui/card.tsx) as references for the
+expected style.
+
+Install and configure a new `shadcn/ui` component.
+
+## Steps
+
+1. Run: `cd apps/web && pnpm dlx shadcn@latest add ${input:componentName}`
+2. Verify the component was created at
+   `apps/web/src/components/ui/${input:componentName}.tsx`.
+3. Add the SPDX header to the generated file if missing:
+
+   ```tsx
+   // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+   // SPDX-License-Identifier: MIT
+   ```
+
+4. Verify imports use `@/lib/utils` for `cn()` and ESM-compatible imports.
+5. Ensure semantic HTML tags: `CardTitle` renders `<h3>`, `CardDescription`
+   renders `<p>` (or equivalent for the component).
+6. Run `pnpm --filter @genshin/web lint` to confirm no lint errors.

--- a/.github/copilot/code-generation.instructions.md
+++ b/.github/copilot/code-generation.instructions.md
@@ -1,0 +1,59 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Code generation instructions
+
+## General
+
+- Start every source file with the SPDX header appropriate to the file type.
+- Use strict TypeScript; never use `any` unless truly unavoidable, and add a
+  justifying comment when it is.
+- Prefer named exports; use default exports only when a framework requires them.
+- Use `import type` for type-only imports.
+- End files with a trailing newline.
+- Wrap file and directory paths in backticks when they appear in prose or
+  YAML metadata (for example, `apps/web`, `docs/how-tos/`).
+- Single quotes, 100-character print width, 2-space indentation (Prettier
+  handles this, but generate compliant code).
+
+## React components (`apps/web`)
+
+- Use function declarations (`export function MyComponent()`) for page and
+  layout components.
+- Use `const` with `React.forwardRef` only for `shadcn/ui` primitives.
+- Colocate small helper components in the same file as private functions (not
+  exported).
+- Use early returns for guard clauses and conditional rendering.
+- Use semantic HTML: headings in order, `<nav>`, `<main>`, `<footer>`,
+  `<button>` (not `<div onClick>`).
+- Use `@/components`, `@/components/ui`, `@/lib`, and `@/lib/utils` path
+  aliases.
+- Apply Tailwind utility classes directly; avoid inline `style` objects.
+- Use `cn()` from `@/lib/utils` to merge conditional class names.
+
+## Hono API routes (`apps/api`)
+
+- Follow REST conventions in `docs/reference/rest-api-conventions.md`.
+- Return `application/problem+json` for errors using `HTTPException`.
+- Use middleware composition; keep route handlers thin.
+- Validate inputs at the boundary.
+
+## Shared packages
+
+- `@genshin/game-data`: export data arrays (for example, `CHARACTERS`) and
+  getter helpers (for example, `getCharacterById`). Export relevant types
+  alongside data.
+- `@genshin/types`: export only `type` declarations. No runtime code.
+
+## State management (`apps/web`)
+
+- **UI state**: zustand stores. Keep stores small and focused.
+- **Server state**: TanStack Query. Use query keys consistently.
+- **Static game data**: import from `@genshin/game-data`. Never duplicate game
+  data in component files.
+
+## Dependencies
+
+- Only import packages that exist in the consuming package's `package.json`.
+- Classify correctly: `dependencies` for runtime, `devDependencies` for build
+  tooling.

--- a/.github/copilot/code-generation.instructions.md
+++ b/.github/copilot/code-generation.instructions.md
@@ -34,7 +34,8 @@
 ## Hono API routes (`apps/api`)
 
 - Follow REST conventions in `docs/reference/rest-api-conventions.md`.
-- Return `application/problem+json` for errors using `HTTPException`.
+- Use `HTTPException` for errors; the global error handler formats the
+  response. The API plans to migrate to `application/problem+json` (RFC 9457).
 - Use middleware composition; keep route handlers thin.
 - Validate inputs at the boundary.
 

--- a/.github/copilot/commit-message.instructions.md
+++ b/.github/copilot/commit-message.instructions.md
@@ -29,7 +29,7 @@ rules of a great Git commit message**.
 
 ## Allowed types
 
-Use the prefixes defined in CONTRIBUTING.md:
+Use the prefixes defined in `CONTRIBUTING.md`:
 
 - `feat:` new feature
 - `fix:` bug fix

--- a/.github/copilot/commit-message.instructions.md
+++ b/.github/copilot/commit-message.instructions.md
@@ -1,0 +1,73 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Commit message instructions
+
+Follow both **Conventional Commits** (for the type prefix) and the **seven
+rules of a great Git commit message**.
+
+## Format
+
+```text
+<type>(<optional scope>): <subject>
+
+<optional body>
+
+<optional footer>
+```
+
+## The seven rules
+
+1. Separate subject from body with a blank line.
+2. Limit the subject line to 50 characters.
+3. Capitalize the subject line (the part after the type prefix).
+4. Don't end the subject line with a period.
+5. Use the imperative mood in the subject line ("Add feature," not "Added"
+   or "Adds").
+6. Wrap the body at 72 characters.
+7. Use the body to explain **what** and **why**, not how.
+
+## Allowed types
+
+Use the prefixes defined in CONTRIBUTING.md:
+
+- `feat:` new feature
+- `fix:` bug fix
+- `docs:` documentation
+- `test:` adding or updating tests
+- `refactor:` code restructuring
+- `style:` formatting
+- `chore:` maintenance
+
+## Scopes
+
+Use the workspace package name when the change is scoped to one package:
+
+- `feat(web):` change in `apps/web`
+- `fix(api):` change in `apps/api`
+- `refactor(game-data):` change in `packages/game-data`
+- `chore(types):` change in `packages/types`
+- `docs:` cross-cutting documentation (no scope needed)
+- `chore(infra):` Terraform and infrastructure changes
+
+Omit the scope for cross-cutting changes that touch multiple packages.
+
+## Examples
+
+```text
+feat(web): Add character filter to collection page
+
+Filter characters by element and weapon type using
+@genshin/game-data helpers. The filter state is managed
+with a zustand store to persist selections across navigation.
+
+Closes #42
+```
+
+```text
+fix(api): Return 404 for unknown character IDs
+```
+
+```text
+chore: Upgrade TypeScript to 5.9.1
+```

--- a/.github/copilot/new-api-route.prompt.md
+++ b/.github/copilot/new-api-route.prompt.md
@@ -13,9 +13,10 @@ and [REST API conventions](../../docs/reference/rest-api-conventions.md).
 Add a new REST resource route to `apps/api`.
 
 Use [main.ts](../../apps/api/src/main.ts) as a reference for middleware.
-The global error handler currently serializes `HTTPException` as
-`{ error, status }` JSON. When the API migrates to RFC 9457 Problem Details,
-update these routes to match.
+The global error handler currently serializes `HTTPException` responses as
+`{ "error": string, "status": "error" }` JSON; the numeric HTTP status code
+is only in the HTTP response status. When the API migrates to RFC 9457
+Problem Details, update these routes to match.
 
 ## Inputs
 

--- a/.github/copilot/new-api-route.prompt.md
+++ b/.github/copilot/new-api-route.prompt.md
@@ -2,7 +2,7 @@
 description: Scaffold a new Hono API route
 agent: agent
 argument-hint: Resource name (plural, lowercase) and HTTP methods
-tools: ['editFiles', 'codebase', 'terminalLastCommand']
+tools: ['editFiles', 'codebase', 'runInTerminal']
 ---
 
 # New API route

--- a/.github/copilot/new-api-route.prompt.md
+++ b/.github/copilot/new-api-route.prompt.md
@@ -1,0 +1,35 @@
+---
+description: Scaffold a new Hono API route
+agent: agent
+argument-hint: Resource name (plural, lowercase) and HTTP methods
+tools: ['editFiles', 'codebase', 'terminalLastCommand']
+---
+
+# New API route
+
+Follow the conventions in [code-generation.instructions.md](code-generation.instructions.md)
+and [REST API conventions](../../docs/reference/rest-api-conventions.md).
+
+Add a new REST resource route to `apps/api`.
+
+Use [main.ts](../../apps/api/src/main.ts) as a reference for middleware and
+error handling patterns.
+
+## Inputs
+
+- Resource name (plural, lowercase): `${input:resource}`
+- HTTP methods needed: `${input:methods}`
+
+## Requirements
+
+1. Create `apps/api/src/${input:resource}/routes.ts` with the route handlers.
+2. Start the file with the SPDX header.
+3. Follow the REST conventions:
+   - Resource-oriented paths: `/api/${input:resource}`.
+   - Correct HTTP method semantics.
+   - Return `application/problem+json` for errors using `HTTPException`.
+   - Use cursor-based pagination for list endpoints (`limit` and `cursor`).
+4. Wire the route into [main.ts](../../apps/api/src/main.ts) using
+   `app.route()`.
+5. Keep handlers thin; extract business logic into separate modules.
+6. Run `pnpm typecheck` to verify the route compiles.

--- a/.github/copilot/new-api-route.prompt.md
+++ b/.github/copilot/new-api-route.prompt.md
@@ -12,8 +12,10 @@ and [REST API conventions](../../docs/reference/rest-api-conventions.md).
 
 Add a new REST resource route to `apps/api`.
 
-Use [main.ts](../../apps/api/src/main.ts) as a reference for middleware and
-error handling patterns.
+Use [main.ts](../../apps/api/src/main.ts) as a reference for middleware.
+The global error handler currently serializes `HTTPException` as
+`{ error, status }` JSON. When the API migrates to RFC 9457 Problem Details,
+update these routes to match.
 
 ## Inputs
 
@@ -27,7 +29,8 @@ error handling patterns.
 3. Follow the REST conventions:
    - Resource-oriented paths: `/api/${input:resource}`.
    - Correct HTTP method semantics.
-   - Return `application/problem+json` for errors using `HTTPException`.
+   - Use `HTTPException` for errors; the global error handler formats the
+     response.
    - Use cursor-based pagination for list endpoints (`limit` and `cursor`).
 4. Wire the route into [main.ts](../../apps/api/src/main.ts) using
    `app.route()`.

--- a/.github/copilot/new-issue.prompt.md
+++ b/.github/copilot/new-issue.prompt.md
@@ -1,0 +1,87 @@
+---
+description: Create a well-structured GitHub issue with labels, milestone, and acceptance criteria
+agent: agent
+argument-hint: Brief description of the problem or feature
+tools: ['githubRepo', 'codebase']
+---
+
+# New GitHub issue
+
+Follow the workflow guardrails in
+[Copilot instructions](../copilot-instructions.md).
+
+## Inputs
+
+- Description: `${input:description}`
+
+## Title format
+
+Write an outcome-oriented title that describes the desired end state, not the
+task. Good titles read as statements that are true when the issue is done:
+
+- "Clients integrate profile media types without negotiation failures"
+- "Profile writes persist across API restarts in Firestore"
+- "Terraform apply and deploy permissions use separate roles"
+
+For bug fixes, prefix with the conventional commit type:
+
+- "fix(web): Collection page no longer crashes on empty data"
+
+## Issue body structure
+
+Use this template:
+
+```markdown
+## Summary
+
+One or two sentences describing what this issue delivers.
+
+## Why
+
+Explain the motivation: what problem exists, what opportunity this creates,
+or what dependency requires it.
+
+## Scope
+
+Bullet list of concrete changes required. Be specific enough that a
+contributor can start without ambiguity.
+
+## Acceptance criteria
+
+Measurable conditions that must be true when this issue is done. Use
+checkboxes:
+
+- [ ] Criterion one
+- [ ] Criterion two
+- [ ] Typecheck and lint pass
+```
+
+## Labels
+
+Apply labels from the repository's label set. Use at least one category label
+and one area label when applicable:
+
+**Category**: `enhancement`, `bug`, `documentation`, `security`
+
+**Area**: `web`, `api`, `game-data`, `types`, `infrastructure`, `terraform`,
+`actions`, `devcontainer`, `authentication`, `database`, `ai`
+
+**Other**: `dependencies`, `good first issue`, `accessibility`
+
+## Milestone
+
+Assign to the current active milestone when the issue fits its scope. Check
+existing milestones before creating or assigning.
+
+## Dependencies
+
+Track issue dependencies only with native GitHub issue relationships
+(`blocked by` / `is blocking`), not body text or comments. Use the sidebar
+controls or `gh` CLI to link related issues.
+
+## Before submitting
+
+1. Search existing issues to avoid duplicates.
+2. Verify the title is outcome-oriented, not task-oriented.
+3. Verify acceptance criteria are measurable, not vague.
+4. Assign appropriate labels and milestone.

--- a/.github/copilot/new-page.prompt.md
+++ b/.github/copilot/new-page.prompt.md
@@ -1,0 +1,32 @@
+---
+description: Scaffold a new React page component in `apps/web`
+agent: agent
+argument-hint: Page name in PascalCase (for example, Settings or CharacterDetail)
+tools: ['editFiles', 'codebase', 'terminalLastCommand']
+---
+
+# New page component
+
+Follow the conventions in [code-generation.instructions.md](code-generation.instructions.md).
+
+Create a new page component at `apps/web/src/pages/${input:PageName}Page.tsx`.
+
+Use [HomePage.tsx](../../apps/web/src/pages/HomePage.tsx) as a reference for
+structure and style.
+
+## Requirements
+
+1. Start with the SPDX header:
+
+   ```tsx
+   // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+   // SPDX-License-Identifier: MIT
+   ```
+
+2. Use a named function export: `export function ${input:PageName}Page()`.
+3. Use semantic HTML with a `<div className="mx-auto max-w-7xl px-4 py-12">` wrapper.
+4. Include an `<h1>` heading as the first visible content.
+5. Add the route to [App.tsx](../../apps/web/src/App.tsx) inside the
+   `<Route element={<Layout />}>` group.
+6. Import the page: `import { ${input:PageName}Page } from './pages/${input:PageName}Page';`.
+7. Run `pnpm typecheck` to verify the new route compiles.

--- a/.github/copilot/new-page.prompt.md
+++ b/.github/copilot/new-page.prompt.md
@@ -9,7 +9,7 @@ tools: ['editFiles', 'codebase', 'terminalLastCommand']
 
 Follow the conventions in [code-generation.instructions.md](code-generation.instructions.md).
 
-Create a new page component at `apps/web/src/pages/${input:PageName}Page.tsx`.
+Create a new page component at `apps/web/src/pages/${input:pageName}Page.tsx`.
 
 Use [HomePage.tsx](../../apps/web/src/pages/HomePage.tsx) as a reference for
 structure and style.
@@ -23,10 +23,10 @@ structure and style.
    // SPDX-License-Identifier: MIT
    ```
 
-2. Use a named function export: `export function ${input:PageName}Page()`.
+2. Use a named function export: `export function ${input:pageName}Page()`.
 3. Use semantic HTML with a `<div className="mx-auto max-w-7xl px-4 py-12">` wrapper.
 4. Include an `<h1>` heading as the first visible content.
 5. Add the route to [App.tsx](../../apps/web/src/App.tsx) inside the
    `<Route element={<Layout />}>` group.
-6. Import the page: `import { ${input:PageName}Page } from './pages/${input:PageName}Page';`.
+6. Import the page: `import { ${input:pageName}Page } from './pages/${input:pageName}Page';`.
 7. Run `pnpm typecheck` to verify the new route compiles.

--- a/.github/copilot/new-page.prompt.md
+++ b/.github/copilot/new-page.prompt.md
@@ -2,7 +2,7 @@
 description: Scaffold a new React page component in `apps/web`
 agent: agent
 argument-hint: Page name in PascalCase (for example, Settings or CharacterDetail)
-tools: ['editFiles', 'codebase', 'terminalLastCommand']
+tools: ['editFiles', 'codebase', 'runInTerminal']
 ---
 
 # New page component

--- a/.github/copilot/new-zustand-store.prompt.md
+++ b/.github/copilot/new-zustand-store.prompt.md
@@ -2,7 +2,7 @@
 description: Create a new zustand store for UI state in `apps/web`
 agent: agent
 argument-hint: Store name in PascalCase and its purpose
-tools: ['editFiles', 'codebase']
+tools: ['editFiles', 'codebase', 'runInTerminal']
 ---
 
 # New zustand store

--- a/.github/copilot/new-zustand-store.prompt.md
+++ b/.github/copilot/new-zustand-store.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a new zustand store for UI state in `apps/web`
 agent: agent
-argument-hint: Store name in PascalCase and its purpose
+argument-hint: Store name in camelCase and its purpose
 tools: ['editFiles', 'codebase', 'runInTerminal']
 ---
 
@@ -18,22 +18,25 @@ Create a new zustand store for managing UI state.
 
 ## Requirements
 
-1. Create `apps/web/src/stores/${input:storeName}Store.ts`.
+1. Create `apps/web/src/stores/${input:storeName}Store.ts` (camelCase file
+   name per project convention).
 2. Start with the SPDX header.
-3. Define a clear interface for the store state and actions:
+3. Define a clear interface for the store state and actions. Capitalize the
+   store name for type names (for example, `teamFilter` → `TeamFilterState`):
 
    ```ts
-   interface ${input:storeName}State {
+   interface TeamFilterState {
      // state fields
    }
 
-   interface ${input:storeName}Actions {
+   interface TeamFilterActions {
      // action methods
    }
    ```
 
 4. Use `create<State & Actions>()` from zustand.
 5. Keep the store focused on a single concern.
-6. Export the hook as `use${input:storeName}Store`.
+6. Export the hook with a capitalized store name:
+   `useTeamFilterStore` (not `useteamFilterStore`).
 7. Don't put server or async state here—use TanStack Query for that.
 8. Run `pnpm typecheck` to verify the store compiles.

--- a/.github/copilot/new-zustand-store.prompt.md
+++ b/.github/copilot/new-zustand-store.prompt.md
@@ -1,0 +1,39 @@
+---
+description: Create a new zustand store for UI state in `apps/web`
+agent: agent
+argument-hint: Store name in PascalCase and its purpose
+tools: ['editFiles', 'codebase']
+---
+
+# New zustand store
+
+Follow the conventions in [code-generation.instructions.md](code-generation.instructions.md).
+
+Create a new zustand store for managing UI state.
+
+## Inputs
+
+- Store name: `${input:storeName}`
+- Purpose: `${input:purpose}`
+
+## Requirements
+
+1. Create `apps/web/src/stores/${input:storeName}Store.ts`.
+2. Start with the SPDX header.
+3. Define a clear interface for the store state and actions:
+
+   ```ts
+   interface ${input:storeName}State {
+     // state fields
+   }
+
+   interface ${input:storeName}Actions {
+     // action methods
+   }
+   ```
+
+4. Use `create<State & Actions>()` from zustand.
+5. Keep the store focused on a single concern.
+6. Export the hook as `use${input:storeName}Store`.
+7. Don't put server or async state here—use TanStack Query for that.
+8. Run `pnpm typecheck` to verify the store compiles.

--- a/.github/copilot/review.instructions.md
+++ b/.github/copilot/review.instructions.md
@@ -97,7 +97,7 @@ violations as review comments with a brief explanation and a suggested fix.
 
 - Verify Vale compliance: use contractions ("don't," "isn't"), em
   dashes without spaces (`word—word`), "for example" instead of Latin
-  abbreviations, and inclusive language (`alex` style).
+  abbreviations (`Google.Latin`), and inclusive language (`alex` style).
 - Handle Vale output in order: suggestions first, then warnings, then errors.
 - Heading hierarchy must not skip levels.
 - Place files in the correct `docs/` subdirectory following Diátaxis:

--- a/.github/copilot/review.instructions.md
+++ b/.github/copilot/review.instructions.md
@@ -44,7 +44,9 @@ violations as review comments with a brief explanation and a suggested fix.
 
 - Routes must follow the conventions in
   `docs/reference/rest-api-conventions.md`.
-- Errors must return `application/problem+json` using `HTTPException`.
+- Use `HTTPException` for errors; the global error handler serializes them
+  as `{ error, status }` JSON. The API plans to migrate to
+  `application/problem+json` (RFC 9457).
 - List endpoints must use cursor-based pagination (`limit` and `cursor`).
 
 ## Game data integrity

--- a/.github/copilot/review.instructions.md
+++ b/.github/copilot/review.instructions.md
@@ -88,3 +88,34 @@ violations as review comments with a brief explanation and a suggested fix.
 - `fireEvent` in tests (use `userEvent` instead).
 - Snapshot tests for UI components (assert on behavior and accessible roles).
 - `test()` in test files (use `it()` per project convention).
+
+## Documentation
+
+- Verify Vale compliance: use contractions ("don't," "isn't"), em
+  dashes without spaces (`word—word`), "for example" instead of Latin
+  abbreviations, and inclusive language (`alex` style).
+- Handle Vale output in order: suggestions first, then warnings, then errors.
+- Heading hierarchy must not skip levels.
+- Place files in the correct `docs/` subdirectory following Diátaxis:
+  `docs/how-tos/` for tasks, `docs/reference/` for lookup material,
+  `docs/explanation/` for rationale.
+- Don't duplicate guidance that exists elsewhere; link to the canonical source.
+- Keep docs accurate to `HEAD`: verify dependencies, commands, and feature
+  status.
+- For valid product or tool names flagged by Vale, add them to
+  `.styles/config/vocabularies/Project/accept.txt` instead of rewriting.
+
+## Infrastructure
+
+- Terraform version must stay aligned across
+  `.github/workflows/terraform-plan.yml`,
+  `.github/workflows/terraform-apply.yml`, and
+  `.github/workflows/pre-commit.yml`. Current baseline: `1.9.0`.
+- GCP projects follow the naming convention
+  `dungeon-studio-genshin-{env}`. `shared` and `core` are
+  production-grade infrastructure.
+- Apply environment labels on project creation.
+- Never hard-code secrets in Terraform or scripts; use environment variables.
+- Verify state storage configuration in `backend.tf` files.
+- Terraform files must include SPDX headers using `#` comment syntax.
+- Enable Google Cloud APIs on demand, only when required by active work.

--- a/.github/copilot/review.instructions.md
+++ b/.github/copilot/review.instructions.md
@@ -1,0 +1,90 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Code review instructions
+
+Use these rules when reviewing pull requests or code selections. Flag
+violations as review comments with a brief explanation and a suggested fix.
+
+## TypeScript strictness
+
+- No implicit or explicit `any`. If `any` is unavoidable, require a justifying
+  comment.
+- Use `import type` for type-only imports.
+- Ensure strict mode is honored: no non-null assertions (`!`) without
+  justification, no `@ts-ignore` without an accompanying issue reference.
+
+## SPDX headers
+
+- Every source file must start with the SPDX header appropriate to its file
+  type. For files that can't have inline headers, verify they're declared in
+  `.reuse/dep5`.
+
+## Dependency classification
+
+- Imports must exist in the consuming package's `package.json`.
+- `dependencies`: runtime code shipped to production.
+- `devDependencies`: build tools, plugins, type definitions, and local tooling.
+- Flag misclassified packages.
+
+<!-- vale Microsoft.HeadingAcronyms = NO -->
+
+## Semantic HTML
+
+<!-- vale Microsoft.HeadingAcronyms = YES -->
+
+- Headings must follow proper hierarchy (no skipped levels).
+- Use structural elements: `<nav>`, `<main>`, `<footer>`, `<section>`.
+- Use native interactive elements (`<button>`, `<a>`, `<input>`), not
+  `<div onClick>`.
+- `shadcn/ui` semantic slots: `CardTitle` renders heading tags, and
+  `CardDescription` renders paragraph tags.
+
+## REST API conventions
+
+- Routes must follow the conventions in
+  `docs/reference/rest-api-conventions.md`.
+- Errors must return `application/problem+json` using `HTTPException`.
+- List endpoints must use cursor-based pagination (`limit` and `cursor`).
+
+## Game data integrity
+
+- Never hard-code game data (characters, weapons, artifacts, elements) in
+  component or route files. Use `@genshin/game-data` helpers.
+- Verify data accuracy against official sources when new entries are added.
+- Data arrays must maintain alphabetical sort order.
+
+## State management boundaries
+
+- **UI state**: zustand stores only. Keep stores small and single-purpose.
+- **Server state**: TanStack Query only. Don't put async/fetch logic in
+  zustand stores.
+- **Static game data**: import from `@genshin/game-data`. Don't duplicate game
+  data in components or stores.
+
+## Path aliases and imports
+
+- Use `@/components`, `@/components/ui`, `@/lib`, and `@/lib/utils` in
+  `apps/web`.
+- Prefer named exports; flag default exports unless a framework requires them.
+
+## Commit message format
+
+- Verify PR titles follow Conventional Commits format: `type(scope): subject`.
+- Subject line must use imperative mood, start with a capital letter, and omit
+  a trailing period.
+- Allowed types: `feat`, `fix`, `docs`, `test`, `refactor`, `style`, `chore`.
+
+## Path formatting in prose
+
+- File and directory paths in prose or YAML metadata must be wrapped in
+  backticks (for example, `apps/web`, `packages/game-data`).
+- Markdown link targets don't need backticks.
+
+## Patterns to flag
+
+- `console.log` left in production code (use structured logging or remove).
+- Inline `style` objects in React components (use Tailwind classes).
+- `fireEvent` in tests (use `userEvent` instead).
+- Snapshot tests for UI components (assert on behavior and accessible roles).
+- `test()` in test files (use `it()` per project convention).

--- a/.github/copilot/review.instructions.md
+++ b/.github/copilot/review.instructions.md
@@ -45,8 +45,10 @@ violations as review comments with a brief explanation and a suggested fix.
 - Routes must follow the conventions in
   `docs/reference/rest-api-conventions.md`.
 - Use `HTTPException` for errors; the global error handler serializes them
-  as `{ error, status }` JSON. The API plans to migrate to
-  `application/problem+json` (RFC 9457).
+  as `{ error, status }` JSON, where `status` is always the string `'error'`.
+  The numeric HTTP status code is conveyed only by the response status, not
+  the JSON body. The API plans to migrate to `application/problem+json`
+  (RFC 9457).
 - List endpoints must use cursor-based pagination (`limit` and `cursor`).
 
 ## Game data integrity

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -1,0 +1,51 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Test generation instructions
+
+## Framework (planned)
+
+The project plans to use **Vitest** as the test runner and **React Testing
+Library** for component tests. Generate tests targeting this stack.
+
+## File placement
+
+- Colocate test files next to source files: `foo.ts` → `foo.test.ts`,
+  `HomePage.tsx` → `HomePage.test.tsx`.
+- Use the `.test.ts` / `.test.tsx` suffix, not `.spec`.
+
+## Structure
+
+- Use `describe` blocks that mirror the module or component name.
+- Use `it` (not `test`) for individual cases.
+- Write test names as plain-English sentences starting with a verb:
+  `it('returns characters filtered by element')`.
+- Follow Arrange → Act → Assert within each test.
+
+## Assertions
+
+- Prefer `expect(...).toBe()` for primitives, `expect(...).toEqual()` for
+  objects and arrays.
+- Use `expect(...).toMatchInlineSnapshot()` sparingly and only for small,
+  stable outputs.
+- Avoid snapshot tests for UI components; assert on behavior and accessible
+  roles instead.
+
+## React component tests
+
+- Query by accessible role or label: `screen.getByRole('heading')`,
+  `screen.getByLabelText('Email')`.
+- Avoid querying by test ID unless no accessible alternative exists.
+- Use `userEvent` over `fireEvent` for realistic interactions.
+- Test behavior (what the user sees and does), not implementation details.
+
+## Data and mocking
+
+- Use `@genshin/game-data` helpers to build realistic test fixtures.
+- Mock network calls at the fetch/adapter level, not inside library internals.
+- Prefer small, focused mocks; avoid mocking modules you own when integration
+  tests suffice.
+
+## SPDX
+
+- Start every test file with the standard SPDX header.

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -48,4 +48,9 @@ Library** for component tests. Generate tests targeting this stack.
 
 ## SPDX
 
-- Start every test file with the standard SPDX header.
+- Start every test file with the SPDX header using line comments:
+
+  ```ts
+  // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+  // SPDX-License-Identifier: MIT
+  ```

--- a/.github/copilot/update-game-data.prompt.md
+++ b/.github/copilot/update-game-data.prompt.md
@@ -1,0 +1,34 @@
+---
+description: Add new game data (characters, weapons, artifacts) to `packages/game-data`
+agent: agent
+argument-hint: Data type (characters, weapons, or artifacts) and game version
+tools: ['editFiles', 'codebase', 'runInTerminal']
+---
+
+# Update game data
+
+Follow the conventions in [code-generation.instructions.md](code-generation.instructions.md).
+
+Add or update game data in `packages/game-data`.
+
+Use [characters.ts](../../packages/game-data/src/characters.ts) as a reference
+for data array structure and sort order.
+
+## Inputs
+
+- Data type: `${input:dataType}` (characters, weapons, or artifacts)
+- Version: `${input:version}` (Genshin Impact version, for example, "5.4")
+
+## Requirements
+
+1. Follow the existing how-to guide for the data type:
+   - Characters: [update-game-characters.md](../../docs/how-tos/update-game-characters.md)
+   - Weapons: [update-game-weapons.md](../../docs/how-tos/update-game-weapons.md)
+   - Artifacts: [update-game-artifacts.md](../../docs/how-tos/update-game-artifacts.md)
+2. Maintain alphabetical sort order within the data arrays.
+3. Use the existing type definitions—don't change type shapes without
+   discussion.
+4. Verify the data compiles: `pnpm --filter @genshin/game-data build`.
+5. Verify exports are accessible from
+   [index.ts](../../packages/game-data/src/index.ts).
+6. Run `pnpm typecheck` to catch cross-package type issues.

--- a/.github/copilot/write-documentation.prompt.md
+++ b/.github/copilot/write-documentation.prompt.md
@@ -26,8 +26,8 @@ Write concise, factual, present-tense prose. Follow these Vale-enforced rules:
   `Microsoft.Contractions` style requires them.
 - **Em dashes**: Write em dashes without spaces (`word—word`). The
   `Microsoft.Dashes` style enforces this.
-- **Latin abbreviations**: Write "for example" instead of Latin shorthand. The
-  `Microsoft.Latin` style flags Latin abbreviations.
+- **Latin abbreviations**: Avoid Latin shorthand such as "e.g." or "i.e.";
+  write the phrases out in full ("for example," "that's").
 - **Quotation punctuation**: Place commas and periods inside quotation marks
   ("like this," not outside).
 - **Inclusive language**: The `alex` style checks for insensitive or

--- a/.github/copilot/write-documentation.prompt.md
+++ b/.github/copilot/write-documentation.prompt.md
@@ -1,0 +1,83 @@
+---
+description: Create or update documentation that passes Vale prose linting
+agent: agent
+argument-hint: File path under `docs/` and the topic to document
+tools: ['editFiles', 'codebase', 'runInTerminal']
+---
+
+# Write documentation
+
+Follow the documentation rules in
+[Copilot instructions](../copilot-instructions.md).
+
+Create or update a Markdown documentation file that conforms to the project's
+Vale configuration and documentation principles.
+
+## Inputs
+
+- File path: `${input:filePath}` (relative to repo root, under `docs/`)
+- Topic: `${input:topic}`
+
+## Prose style rules
+
+Write concise, factual, present-tense prose. Follow these Vale-enforced rules:
+
+- **Contractions**: Always use contractions ("don't," "isn't," "can't"). The
+  `Microsoft.Contractions` style requires them.
+- **Em dashes**: Write em dashes without spaces (`word—word`). The
+  `Microsoft.Dashes` style enforces this.
+- **Latin abbreviations**: Write "for example" instead of Latin shorthand. The
+  `Microsoft.Latin` style flags Latin abbreviations.
+- **Quotation punctuation**: Place commas and periods inside quotation marks
+  ("like this," not outside).
+- **Inclusive language**: The `alex` style checks for insensitive or
+  exclusionary language.
+- **Terminology**: Use project-accepted terms from
+  `.styles/config/vocabularies/Project/accept.txt`. Use `pnpm` (not `npm` or
+  `yarn`), and match exact capitalization for tool names.
+
+## Document structure
+
+1. Start with the SPDX header in HTML comment syntax:
+
+   ```markdown
+   <!--
+   SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+   SPDX-License-Identifier: MIT
+   -->
+   ```
+
+2. Add a level-1 heading (`#`) as the document title.
+3. Use proper heading hierarchy (`##`, `###`)—don't skip levels.
+4. Place the file in the correct `docs/` subdirectory following the
+   [Diátaxis](https://diataxis.fr/) framework:
+   - `docs/how-tos/` for task-oriented guides.
+   - `docs/reference/` for lookup material.
+   - `docs/explanation/` for background and rationale.
+
+## Validation workflow
+
+After writing or editing the file, run Vale and handle output in this order:
+
+1. **Suggestions**: Review every suggestion one by one. Apply each one or make
+   an explicit, reasoned decision not to apply it.
+2. **Warnings**: Fix all warnings.
+3. **Errors**: Fix all errors (these are commit-blocking).
+4. If a valid product or tool name is flagged, add it to
+   `.styles/config/vocabularies/Project/accept.txt` instead of rewriting.
+5. Don't modify third-party Vale styles under `.styles/` (except
+   `.styles/config/`).
+
+Run validation:
+
+```bash
+vale ${input:filePath}
+```
+
+## Cross-references
+
+- Don't duplicate guidance that exists elsewhere—link to the canonical source.
+- Link to `docs/reference/rest-api-conventions.md` for API design.
+- Link to `docs/how-tos/add-spdx-headers.md` for SPDX details.
+- Keep docs accurate to `HEAD`: verify dependencies, commands, and feature
+  status before writing.

--- a/.github/copilot/write-documentation.prompt.md
+++ b/.github/copilot/write-documentation.prompt.md
@@ -26,8 +26,8 @@ Write concise, factual, present-tense prose. Follow these Vale-enforced rules:
   `Microsoft.Contractions` style requires them.
 - **Em dashes**: Write em dashes without spaces (`word—word`). The
   `Microsoft.Dashes` style enforces this.
-- **Latin abbreviations**: Avoid Latin shorthand such as "e.g." or "i.e.";
-  write the phrases out in full ("for example," "that's").
+- **Latin abbreviations**: Write "for example" instead of "e.g." and "that's"
+  instead of "i.e." The `Google.Latin` style flags Latin abbreviations.
 - **Quotation punctuation**: Place commas and periods inside quotation marks
   ("like this," not outside).
 - **Inclusive language**: The `alex` style checks for insensitive or

--- a/.github/copilot/write-documentation.prompt.md
+++ b/.github/copilot/write-documentation.prompt.md
@@ -71,6 +71,12 @@ After writing or editing the file, run Vale and handle output in this order:
 Run validation:
 
 ```bash
+pre-commit run vale --all-files
+```
+
+To check a single file without pre-commit overhead:
+
+```bash
 vale ${input:filePath}
 ```
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -52,3 +52,9 @@ License: MIT
 Files: *.json .prettierrc
 Copyright: 2026 Alex Brandt <alunduil@gmail.com>
 License: MIT
+
+# Copilot prompt files (frontmatter must be first line, no room for SPDX)
+
+Files: .github/copilot/*.prompt.md
+Copyright: 2026 Alex Brandt <alunduil@gmail.com>
+License: MIT

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -32,6 +32,9 @@ Vitest
 markdownlint
 Markdownlint
 yamllint
+Colocate
+middleware
+tooltip
 
 # Configuration and tooling terms
 config

--- a/.vale.ini
+++ b/.vale.ini
@@ -12,6 +12,8 @@ MinAlertLevel = suggestion
 # Lint markdown files only
 [*.md]
 BasedOnStyles = Vale, Google, Microsoft, alex
+
+# Disabled Google rules: each has a Microsoft equivalent that takes precedence.
 Google.Headings = NO
 Google.Contractions = NO
 Google.Acronyms = NO
@@ -19,4 +21,7 @@ Google.EmDash = NO
 Google.Passive = NO
 Google.Semicolons = NO
 Google.WordList = NO
+
+# Google.Latin stays enabled: no Microsoft equivalent exists.
+
 alex.ProfanityUnlikely = NO

--- a/.vale.ini
+++ b/.vale.ini
@@ -16,7 +16,6 @@ Google.Headings = NO
 Google.Contractions = NO
 Google.Acronyms = NO
 Google.EmDash = NO
-Google.Latin = NO
 Google.Passive = NO
 Google.Semicolons = NO
 Google.WordList = NO

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,9 +82,7 @@
     { "file": ".github/copilot/commit-message.instructions.md" }
   ],
   "github.copilot.chat.reviewSelection.instructions": [
-    {
-      "text": "Review for: strict TypeScript (no implicit any), correct dependency classification, semantic HTML, proper SPDX headers, and adherence to REST conventions in docs/reference/rest-api-conventions.md. Flag hard-coded game data that should use @genshin/game-data helpers."
-    }
+    { "file": ".github/copilot/review.instructions.md" }
   ],
 
   // CSS/Tailwind - DISABLED until Issue #20 is implemented

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,6 +71,22 @@
   // Prettier (redundant with .prettierrc but explicit for clarity)
   "prettier.requireConfig": true,
 
+  // GitHub Copilot - task-specific instructions
+  "github.copilot.chat.codeGeneration.instructions": [
+    { "file": ".github/copilot/code-generation.instructions.md" }
+  ],
+  "github.copilot.chat.testGeneration.instructions": [
+    { "file": ".github/copilot/test-generation.instructions.md" }
+  ],
+  "github.copilot.chat.commitMessageGeneration.instructions": [
+    { "file": ".github/copilot/commit-message.instructions.md" }
+  ],
+  "github.copilot.chat.reviewSelection.instructions": [
+    {
+      "text": "Review for: strict TypeScript (no implicit any), correct dependency classification, semantic HTML, proper SPDX headers, and adherence to REST conventions in docs/reference/rest-api-conventions.md. Flag hard-coded game data that should use @genshin/game-data helpers."
+    }
+  ],
+
   // CSS/Tailwind - DISABLED until Issue #20 is implemented
   "css.validate": true
   // Uncomment when Tailwind is installed:


### PR DESCRIPTION
## Summary

Add task-specific instruction files and reusable prompt files for GitHub Copilot Chat, along with VS Code settings to wire them in automatically.

## What changed

### Instruction files (`.github/copilot/`)

| File | Purpose |
|------|---------|
| `code-generation.instructions.md` | SPDX headers, strict TypeScript, React/Hono/package patterns |
| `test-generation.instructions.md` | Vitest + React Testing Library conventions |
| `commit-message.instructions.md` | Conventional Commits + the 7 rules of a great commit message |

### Prompt files (`.github/copilot/`)

| File | Workflow |
|------|----------|
| `new-page.prompt.md` | Scaffold a React page and wire its route |
| `new-api-route.prompt.md` | Scaffold a Hono REST route |
| `add-shadcn-component.prompt.md` | Install and configure a `shadcn/ui` component |
| `update-game-data.prompt.md` | Add characters, weapons, or artifacts to `packages/game-data` |
| `new-zustand-store.prompt.md` | Create a focused zustand store |
| `write-documentation.prompt.md` | Write Vale-compliant documentation |

### Other changes

- **`.vscode/settings.json`**: Added `github.copilot.chat.*` settings to inject instruction files for code generation, test generation, commit messages, and review selection.
- **`.github/copilot-instructions.md`**: Added path formatting rule — wrap file and directory paths in backticks in prose.
- **`.reuse/dep5`**: Added prompt files for SPDX compliance.
- **`.styles/config/vocabularies/Project/accept.txt`**: Added `Colocate`, `middleware`, `tooltip`.

## Notes

- Prompt files use `agent: agent` mode, `argument-hint` for guided input, and `tools` for scoped tool access.
- Paths in YAML frontmatter descriptions are either backtick-wrapped or omitted to avoid Vale false positives on directory names like `apps/api`.