### PR TITLE
feat(infra): add Google OAuth identity provider config

### DIFF
--- a/infrastructure/terraform/environments/dev/firebase_auth.tf
+++ b/infrastructure/terraform/environments/dev/firebase_auth.tf
@@ -35,6 +35,29 @@ resource "google_identity_platform_config" "default" {
   ]
 }
 
-# TODO(#36): Add google_identity_platform_default_supported_idp_config for
-# google.com after OAuth credentials are stored in Secret Manager.
-# Requires a second apply once the manual steps are complete.
+# Read the Google OAuth client ID from Secret Manager.
+data "google_secret_manager_secret_version" "firebase_auth_google_client_id" {
+  project = var.gcp_dev_project_id
+  secret  = google_secret_manager_secret.firebase_auth_google_client_id.secret_id
+  version = "latest"
+}
+
+# Read the Google OAuth client secret from Secret Manager.
+data "google_secret_manager_secret_version" "firebase_auth_google_client_secret" {
+  project = var.gcp_dev_project_id
+  secret  = google_secret_manager_secret.firebase_auth_google_client_secret.secret_id
+  version = "latest"
+}
+
+# Configure Google as a supported identity provider.
+resource "google_identity_platform_default_supported_idp_config" "google" {
+  project = var.gcp_dev_project_id
+
+  idp_id        = "google.com"
+  client_id     = data.google_secret_manager_secret_version.firebase_auth_google_client_id.secret_data
+  client_secret = data.google_secret_manager_secret_version.firebase_auth_google_client_secret.secret_data
+
+  enabled = true
+
+  depends_on = [google_identity_platform_config.default]
+}


### PR DESCRIPTION
## Summary

Phase 2 of #36. Adds the Google OAuth identity provider configuration now that OAuth credentials are stored in Secret Manager.

### Changes

- **`firebase_auth.tf`**:
  - Add `data` sources to read OAuth client ID and secret from Secret Manager
  - Add `google_identity_platform_default_supported_idp_config` for `google.com`
  - Remove TODO placeholder

### Acceptance criteria addressed

- [x] `google_identity_platform_default_supported_idp_config` resource for `google.com` is applied
- [x] OAuth credentials read from GCP Secret Manager (not GitHub Secrets)
- [x] `terraform validate` passes
- [x] `terraform fmt` passes

Closes #36