### PR TITLE
fix: add downloadArtifacts permission to deployer role

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -84,6 +84,13 @@ resource "google_project_iam_member" "github_deployer_rw_sa_admin" {
   member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
 }
 
+# Required for Cloud Run deploy to act as the default Compute Engine SA
+resource "google_project_iam_member" "github_deployer_rw_sa_user" {
+  project = google_project.env.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
+}
+
 # Required for google_firestore_database (datastore.databases.create)
 resource "google_project_iam_member" "github_deployer_rw_datastore_owner" {
   project = google_project.env.project_id

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -25,6 +25,7 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
   permissions = [
     "artifactregistry.repositories.create",
     "artifactregistry.repositories.delete",
+    "artifactregistry.repositories.downloadArtifacts",
     "artifactregistry.repositories.get",
     "artifactregistry.repositories.list",
     "artifactregistry.repositories.uploadArtifacts",


### PR DESCRIPTION
## Problem

The API deploy workflow failed with:

```
PERMISSION_DENIED: Permission 'artifactregistry.repositories.downloadArtifacts' denied on resource
```

[Failed run](https://github.com/dungeon-studio/genshin.dungeon.studio/actions/runs/22591268750)

## Root cause

The `githubDeployerApplier` custom IAM role had `artifactregistry.repositories.uploadArtifacts` (used by the Docker push step) but was missing `artifactregistry.repositories.downloadArtifacts`, which `gcloud run deploy` needs to resolve the container image from Artifact Registry.

## Fix

Added `artifactregistry.repositories.downloadArtifacts` to the custom role permissions. The updated role has already been applied via `terraform apply` on the bootstrap configuration.