### PR TITLE
feat(api): implement character CRUD API endpoints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,5 @@ build
 
 # Exclude unused workspace paths (API build doesn't copy these)
 apps/web
-packages
 .github
 docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
 
       - name: Typecheck
-        run: pnpm --filter @genshin/web typecheck
+        run: pnpm turbo run typecheck --filter=@genshin/web
 
       - name: Build
-        run: pnpm --filter @genshin/web build
+        run: pnpm turbo run build --filter=@genshin/web
 
       - name: Verify Build Artifacts
         run: bash apps/web/scripts/verify-build-output.sh
@@ -45,13 +45,13 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
 
       - name: Typecheck
-        run: pnpm --filter @genshin/api typecheck
+        run: pnpm turbo run typecheck --filter=@genshin/api
 
       - name: Test
-        run: pnpm --filter @genshin/api test
+        run: pnpm turbo run test --filter=@genshin/api
 
       - name: Build
-        run: pnpm --filter @genshin/api build
+        run: pnpm turbo run build --filter=@genshin/api
 
   packages:
     name: Packages
@@ -65,10 +65,10 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
 
       - name: Build packages
-        run: pnpm --filter "./packages/**" build
+        run: pnpm turbo run build --filter="./packages/**"
 
       - name: Typecheck packages
-        run: pnpm --filter "./packages/**" typecheck
+        run: pnpm turbo run typecheck --filter="./packages/**"
 
 # ---------------------------------------------------------------------------
 # Maintenance notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Typecheck
         run: pnpm --filter @genshin/api typecheck
 
+      - name: Test
+        run: pnpm --filter @genshin/api test
+
       - name: Build
         run: pnpm --filter @genshin/api build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
             >> "$GITHUB_OUTPUT"
 
       - name: Build
