### PR TITLE
ci: add workflow_dispatch triggers to deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches: [develop]
     paths:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   web:
-    if: github.ref_name == 'develop'
+    if: github.ref == 'refs/heads/develop'
     name: Web
     runs-on: ubuntu-latest
     environment: dev
@@ -53,7 +53,7 @@ jobs:
         run: bash apps/web/scripts/verify-deployment.sh "https://develop.genshin.dungeon.studio"
 
   api:
-    if: github.ref_name == 'develop'
+    if: github.ref == 'refs/heads/develop'
     name: API
     runs-on: ubuntu-latest
     environment: dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   web:
+    if: github.ref_name == 'develop'
     name: Web
     runs-on: ubuntu-latest
     environment: dev
@@ -52,6 +53,7 @@ jobs:
         run: bash apps/web/scripts/verify-deployment.sh "https://develop.genshin.dungeon.studio"
 
   api:
+    if: github.ref_name == 'develop'
     name: API
     runs-on: ubuntu-latest
     environment: dev

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   core:
-    if: github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
 
   dev:
-    if: github.ref_name == 'develop'
+    if: github.ref == 'refs/heads/develop'
     needs: core
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
 
   staging:
-    if: startsWith(github.ref_name, 'release/')
+    if: startsWith(github.ref, 'refs/heads/release/')
     needs: core
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -5,6 +5,7 @@
 name: Terraform Apply
 
 on:
+  workflow_dispatch:
   push:
     branches: [develop, 'release/**']
     paths:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   core:
+    if: github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core


### PR DESCRIPTION
Adds `workflow_dispatch` to `deploy.yml` and `terraform-apply.yml` so they can be manually triggered from the Actions UI.

This is useful when a run fails for a reason that can't be rerun (e.g. a GitHub Action wasn't in the org allowlist yet) and there's no pending code change to retrigger it naturally.