### PR TITLE
fix(deploy): use access token for Firebase CLI authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: google-github-actions/auth@v3
+        id: auth
         with:
           workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
           service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
+          token_format: access_token
 
       - uses: ./.github/actions/setup-node-pnpm
 
@@ -42,9 +44,19 @@ jobs:
       - name: Verify Build
         run: bash apps/web/scripts/verify-build-output.sh
 
+      - name: Cache Firebase Hosting deploy
+        uses: actions/cache@v5
+        with:
+          path: apps/web/.firebase
+          key: firebase-hosting-${{ github.sha }}
+          restore-keys: |
+            firebase-hosting-
+
       - name: Deploy
-        run: npx -y firebase-tools@15.9.0 deploy --only hosting --project "$GCP_PROJECT_ID"
+        run: npx -y firebase-tools@15.9.0 deploy --only hosting --project "$GCP_PROJECT_ID" --token "$FIREBASE_TOKEN"
         working-directory: apps/web
+        env:
+          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
 
       - name: Verify
         run: bash apps/web/scripts/verify-deployment.sh "https://develop.genshin.dungeon.studio"

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ vite.config.ts.timestamp-*
 .gcp/
 service-account*.json
 
+# Firebase
+.firebase/
+
 # ===================================
 # Temporary Files
 # ===================================


### PR DESCRIPTION
The Firebase CLI doesn't support WIF external credential files when calling the Hosting API (returns 500). This generates an access token via `google-github-actions/auth` and passes it via `--token`, which keeps the WIF architecture (no stored service account keys).

Also:
- Caches `apps/web/.firebase` in CI to skip re-uploading unchanged files on subsequent deploys
- Adds `.firebase/` to `.gitignore`