### PR TITLE
fix(bootstrap): add firebase.projects.get to deployer role

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -44,6 +44,7 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "dns.resourceRecordSets.delete",
     "dns.resourceRecordSets.list",
     "dns.resourceRecordSets.update",
+    "firebase.projects.get",
     "firebase.projects.update",
     "firebaseauth.configs.create",
     "firebaseauth.configs.get",

--- a/infrastructure/terraform/environments/dev/web.tf
+++ b/infrastructure/terraform/environments/dev/web.tf
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
+# Initialize Firebase on the GCP project
+resource "google_firebase_project" "default" {
+  provider = google-beta
+  project  = var.gcp_dev_project_id
+
+  depends_on = [google_project_service.firebase]
+}
+
 # Enable Firebase Hosting API
 resource "google_project_service" "firebase_hosting" {
   project = var.gcp_dev_project_id
@@ -17,7 +25,10 @@ resource "google_firebase_hosting_site" "web" {
   project  = var.gcp_dev_project_id
   site_id  = "dungeon-studio-genshin-dev"
 
-  depends_on = [google_project_service.firebase_hosting]
+  depends_on = [
+    google_firebase_project.default,
+    google_project_service.firebase_hosting,
+  ]
 }
 
 # Custom domain for the Firebase Hosting site


### PR DESCRIPTION
The Firebase CLI requires `firebase.projects.get` to look up the project before deploying. Without it, `firebase deploy` fails with:

```
Error: Failed to get Firebase project dungeon-studio-genshin-dev.
Please make sure the project exists and your account has permission to access it.
```

Adds `firebase.projects.get` to the RW deployer custom role alongside the existing `firebase.projects.update`.

**Note:** After merging, bootstrap Terraform must be applied to update the IAM role before the deploy workflow will succeed.