-        run: pnpm --filter @genshin/web build
+        run: pnpm turbo run build --filter=@genshin/web
         env:
           VITE_FIREBASE_API_KEY: ${{ steps.firebase-config.outputs.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ steps.firebase-config.outputs.VITE_FIREBASE_AUTH_DOMAIN }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,65 +1,37 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-# Define versions for Corepack and pnpm to ensure consistency across all stages
 ARG COREPACK_VERSION=0.34.6
 ARG PNPM_VERSION=9.15.4
 
 # Build stage
 FROM node:25.8.1-slim AS builder
 
-# Pass ARGs to this stage
 ARG COREPACK_VERSION
 ARG PNPM_VERSION
 
 WORKDIR /app
 
-# Install Corepack (not bundled in Node.js 25+) and enable it with the pinned pnpm version
-# Remove leftover Yarn 1.x symlinks from the base image to avoid conflicts
 RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
     npm install -g corepack@${COREPACK_VERSION} && \
     corepack enable && \
     corepack prepare pnpm@${PNPM_VERSION} --activate
 
-# Copy workspace configuration and package manifests
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-
-# Copy only API package.json to maximize Docker layer cache reuse
+# Copy manifests for all workspace packages so pnpm resolves the full dependency graph
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps/api/package.json ./apps/api/
+COPY packages/types/package.json ./packages/types/
+COPY packages/game-data/package.json ./packages/game-data/
 
-# Install dependencies for @genshin/api only (skip unnecessary workspace packages)
-RUN pnpm install --filter @genshin/api --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
-# Copy API source after dependencies are installed
+# Copy source and build — turbo handles dependency ordering via ^build
+COPY packages ./packages
 COPY apps/api ./apps/api
+RUN pnpm turbo run build --filter=@genshin/api
 
-# Build the API
-RUN pnpm --filter @genshin/api build
-
-# Production dependencies stage
-FROM node:25.8.1-slim AS deps
-
-# Pass ARGs to this stage
-ARG COREPACK_VERSION
-ARG PNPM_VERSION
-
-WORKDIR /app
-
-# Install Corepack (not bundled in Node.js 25+) and enable it with the pinned pnpm version
-# Remove leftover Yarn 1.x symlinks from the base image to avoid conflicts
-RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
-    npm install -g corepack@${COREPACK_VERSION} && \
-    corepack enable && \
-    corepack prepare pnpm@${PNPM_VERSION} --activate
-
-# Copy root workspace files for pnpm to read the lockfile
-COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
-
-# Copy API package manifest for production dependency installation
-COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
-
-# Install production dependencies only for @genshin/api using the lockfile
-RUN pnpm install --filter @genshin/api --prod --frozen-lockfile
+# Install production-only dependencies
+RUN pnpm install --prod --frozen-lockfile
 
 # Production stage
 FROM node:25.8.1-slim
@@ -68,15 +40,12 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Copy production node_modules from deps stage
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
-
-# Copy package.json (needed for ES module support and version reading)
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
-
-# Copy built files
 COPY --from=builder /app/apps/api/dist ./apps/api/dist
+COPY --from=builder /app/packages/types ./packages/types
+COPY --from=builder /app/packages/game-data ./packages/game-data
 
 EXPOSE 8080
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,6 +12,8 @@ ARG PNPM_VERSION
 
 WORKDIR /app
 
+ENV CI=true
+
 RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
     npm install -g corepack@${COREPACK_VERSION} && \
     corepack enable && \

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,25 +2,26 @@
 # SPDX-License-Identifier: MIT
 
 ARG COREPACK_VERSION=0.34.6
-ARG PNPM_VERSION=9.15.4
 
 # Build stage
 FROM node:25.8.1-slim AS builder
 
 ARG COREPACK_VERSION
-ARG PNPM_VERSION
 
 WORKDIR /app
 
 ENV CI=true
 
+# Copy root package.json first so corepack reads packageManager from it
+COPY package.json ./
+
 RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
     npm install -g corepack@${COREPACK_VERSION} && \
     corepack enable && \
-    corepack prepare pnpm@${PNPM_VERSION} --activate
+    corepack install
 
-# Copy manifests for all workspace packages so pnpm resolves the full dependency graph
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+# Copy remaining manifests so pnpm resolves the full dependency graph
+COPY pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps/api/package.json ./apps/api/
 COPY packages/types/package.json ./packages/types/
 COPY packages/game-data/package.json ./packages/game-data/

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/main.ts",
-    "build": "tsc && tsc-alias",
+    "build": "tsc --project tsconfig.build.json && tsc-alias --project tsconfig.build.json",
     "start": "node dist/main.js",
     "lint": "eslint .",
     "test": "vitest run",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,9 +8,12 @@
     "build": "tsc && tsc-alias",
     "start": "node dist/main.js",
     "lint": "eslint .",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc --project tsconfig.scripts.json --noEmit"
   },
   "dependencies": {
+    "@genshin/game-data": "workspace:*",
+    "@genshin/types": "workspace:*",
     "@hono/node-server": "1.19.11",
     "firebase-admin": "13.7.0",
     "hono": "4.12.7"
@@ -23,6 +26,7 @@
     "tsc-alias": "1.8.16",
     "tsx": "4.21.0",
     "typescript": "5.9.3",
-    "typescript-eslint": "8.57.0"
+    "typescript-eslint": "8.57.0",
+    "vitest": "4.1.0"
   }
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -54,6 +54,7 @@ app.onError((err, c) => {
       type: 'about:blank',
       title: 'Internal Server Error',
       status: 500,
+      detail: 'An unexpected error occurred',
     },
     { status: 500, headers: PROBLEM_JSON },
   );
