### PR TITLE
fix(terraform): force_destroy GCS bucket for clean removal

### DIFF
--- a/infrastructure/terraform/environments/dev/web.tf
+++ b/infrastructure/terraform/environments/dev/web.tf
@@ -1,6 +1,15 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
+# TODO: Remove after successful apply — only kept to let Terraform destroy the
+# non-empty bucket (force_destroy was previously false).
+resource "google_storage_bucket" "web" {
+  name          = "develop.genshin.dungeon.studio"
+  project       = var.gcp_dev_project_id
+  location      = "EU"
+  force_destroy = true
+}
+
 # Enable Firebase Hosting API
 resource "google_project_service" "firebase_hosting" {
   project = var.gcp_dev_project_id


### PR DESCRIPTION
## Summary

The terraform-apply for #392 failed because the GCS bucket `develop.genshin.dungeon.studio` contains objects and `force_destroy` was `false`.

This PR temporarily re-adds the `google_storage_bucket.web` resource with `force_destroy = true` so Terraform can delete it.

**After a successful apply, a follow-up PR should remove this resource entirely.**

Part of #386