### PR TITLE
docs: capture build, Docker, and API conventions from PR #446 review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,8 +37,8 @@
 
 ## Build and CI rules
 
-- Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
-- The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. Keep both in sync when changing compiler options.
+- Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't automatically build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
+- The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. The build config extends `tsconfig.json`, so compiler options stay in sync automatically; only the exclude patterns differ.
 
 ## State usage
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@
 - Workspace packages consumed by other packages must expose `types` and `default` in `exports` and include `main`.
 - Use ISO 8601 strings for timestamps such as `createdAt` and `updatedAt`, not `Date` objects.
 - Maintain game-data accuracy when working with `packages/game-data`.
-- Test alongside code when possible; the team plans an automated test stack, so perform manual local validation now.
+- Test alongside code when possible; the API has Vitest coverage, but web and UI testing is planned and not yet implemented.
 
 ## Build and CI rules
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,8 +13,9 @@
 
 - Stack: Turborepo + pnpm + TypeScript 5.9 strict mode.
 - Web: React 19, Vite, Tailwind, `shadcn/ui`, zustand, TanStack Query, `react-router-dom`.
-- API: Hono + Node.js.
-- Not yet implemented: Firestore, Firebase Auth, Claude MCP, Vitest, React Testing Library, Bun.
+- API: Hono + Node.js, Firestore, Firebase Auth.
+- Testing: Vitest (API integration tests).
+- Not yet implemented: Claude MCP, React Testing Library, Bun.
 - `shadcn/ui` setup: New York style, neutral base color, CSS variables, and ESM Tailwind plugin imports.
 
 ## Repository map
@@ -34,6 +35,11 @@
 - Maintain game-data accuracy when working with `packages/game-data`.
 - Test alongside code when possible; the team plans an automated test stack, so perform manual local validation now.
 
+## Build and CI rules
+
+- Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
+- The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. Keep both in sync when changing compiler options.
+
 ## State usage
 
 - Use zustand for UI state, TanStack Query for server state, and `@genshin/game-data` helpers for static game data.
@@ -41,6 +47,7 @@
 ## API design rules
 
 - Use the [REST API conventions reference](../docs/reference/rest-api-conventions.md) as guidance for API route shape, methods, status codes, error format, pagination, and auth handling.
+- All error responses use RFC 9457 Problem Details (`application/problem+json`). Always include a `detail` field, even for generic errors, to keep a stable schema for clients.
 
 ## Frontend rules
 
@@ -114,6 +121,12 @@
   - `.github/workflows/terraform-apply.yml`
   - `.github/workflows/pre-commit.yml`, when Terraform is in use
 - Current Terraform version baseline: `1.9.0`.
+
+## Docker rules
+
+- Don't hard-code the pnpm version in the Dockerfile. Copy `package.json` first and use `corepack install` so corepack reads the `packageManager` field.
+- When adding workspace package dependencies to an app, verify `.dockerignore` doesn't exclude them from the build context.
+- Set `ENV CI=true` in builder stages so pnpm runs non-interactively.
 
 ## File naming
 

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -23,6 +23,8 @@ Vite
 Bun
 pnpm
 npm
+corepack
+Dockerfile
 
 # Code quality tools
 ESLint
@@ -71,6 +73,7 @@ repo
 repos
 roadmaps
 semver
+typechecking
 unversioned
 validators
 

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -43,6 +43,8 @@ See [JSONSchema2020-12]: <https://json-schema.org/draft/2020-12>
 
 Use the Problem Details standard for machine-readable error responses. Return `application/problem+json` with stable fields and consistent extension members where needed.
 
+Always include a `detail` field in every Problem Details response, even for generic errors such as `500 Internal Server Error` or `404 Not Found`. This ensures clients can parse the error body uniformly without branching on status code.
+
 See [RFC9457]: <https://www.rfc-editor.org/rfc/rfc9457>
 
 ### 6. Consistent list behavior

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,7 @@
       "inputs": ["**/*.{ts,tsx}", "package.json", "eslint.config.*"]
     },
     "test": {
+      "dependsOn": ["^build"],
       "inputs": ["src/**", "package.json", "vite.config.*", "vitest.config.*", "tsconfig*.json"]
     },
     "typecheck": {


### PR DESCRIPTION
## Summary

Codifies lessons learned during the character CRUD API implementation (PR #446) into project documentation so future work short-circuits the same decisions.

### Changes

**`copilot-instructions.md`**:
- Update Snapshot: Firestore, Firebase Auth, and Vitest are now implemented.
- Add **Build and CI rules**: always use `pnpm turbo run` (not raw `pnpm --filter`) for build/typecheck/test; document the `tsconfig.json` / `tsconfig.build.json` split pattern.
- Add **Docker rules**: use `corepack install` with `packageManager` field instead of hard-coding pnpm versions; verify `.dockerignore` when adding workspace dependencies; set `CI=true` in builder stages.
- Add **API design rule**: all RFC 9457 Problem Details responses must include a `detail` field for a stable client schema.

**`docs/reference/rest-api-conventions.md`**:
- Expand the error contract section with explicit `detail` field guidance.

**Vale vocabulary**:
- Add `Dockerfile`, `corepack`, and `typechecking` to accepted terms.