@@ -66,6 +67,7 @@ app.notFound((c) =>
       type: 'about:blank',
       title: 'Not Found',
       status: 404,
+      detail: 'The requested resource does not exist',
     },
     { status: 404, headers: PROBLEM_JSON },
   ),

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { AuthVariables } from '@/middleware/auth';
+import { characters } from '@/routes/characters';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { HTTPException } from 'hono/http-exception';
+import { logger } from 'hono/logger';
+import { readFileSync } from 'node:fs';
+import { STATUS_CODES } from 'node:http';
+
+// Read version from package.json to maintain single source of truth
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+
+export const PROBLEM_JSON = { 'Content-Type': 'application/problem+json' };
+
+export const app = new Hono<{ Variables: Partial<AuthVariables> }>();
+
+// Request logging middleware
+app.use('*', logger());
+
+// CORS middleware - allow frontend origin
+const rawFrontendOrigin = process.env.FRONTEND_ORIGIN ?? 'http://localhost:5173';
+const frontendOrigin = rawFrontendOrigin.trim();
+if (frontendOrigin === '' || frontendOrigin === '*') {
+  throw new Error("FRONTEND_ORIGIN must be a specific origin; '*' is not valid.");
+}
+app.use(
+  '*',
+  cors({
+    origin: frontendOrigin,
+    credentials: true,
+  }),
+);
+
+// Error handling middleware — RFC 9457 Problem Details
+app.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    return c.json(
+      {
+        type: 'about:blank',
+        title: STATUS_CODES[err.status] ?? 'Unknown Error',
+        status: err.status,
+        detail: err.message,
+      },
+      { status: err.status, headers: PROBLEM_JSON },
+    );
+  }
+
+  console.error('Unexpected error:', err);
+  return c.json(
+    {
+      type: 'about:blank',
+      title: 'Internal Server Error',
+      status: 500,
+    },
+    { status: 500, headers: PROBLEM_JSON },
+  );
+});
+
+// 404 handler for unmatched routes — RFC 9457 Problem Details
+app.notFound((c) =>
+  c.json(
+    {
+      type: 'about:blank',
+      title: 'Not Found',
+      status: 404,
+    },
+    { status: 404, headers: PROBLEM_JSON },
+  ),
+);
+
+app.get('/', (c) =>
+  c.json({
+    message: 'Genshin API',
+    version: packageJson.version,
+  }),
+);
+
+app.get('/health', (c) =>
+  c.json({
+    status: 'ok',
+    sha: process.env.APP_GIT_SHA ?? null,
+  }),
+);
+
+// Routes
+app.route('/api/characters', characters);

--- a/apps/api/src/lib/firebase/app.ts
+++ b/apps/api/src/lib/firebase/app.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { getApp, getApps, initializeApp } from 'firebase-admin/app';
+
+// Initialize with Application Default Credentials (ADC).
+// In GCP, credentials are provided automatically.
+// Locally, set the GOOGLE_APPLICATION_CREDENTIALS environment variable.
+export const app = getApps().length > 0 ? getApp() : initializeApp();

--- a/apps/api/src/lib/firebase/auth.ts
+++ b/apps/api/src/lib/firebase/auth.ts
@@ -1,13 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { getApp, getApps, initializeApp } from 'firebase-admin/app';
+import { app } from '@/lib/firebase/app';
 import { type DecodedIdToken, getAuth } from 'firebase-admin/auth';
 
