### PR TITLE
fix(deploy): use Firebase CLI instead of action for WIF compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         run: bash apps/web/scripts/verify-build-output.sh
 
       - name: Deploy
-        run: npx firebase-tools deploy --only hosting --project "$GCP_PROJECT_ID"
+        run: npx -y firebase-tools@15.9.0 deploy --only hosting --project "$GCP_PROJECT_ID"
         working-directory: apps/web
 
       - name: Verify

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,11 +43,8 @@ jobs:
         run: bash apps/web/scripts/verify-build-output.sh
 
       - name: Deploy
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          projectId: ${{ env.GCP_PROJECT_ID }}
-          channelId: live
-          entryPoint: apps/web
+        run: npx firebase-tools deploy --only hosting --project "$GCP_PROJECT_ID"
+        working-directory: apps/web
 
       - name: Verify
         run: bash apps/web/scripts/verify-deployment.sh "https://develop.genshin.dungeon.studio"


### PR DESCRIPTION
The `FirebaseExtended/action-hosting-deploy` action requires a `firebaseServiceAccount` JSON key and does not support Workload Identity Federation.

This replaces it with `npx firebase-tools deploy --only hosting`, which respects the Application Default Credentials set by `google-github-actions/auth@v3`, keeping deployment consistent with the WIF architecture (DSGEP-001).

Merging this will also retrigger the deploy workflow for the first Firebase Hosting deployment.