### PR TITLE
fix: add firebase.projects.get to RO planner role

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -30,6 +30,7 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
     "dns.managedZones.get",
     "dns.managedZones.list",
     "dns.resourceRecordSets.list",
+    "firebase.projects.get",
     "firebaseauth.configs.get",
     "firebasehosting.sites.get",
     "firebasehosting.sites.list",


### PR DESCRIPTION
## Problem

Terraform plan for the dev environment fails with a 403 permission error when refreshing the `google_firebase_project` resource (run #425).

The `github-deployer-ro` custom role (`githubDeployerPlanner`) was missing the `firebase.projects.get` permission. The provider needs this to read the Firebase project state during plan, but only write permissions (`firebase.projects.get` and `firebase.projects.update`) existed on the RW role.

## Fix

Add `firebase.projects.get` to the RO planner custom role. This is a read-only permission consistent with the existing least-privilege pattern.

## Notes

Bootstrap has already been manually applied to update the custom role in GCP. This PR captures the code change.