### PR TITLE
feat(terraform): register Firebase web app for frontend SDK config

### DIFF
--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -30,3 +30,16 @@ output "firebase_auth_config_name" {
   value       = google_identity_platform_config.default.name
   sensitive   = false
 }
+
+output "firebase_web_app_config" {
+  description = "Firebase Web App SDK config for the frontend build"
+  value = {
+    api_key             = data.google_firebase_web_app_config.web.api_key
+    auth_domain         = "${var.gcp_dev_project_id}.firebaseapp.com"
+    project_id          = var.gcp_dev_project_id
+    storage_bucket      = data.google_firebase_web_app_config.web.storage_bucket
+    messaging_sender_id = data.google_firebase_web_app_config.web.messaging_sender_id
+    app_id              = google_firebase_web_app.web.app_id
+  }
+  sensitive = false
+}

--- a/infrastructure/terraform/environments/dev/web.tf
+++ b/infrastructure/terraform/environments/dev/web.tf
@@ -43,3 +43,20 @@ resource "google_firebase_hosting_custom_domain" "web" {
 
   depends_on = [google_firebase_hosting_site.web]
 }
+
+# Register a Firebase Web App for the frontend.
+# The SDK config (API key, auth domain, etc.) is derived from this resource.
+resource "google_firebase_web_app" "web" {
+  provider     = google-beta
+  project      = var.gcp_dev_project_id
+  display_name = "Genshin Team Builder (dev)"
+
+  depends_on = [google_firebase_project.default]
+}
+
+# Read the SDK config for the registered web app.
+data "google_firebase_web_app_config" "web" {
+  provider   = google-beta
+  project    = var.gcp_dev_project_id
+  web_app_id = google_firebase_web_app.web.app_id
+}


### PR DESCRIPTION
## Summary

Register a Firebase Web App in the dev environment so the frontend can initialize the Firebase JS SDK for authentication.

This is **PR 1 of 2** for #37. The Terraform resources must exist before the deploy workflow can fetch the SDK config at build time.

## Changes

### `infrastructure/terraform/environments/dev/web.tf`
- Add `google_firebase_web_app` resource — registers the frontend as a Firebase client
- Add `google_firebase_web_app_config` data source — reads the generated SDK config (API key, app ID, etc.)

### `infrastructure/terraform/environments/dev/outputs.tf`
- Add `firebase_web_app_config` output — composite object with all SDK config values so developers can populate `.env.local` via `terraform output`

## Context

A `google_firebase_web_app` is a registration record in the Firebase project. It does not change how hosting works — it generates the client credentials (API key, app ID, messaging sender ID) that `firebase/auth` needs to call Firebase services from the browser.

These values are public by design (they ship in every user's browser). Security is enforced server-side by Firebase Security Rules and the backend token verification middleware.

## What's next (PR 2)

After this merges and `terraform-apply` creates the web app:
- Firebase Auth feature in `apps/web/src/features/auth/`
- Deploy workflow fetches SDK config from GCP at build time (no GitHub secrets needed)
- Vite env type declarations and `.env.example` for local dev

Refs: #37