### PR TITLE
fix(api): use nodenext module resolution for ESM compatibility

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { AuthVariables } from '@/middleware/auth';
-import { characters } from '@/routes/characters';
+import type { AuthVariables } from '@/middleware/auth.js';
+import { characters } from '@/routes/characters.js';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';

--- a/apps/api/src/lib/firebase/auth.ts
+++ b/apps/api/src/lib/firebase/auth.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { app } from '@/lib/firebase/app';
+import { app } from '@/lib/firebase/app.js';
 import { type DecodedIdToken, getAuth } from 'firebase-admin/auth';
 
 const auth = getAuth(app);

--- a/apps/api/src/lib/firebase/firestore.ts
+++ b/apps/api/src/lib/firebase/firestore.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { app } from '@/lib/firebase/app';
+import { app } from '@/lib/firebase/app.js';
 import { getFirestore } from 'firebase-admin/firestore';
 
 export const db = getFirestore(app);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { app } from '@/app';
+import { app } from '@/app.js';
 import { serve } from '@hono/node-server';
 
 const port = parseInt(process.env.PORT || '8080', 10);

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { DecodedIdToken } from '@/lib/firebase/auth';
-import { verifyToken } from '@/lib/firebase/auth';
+import type { DecodedIdToken } from '@/lib/firebase/auth.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
 

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { db } from '@/lib/firebase/firestore';
+import { db } from '@/lib/firebase/firestore.js';
 import type { CollectionCharacter, ISOTimestamp } from '@genshin/types';
 
 import { fromDocument, toDocument, type DocumentData } from './document.js';

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -4,11 +4,11 @@
 import type { CollectionCharacter } from '@genshin/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/lib/firebase/auth', () => ({
+vi.mock('@/lib/firebase/auth.js', () => ({
   verifyToken: vi.fn(),
 }));
 
-vi.mock('@/repositories/characters', () => ({
+vi.mock('@/repositories/characters/index.js', () => ({
   listCharacters: vi.fn(),
   getCharacter: vi.fn(),
   saveCharacter: vi.fn(),
@@ -19,14 +19,14 @@ vi.mock('@genshin/game-data', () => ({
   getCharacterById: vi.fn(),
 }));
 
-import { app } from '@/app';
-import { verifyToken } from '@/lib/firebase/auth';
+import { app } from '@/app.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
 import {
   deleteCharacter,
   getCharacter,
   listCharacters,
   saveCharacter,
-} from '@/repositories/characters';
+} from '@/repositories/characters/index.js';
 import { getCharacterById } from '@genshin/game-data';
 import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/types';
 

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { AuthVariables } from '@/middleware/auth';
-import { auth } from '@/middleware/auth';
+import type { AuthVariables } from '@/middleware/auth.js';
+import { auth } from '@/middleware/auth.js';
 import {
   deleteCharacter,
   getCharacter,
   listCharacters,
   saveCharacter,
-} from '@/repositories/characters';
+} from '@/repositories/characters/index.js';
 import { getCharacterById } from '@genshin/game-data';
 import {
   MAX_CONSTELLATION_LEVEL,

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "nodenext",
     "lib": ["ES2022"],
-    "moduleResolution": "bundler",
+    "moduleResolution": "nodenext",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Problem

The API deployment to Cloud Run failed ([run #23072191485](https://github.com/dungeon-studio/genshin.dungeon.studio/actions/runs/23072191485)) because the container crashed on startup with:

```
ERR_MODULE_NOT_FOUND: Cannot find module './app' imported from /app/apps/api/dist/main.js
```

The compiled output had relative imports without `.js` extensions (e.g., `'./app'` instead of `'./app.js'`), which fails under Node.js ESM resolution. The container could never listen on `PORT=8080`.

## Root cause

`tsconfig.json` used `moduleResolution: "bundler"`, which doesn't enforce `.js` extensions in source imports. `tsc` emits imports as-is, and `tsc-alias` rewrites path aliases to relative paths but also doesn't append extensions. Node.js ESM requires explicit file extensions.

## Fix

- Switch `module` and `moduleResolution` from `ESNext`/`bundler` to `nodenext`, which enforces proper ESM semantics at the TypeScript level.
- Add `.js` extensions to all `@/` alias imports in source files.
- Update `vi.mock()` paths in the test file to match.

## Verification

- Build: `pnpm turbo run build --filter=@genshin/api` — passes
- Typecheck: `pnpm turbo run typecheck --filter=@genshin/api` — passes
- Tests: `pnpm turbo run test --filter=@genshin/api` — 18 tests pass
- Runtime: `node apps/api/dist/main.js` — starts and listens on port 8080