### PR TITLE
ci: derive pnpm version from package.json packageManager

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 name: Setup Node.js and pnpm
-description: Install Node.js 20, pnpm 9.15.4, and restore dependency cache
+description: Install Node.js 20, pnpm (version from package.json), and restore dependency cache
 
 runs:
   using: composite
@@ -17,7 +17,6 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9.15.4
         run_install: false
 
     - name: Get pnpm store directory

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.15.4
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
Remove hardcoded pnpm version from the `setup-node-pnpm` composite action and the `pre-commit` workflow.

`pnpm/action-setup@v4` reads the version from the `packageManager` field in `package.json` automatically, so there is no need to duplicate it in workflow files. This keeps CI in sync with the project declaration and avoids version-mismatch failures.