-// Initialize with Application Default Credentials (ADC).
-// In GCP, credentials are provided automatically.
-// Locally, set the GOOGLE_APPLICATION_CREDENTIALS environment variable.
-const app = getApps().length > 0 ? getApp() : initializeApp();
 const auth = getAuth(app);
 
 export async function verifyToken(idToken: string): Promise<DecodedIdToken> {

--- a/apps/api/src/lib/firebase/firestore.ts
+++ b/apps/api/src/lib/firebase/firestore.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { app } from '@/lib/firebase/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const db = getFirestore(app);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,84 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { AuthVariables } from '@/middleware/auth';
+import { app } from '@/app';
 import { serve } from '@hono/node-server';
-import { Hono } from 'hono';
-import { cors } from 'hono/cors';
-import { HTTPException } from 'hono/http-exception';
-import { logger } from 'hono/logger';
-import { readFileSync } from 'node:fs';
-
-// Read version from package.json to maintain single source of truth
-const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
-
-const app = new Hono<{ Variables: Partial<AuthVariables> }>();
-
-// Request logging middleware
-app.use('*', logger());
-
-// CORS middleware - allow frontend origin
-const rawFrontendOrigin = process.env.FRONTEND_ORIGIN ?? 'http://localhost:5173';
-const frontendOrigin = rawFrontendOrigin.trim();
-if (frontendOrigin === '' || frontendOrigin === '*') {
-  throw new Error("FRONTEND_ORIGIN must be a specific origin; '*' is not valid.");
-}
-app.use(
-  '*',
-  cors({
-    origin: frontendOrigin,
-    credentials: true,
-  }),
-);
-
-// Error handling middleware
-app.onError((err, c) => {
-  // Handle Hono's HTTPException (intended errors like 404, validation errors, etc.)
-  if (err instanceof HTTPException) {
-    return c.json(
-      {
-        error: err.message,
-        status: 'error',
-      },
-      err.status,
-    );
-  }
-
-  // Handle unexpected errors - log full details server-side, return generic message
-  console.error('Unexpected error:', err);
-  return c.json(
-    {
-      error: 'Internal server error',
-      status: 'error',
-    },
-    500,
-  );
-});
-
-// 404 handler for unmatched routes
-app.notFound((c) =>
-  c.json(
-    {
-      error: 'Not found',
-      status: 'error',
-    },
-    404,
-  ),
-);
-
-app.get('/', (c) =>
-  c.json({
-    message: 'Genshin API',
-    version: packageJson.version,
-  }),
-);
-
-app.get('/health', (c) =>
-  c.json({
-    status: 'ok',
-    sha: process.env.APP_GIT_SHA ?? null,
-  }),
-);
 
 const port = parseInt(process.env.PORT || '8080', 10);
 console.log(`Server running at http://localhost:${port}`);

--- a/apps/api/src/repositories/characters/document.ts
+++ b/apps/api/src/repositories/characters/document.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionCharacter, ISOTimestamp } from '@genshin/types';
+
+export interface DocumentData {
+  constellationLevel: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function fromDocument(characterId: string, data: DocumentData): CollectionCharacter {
+  return {
+    characterId,
+    constellationLevel: data.constellationLevel,
+    createdAt: data.createdAt as ISOTimestamp,
+    updatedAt: data.updatedAt as ISOTimestamp,
+  };
+}
+
+export function toDocument(character: CollectionCharacter): DocumentData {
+  return {
+    constellationLevel: character.constellationLevel,
+    createdAt: character.createdAt,
+    updatedAt: character.updatedAt,
+  };
+}

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { db } from '@/lib/firebase/firestore';
+import type { CollectionCharacter, ISOTimestamp } from '@genshin/types';
+
+import { fromDocument, toDocument, type DocumentData } from './document.js';
+
+function collectionRef(userId: string) {
+  return db.collection('users').doc(userId).collection('characters');
+}
+
+export async function listCharacters(userId: string): Promise<CollectionCharacter[]> {
+  const snapshot = await collectionRef(userId).get();
+
+  return snapshot.docs.map((doc) => fromDocument(doc.id, doc.data() as DocumentData));
+}
+
+export async function getCharacter(
+  userId: string,
+  characterId: string,
+): Promise<CollectionCharacter | null> {
+  const doc = await collectionRef(userId).doc(characterId).get();
+
+  if (!doc.exists) {
+    return null;
+  }
+
+  return fromDocument(characterId, doc.data() as DocumentData);
+}
+
+export interface SaveCharacterResult {
+  character: CollectionCharacter;
+  created: boolean;
+}
+
+export async function saveCharacter(
+  userId: string,
+  characterId: string,
+  constellationLevel: number,
+): Promise<SaveCharacterResult> {
+  const docRef = collectionRef(userId).doc(characterId);
+  const existing = await docRef.get();
+  const now = new Date().toISOString() as ISOTimestamp;
+
+  const character: CollectionCharacter = {
+    characterId,
+    constellationLevel,
+    createdAt: existing.exists
+      ? ((existing.data() as DocumentData).createdAt as ISOTimestamp)
+      : now,
+    updatedAt: now,
+  };
+
+  await docRef.set(toDocument(character));
+
+  return { character, created: !existing.exists };
+}
+
+export async function deleteCharacter(userId: string, characterId: string): Promise<void> {
+  await collectionRef(userId).doc(characterId).delete();
+}

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -118,7 +118,7 @@ describe('Character routes', () => {
       const res = await app.request(authedRequest('GET', '/api/characters/albedo'));
 
       expect(res.status).toBe(404);
-      const body = await res.json();
+      const body = (await res.json()) as { detail: string };
       expect(body.detail).toBe('Character not found in collection');
     });
   });
