### PR TITLE
Pin Cloud Run runtime settings for API deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,7 +126,11 @@ jobs:
           region: ${{ env.CLOUD_RUN_REGION }}
           service: ${{ env.CLOUD_RUN_SERVICE_NAME }}
           image: ${{ steps.image.outputs.image_uri }}
-          flags: --allow-unauthenticated
+          flags: >-
+            --allow-unauthenticated
+            --cpu=1
+            --memory=512Mi
+            --concurrency=80
           env_vars: |
             FRONTEND_ORIGIN=${{ env.FRONTEND_ORIGIN }}
             APP_GIT_SHA=${{ github.sha }}


### PR DESCRIPTION
## Summary

Add explicit `--cpu`, `--memory`, and `--concurrency` flags to the `deploy-cloudrun` step so Cloud Run runtime settings are versioned in CI rather than relying on defaults.

## Changes

- **`.github/workflows/deploy.yml`**: Updated the Deploy step `flags` field from a single `--allow-unauthenticated` to include:
  - `--cpu=1`
  - `--memory=512Mi`
  - `--concurrency=80`

## Values

Based on the runtime profile agreed in #67:

| Setting | Value |
|---|---|
| CPU | 1 vCPU |
| Memory | 512 MiB |
| Concurrency | 80 |

## Verification

- Existing health checks (public + authenticated) validate the deployment after these settings take effect.
- All pre-commit hooks pass.

Closes #345