@@ -169,8 +169,20 @@ describe('Character routes', () => {
       );
 
       expect(res.status).toBe(400);
-      const body = await res.json();
+      const body = (await res.json()) as { detail: string };
       expect(body.detail).toBe('Unknown character: not-a-character');
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const res = await app.request(
+        new Request('http://localhost/api/characters/albedo', {
+          method: 'PUT',
+          headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+          body: 'not-json',
+        }),
+      );
+
+      expect(res.status).toBe(400);
     });
 
     it('returns 400 when constellationLevel is missing', async () => {

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionCharacter } from '@genshin/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/firebase/auth', () => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock('@/repositories/characters', () => ({
+  listCharacters: vi.fn(),
+  getCharacter: vi.fn(),
+  saveCharacter: vi.fn(),
+  deleteCharacter: vi.fn(),
+}));
+
+vi.mock('@genshin/game-data', () => ({
+  getCharacterById: vi.fn(),
+}));
+
+import { app } from '@/app';
+import { verifyToken } from '@/lib/firebase/auth';
+import {
+  deleteCharacter,
+  getCharacter,
+  listCharacters,
+  saveCharacter,
+} from '@/repositories/characters';
+import { getCharacterById } from '@genshin/game-data';
+import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/types';
+
+const FAKE_UID = 'test-user-123';
+const FAKE_TOKEN = { uid: FAKE_UID } as Awaited<ReturnType<typeof verifyToken>>;
+
+const FAKE_CHARACTER: CollectionCharacter = {
+  characterId: 'albedo',
+  constellationLevel: 2,
+  createdAt: '2026-01-01T00:00:00.000Z' as CollectionCharacter['createdAt'],
+  updatedAt: '2026-03-13T00:00:00.000Z' as CollectionCharacter['updatedAt'],
+};
+
+function authedRequest(method: string, path: string, body?: unknown) {
+  const init: RequestInit = {
+    method,
+    headers: { Authorization: 'Bearer valid-token' },
+  };
+
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { ...init.headers, 'Content-Type': 'application/json' };
+  }
+
+  return new Request(`http://localhost${path}`, init);
+}
+
+describe('Character routes', () => {
+  beforeEach(() => {
+    vi.mocked(verifyToken).mockResolvedValue(FAKE_TOKEN);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 without Authorization header', async () => {
+      const res = await app.request('/api/characters');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with malformed Authorization header', async () => {
+      const res = await app.request('/api/characters', {
+        headers: { Authorization: 'NotBearer token' },
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/characters', () => {
+    it('returns 200 with character list', async () => {
+      vi.mocked(listCharacters).mockResolvedValue([FAKE_CHARACTER]);
+
+      const res = await app.request(authedRequest('GET', '/api/characters'));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([FAKE_CHARACTER]);
+    });
+
+    it('returns 200 with empty list when no characters', async () => {
+      vi.mocked(listCharacters).mockResolvedValue([]);
+
+      const res = await app.request(authedRequest('GET', '/api/characters'));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([]);
+    });
+  });
+
+  describe('GET /api/characters/:characterId', () => {
+    it('returns 200 with character', async () => {
+      vi.mocked(getCharacter).mockResolvedValue(FAKE_CHARACTER);
+
+      const res = await app.request(authedRequest('GET', '/api/characters/albedo'));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual(FAKE_CHARACTER);
+    });
+
+    it('returns 404 when character not in collection', async () => {
+      vi.mocked(getCharacter).mockResolvedValue(null);
+
+      const res = await app.request(authedRequest('GET', '/api/characters/albedo'));
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.detail).toBe('Character not found in collection');
+    });
+  });
+
+  describe('PUT /api/characters/:characterId', () => {
+    beforeEach(() => {
+      vi.mocked(getCharacterById).mockReturnValue({
+        id: 'albedo',
+        name: 'Albedo',
+      } as ReturnType<typeof getCharacterById>);
+    });
+
+    it('returns 201 when character is newly added', async () => {
+      vi.mocked(saveCharacter).mockResolvedValue({
+        character: FAKE_CHARACTER,
+        created: true,
+      });
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2 }),
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body).toEqual(FAKE_CHARACTER);
+    });
+
+    it('returns 200 when character is updated', async () => {
+      vi.mocked(saveCharacter).mockResolvedValue({
+        character: FAKE_CHARACTER,
+        created: false,
+      });
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2 }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual(FAKE_CHARACTER);
+    });
+
+    it('returns 400 for unknown character ID', async () => {
+      vi.mocked(getCharacterById).mockReturnValue(undefined);
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/not-a-character', { constellationLevel: 0 }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.detail).toBe('Unknown character: not-a-character');
+    });
+
+    it('returns 400 when constellationLevel is missing', async () => {
+      const res = await app.request(authedRequest('PUT', '/api/characters/albedo', {}));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when constellationLevel is not a number', async () => {
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 'high' }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when constellationLevel is below minimum', async () => {
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', {
+          constellationLevel: MIN_CONSTELLATION_LEVEL - 1,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when constellationLevel is above maximum', async () => {
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', {
+          constellationLevel: MAX_CONSTELLATION_LEVEL + 1,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when constellationLevel is not an integer', async () => {
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2.5 }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts constellationLevel at minimum boundary', async () => {
+      vi.mocked(saveCharacter).mockResolvedValue({
+        character: { ...FAKE_CHARACTER, constellationLevel: MIN_CONSTELLATION_LEVEL },
+        created: true,
+      });
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', {
+          constellationLevel: MIN_CONSTELLATION_LEVEL,
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('accepts constellationLevel at maximum boundary', async () => {
+      vi.mocked(saveCharacter).mockResolvedValue({
+        character: { ...FAKE_CHARACTER, constellationLevel: MAX_CONSTELLATION_LEVEL },
+        created: true,
+      });
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/characters/albedo', {
+          constellationLevel: MAX_CONSTELLATION_LEVEL,
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('DELETE /api/characters/:characterId', () => {
+    it('returns 204 with no body', async () => {
+      vi.mocked(deleteCharacter).mockResolvedValue();
+
+      const res = await app.request(authedRequest('DELETE', '/api/characters/albedo'));
+
+      expect(res.status).toBe(204);
+      expect(await res.text()).toBe('');
+    });
+  });
+});

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -58,7 +58,12 @@ characters.put('/:characterId', async (c) => {
     throw new HTTPException(400, { message: `Unknown character: ${characterId}` });
   }
 
-  const body = await c.req.json<SaveCharacterBody>();
+  let body: SaveCharacterBody;
+  try {
+    body = await c.req.json<SaveCharacterBody>();
+  } catch {
+    throw new HTTPException(400, { message: 'Invalid or missing JSON body' });
+  }
 
   const { constellationLevel } = body;
 

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { AuthVariables } from '@/middleware/auth';
+import { auth } from '@/middleware/auth';
+import {
+  deleteCharacter,
+  getCharacter,
+  listCharacters,
+  saveCharacter,
+} from '@/repositories/characters';
+import { getCharacterById } from '@genshin/game-data';
+import {
+  MAX_CONSTELLATION_LEVEL,
+  MIN_CONSTELLATION_LEVEL,
+  isValidConstellationLevel,
+} from '@genshin/types';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+export const characters = new Hono<{ Variables: AuthVariables }>();
+
+characters.use('*', auth);
+
+interface SaveCharacterBody {
+  constellationLevel?: unknown;
+}
+
+// GET /api/characters — List user's character collection
+characters.get('/', async (c) => {
+  const userId = c.get('user').uid;
+  const items = await listCharacters(userId);
+
+  return c.json(items);
+});
+
+// GET /api/characters/:characterId — Get specific character record
+characters.get('/:characterId', async (c) => {
+  const userId = c.get('user').uid;
+  const { characterId } = c.req.param();
+
+  const character = await getCharacter(userId, characterId);
+
+  if (!character) {
+    throw new HTTPException(404, { message: 'Character not found in collection' });
+  }
+
+  return c.json(character);
+});
+
+// PUT /api/characters/:characterId — Save/update character (idempotent upsert)
+characters.put('/:characterId', async (c) => {
+  const userId = c.get('user').uid;
+  const { characterId } = c.req.param();
+
+  // Verify characterId exists in game data
+  if (!getCharacterById(characterId)) {
+    throw new HTTPException(400, { message: `Unknown character: ${characterId}` });
+  }
+
+  const body = await c.req.json<SaveCharacterBody>();
+
+  const { constellationLevel } = body;
+
+  if (!isValidConstellationLevel(constellationLevel)) {
+    throw new HTTPException(400, {
+      message: `constellationLevel must be an integer between ${MIN_CONSTELLATION_LEVEL} and ${MAX_CONSTELLATION_LEVEL}`,
+    });
+  }
+
+  const { character, created } = await saveCharacter(userId, characterId, constellationLevel);
+
+  return c.json(character, created ? 201 : 200);
+});
+
+// DELETE /api/characters/:characterId — Remove from collection
+characters.delete('/:characterId', async (c) => {
+  const userId = c.get('user').uid;
+  const { characterId } = c.req.param();
+
+  await deleteCharacter(userId, characterId);
+
+  return c.body(null, 204);
+});

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -21,6 +21,5 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -21,5 +21,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@': new URL('./src', import.meta.url).pathname,
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
   test: {

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname,
+    },
+  },
+  test: {
+    globals: true,
+  },
+});

--- a/packages/types/src/collectionCharacter.ts
+++ b/packages/types/src/collectionCharacter.ts
@@ -1,0 +1,25 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+import type { Character } from '@genshin/game-data';
+
+import type { ISOTimestamp } from './isoTimestamp.js';
+
+export const MIN_CONSTELLATION_LEVEL = 0;
+export const MAX_CONSTELLATION_LEVEL = 6;
+
+export interface CollectionCharacter {
+  characterId: Character['id'];
+  constellationLevel: number;
+  createdAt: ISOTimestamp;
+  updatedAt: ISOTimestamp;
+}
+
+export function isValidConstellationLevel(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= MIN_CONSTELLATION_LEVEL &&
+    value <= MAX_CONSTELLATION_LEVEL
+  );
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+export {
+  MAX_CONSTELLATION_LEVEL,
+  MIN_CONSTELLATION_LEVEL,
+  isValidConstellationLevel,
+  type CollectionCharacter,
+} from './collectionCharacter.js';
+export type { ISOTimestamp } from './isoTimestamp.js';
 export type { Team, TeamSlot } from './team.js';
 export type { ArtifactPlan, TeamMember } from './teamMember.js';
 export type { User } from './user.js';

--- a/packages/types/src/isoTimestamp.ts
+++ b/packages/types/src/isoTimestamp.ts
@@ -1,0 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+declare const __brand: unique symbol;
+
+export type ISOTimestamp = string & { readonly [__brand]: 'ISOTimestamp' };

--- a/packages/types/src/team.ts
+++ b/packages/types/src/team.ts
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
+import type { ISOTimestamp } from './isoTimestamp.js';
 import type { TeamMember } from './teamMember.js';
 
 /**
@@ -29,12 +30,6 @@ export interface Team {
    */
   members: [TeamMember, TeamMember, TeamMember, TeamMember];
   description?: string;
-  /**
-   * ISO 8601 timestamp string representing when the team was created.
-   */
-  createdAt: string;
-  /**
-   * ISO 8601 timestamp string representing when the team was last updated.
-   */
-  updatedAt: string;
+  createdAt: ISOTimestamp;
+  updatedAt: ISOTimestamp;
 }

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,6 +1,8 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
+import type { ISOTimestamp } from './isoTimestamp.js';
+
 /**
  * User represents a Genshin Impact player authenticated via OIDC
  */
@@ -12,6 +14,6 @@ export interface User {
   emailVerified: boolean;
   provider: string;
   providerUserId: string;
-  createdAt: string; // ISO 8601 timestamp
-  updatedAt: string; // ISO 8601 timestamp
+  createdAt: ISOTimestamp;
+  updatedAt: ISOTimestamp;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@genshin/game-data':
+        specifier: workspace:*
+        version: link:../../packages/game-data
+      '@genshin/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@hono/node-server':
         specifier: 1.19.11
         version: 1.19.11(hono@4.12.7)
@@ -69,6 +75,9 @@ importers:
       typescript-eslint:
         specifier: 8.57.0
         version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
 
   apps/web:
     dependencies:
@@ -1179,6 +1188,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
 
@@ -1294,6 +1306,12 @@ packages:
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -1401,6 +1419,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1463,6 +1510,10 @@ packages:
   arrify@2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1535,6 +1586,10 @@ packages:
 
   caniuse-lite@1.0.30001778:
     resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1680,6 +1735,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1750,6 +1808,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1757,6 +1818,10 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2493,6 +2558,9 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2538,6 +2606,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2787,6 +2858,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2806,6 +2880,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
@@ -2893,9 +2973,20 @@ packages:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3067,6 +3158,41 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3095,6 +3221,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4136,6 +4267,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -4230,6 +4363,13 @@ snapshots:
 
   '@types/caseless@0.12.5':
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -4366,6 +4506,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
 
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -4425,6 +4606,8 @@ snapshots:
 
   arrify@2.0.1:
     optional: true
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -4496,6 +4679,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001778: {}
+
+  chai@6.2.2: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -4634,6 +4819,8 @@ snapshots:
   es-errors@1.3.0:
     optional: true
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4759,10 +4946,16 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   event-target-shim@5.0.1:
     optional: true
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -5530,6 +5723,8 @@ snapshots:
   object-hash@3.0.0:
     optional: true
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5578,6 +5773,8 @@ snapshots:
       minipass: 7.1.3
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -5771,6 +5968,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
@@ -5784,6 +5983,10 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   stream-events@1.0.5:
     dependencies:
@@ -5920,10 +6123,16 @@ snapshots:
       - supports-color
     optional: true
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6053,6 +6262,34 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.21.0
 
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@4.2.4: {}
@@ -6081,6 +6318,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

Implements character CRUD API endpoints for user character collection management.

### Changes

**Routes** (`apps/api/src/routes/characters.ts`):
- `GET /api/characters` — list user's character collection
- `GET /api/characters/:characterId` — get specific character record (404 if missing)
- `PUT /api/characters/:characterId` — idempotent upsert with validation
- `DELETE /api/characters/:characterId` — remove from collection (204)

**Repository layer** (`apps/api/src/repositories/characters/`):
- Firestore data access with internal document type and converters
- `listCharacters`, `getCharacter`, `saveCharacter`, `deleteCharacter`

**Types** (`packages/types`):
- `CollectionCharacter` interface with `ISOTimestamp` branded type
- `isValidConstellationLevel` type guard
- `MIN_CONSTELLATION_LEVEL` / `MAX_CONSTELLATION_LEVEL` constants

**Infrastructure**:
- Extract `app.ts` from `main.ts` for testability
- Extract Firebase app initialization to shared module
- Add vitest with 18 integration tests
- Add test step to CI workflow
- Dockerfile: use corepack + `packageManager` field (no hard-coded pnpm version)
- CI/deploy: use `pnpm turbo run` for workspace dependency build ordering

### Breaking changes

**Error response format**: All API error responses now use [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) with `Content-Type: application/problem+json`. The previous `{ error, status }` shape is replaced by `{ type, title, status, detail }`. All responses include a `detail` field for a stable schema. This aligns with the planned format documented in `docs/reference/rest-api-conventions.md`.

### Deferred
- Character level tracking (1–90) → #444
- HATEOAS root endpoint → #443
- Firebase Emulator Suite for repository tests → #445
- `saveCharacter` read-then-write race condition → #447

Closes #42