### PR TITLE
feat: implement weapon CRUD API endpoints

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { characters } from '@/routes/characters.js';
+import { weapons } from '@/routes/weapons.js';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
@@ -89,3 +90,4 @@ app.get('/health', (c) =>
 
 // Routes
 app.route('/api/characters', characters);
+app.route('/api/weapons', weapons);

--- a/apps/api/src/repositories/weapons/document.ts
+++ b/apps/api/src/repositories/weapons/document.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/types';
+
+export interface DocumentData {
+  refinementLevel: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function fromDocument(
+  weaponInstanceId: UUID,
+  weaponId: string,
+  data: DocumentData,
+): CollectionWeapon {
+  return {
+    weaponInstanceId,
+    weaponId,
+    refinementLevel: data.refinementLevel,
+    createdAt: data.createdAt as ISOTimestamp,
+    updatedAt: data.updatedAt as ISOTimestamp,
+  };
+}
+
+export function toDocument(weapon: CollectionWeapon): DocumentData {
+  return {
+    refinementLevel: weapon.refinementLevel,
+    createdAt: weapon.createdAt,
+    updatedAt: weapon.updatedAt,
+  };
+}

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { db } from '@/lib/firebase/firestore.js';
+import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/types';
+import { randomUUID } from 'node:crypto';
+
+import { fromDocument, toDocument, type DocumentData } from './document.js';
+
+function collectionRef(userId: string, weaponId: string) {
+  return db
+    .collection('users')
+    .doc(userId)
+    .collection('weapons')
+    .doc(weaponId)
+    .collection('instances');
+}
+
+export async function listWeapons(userId: string): Promise<CollectionWeapon[]> {
+  const weaponsRef = db.collection('users').doc(userId).collection('weapons');
+  const weaponDocs = await weaponsRef.listDocuments();
+
+  const results: CollectionWeapon[] = [];
+
+  for (const weaponDoc of weaponDocs) {
+    const snapshot = await weaponDoc.collection('instances').get();
+    for (const doc of snapshot.docs) {
+      results.push(fromDocument(doc.id as UUID, weaponDoc.id, doc.data() as DocumentData));
+    }
+  }
+
+  return results;
+}
+
+export async function listWeaponInstances(
+  userId: string,
+  weaponId: string,
+): Promise<CollectionWeapon[]> {
+  const snapshot = await collectionRef(userId, weaponId).get();
+
+  return snapshot.docs.map((doc) =>
+    fromDocument(doc.id as UUID, weaponId, doc.data() as DocumentData),
+  );
+}
+
+export async function getWeaponInstance(
+  userId: string,
+  weaponId: string,
+  weaponInstanceId: UUID,
+): Promise<CollectionWeapon | null> {
+  const doc = await collectionRef(userId, weaponId).doc(weaponInstanceId).get();
+
+  if (!doc.exists) {
+    return null;
+  }
+
+  return fromDocument(weaponInstanceId as UUID, weaponId, doc.data() as DocumentData);
+}
+
+export async function createWeaponInstance(
+  userId: string,
+  weaponId: string,
+  refinementLevel: number,
+): Promise<CollectionWeapon> {
+  const weaponInstanceId = randomUUID() as UUID;
+  const now = new Date().toISOString() as ISOTimestamp;
+
+  const weapon: CollectionWeapon = {
+    weaponInstanceId,
+    weaponId,
+    refinementLevel,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await collectionRef(userId, weaponId).doc(weaponInstanceId).set(toDocument(weapon));
+
+  return weapon;
+}
+
+export async function updateWeaponInstance(
+  userId: string,
+  weaponId: string,
+  weaponInstanceId: UUID,
+  refinementLevel: number,
+): Promise<CollectionWeapon | null> {
+  const docRef = collectionRef(userId, weaponId).doc(weaponInstanceId);
+  const existing = await docRef.get();
+
+  if (!existing.exists) {
+    return null;
+  }
+
+  const existingData = existing.data() as DocumentData;
+  const now = new Date().toISOString() as ISOTimestamp;
+
+  const weapon: CollectionWeapon = {
+    weaponInstanceId,
+    weaponId,
+    refinementLevel,
+    createdAt: existingData.createdAt as ISOTimestamp,
+    updatedAt: now,
+  };
+
+  await docRef.set(toDocument(weapon));
+
+  return weapon;
+}
+
+export async function deleteWeaponInstance(
+  userId: string,
+  weaponId: string,
+  weaponInstanceId: UUID,
+): Promise<void> {
+  await collectionRef(userId, weaponId).doc(weaponInstanceId).delete();
+}

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -123,4 +123,9 @@ export async function deleteWeaponInstance(
   weaponInstanceId: UUID,
 ): Promise<void> {
   await collectionRef(userId, weaponId).doc(weaponInstanceId).delete();
+
+  const remaining = await collectionRef(userId, weaponId).limit(1).get();
+  if (remaining.empty) {
+    await db.collection('users').doc(userId).collection('weapons').doc(weaponId).delete();
+  }
 }

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -22,19 +22,13 @@ export async function listWeapons(userId: string): Promise<Record<string, Collec
 
   const results: Record<string, CollectionWeapon[]> = {};
 
-  const snapshots = await Promise.all(
-    weaponDocs.map(async (weaponDoc) => ({
-      weaponId: weaponDoc.id,
-      snapshot: await weaponDoc.collection('instances').get(),
-    })),
-  );
-
-  for (const { weaponId, snapshot } of snapshots) {
+  for (const weaponDoc of weaponDocs) {
+    const snapshot = await weaponDoc.collection('instances').get();
     const instances = snapshot.docs.map((doc) =>
-      fromDocument(doc.id as UUID, weaponId, doc.data() as DocumentData),
+      fromDocument(doc.id as UUID, weaponDoc.id, doc.data() as DocumentData),
     );
     if (instances.length > 0) {
-      results[weaponId] = instances;
+      results[weaponDoc.id] = instances;
     }
   }
 

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -16,16 +16,25 @@ function collectionRef(userId: string, weaponId: string) {
     .collection('instances');
 }
 
-export async function listWeapons(userId: string): Promise<CollectionWeapon[]> {
+export async function listWeapons(userId: string): Promise<Record<string, CollectionWeapon[]>> {
   const weaponsRef = db.collection('users').doc(userId).collection('weapons');
   const weaponDocs = await weaponsRef.listDocuments();
 
-  const results: CollectionWeapon[] = [];
+  const results: Record<string, CollectionWeapon[]> = {};
 
-  for (const weaponDoc of weaponDocs) {
-    const snapshot = await weaponDoc.collection('instances').get();
-    for (const doc of snapshot.docs) {
-      results.push(fromDocument(doc.id as UUID, weaponDoc.id, doc.data() as DocumentData));
+  const snapshots = await Promise.all(
+    weaponDocs.map(async (weaponDoc) => ({
+      weaponId: weaponDoc.id,
+      snapshot: await weaponDoc.collection('instances').get(),
+    })),
+  );
+
+  for (const { weaponId, snapshot } of snapshots) {
+    const instances = snapshot.docs.map((doc) =>
+      fromDocument(doc.id as UUID, weaponId, doc.data() as DocumentData),
+    );
+    if (instances.length > 0) {
+      results[weaponId] = instances;
     }
   }
 
@@ -73,7 +82,14 @@ export async function createWeaponInstance(
     updatedAt: now,
   };
 
-  await collectionRef(userId, weaponId).doc(weaponInstanceId).set(toDocument(weapon));
+  const batch = db.batch();
+  batch.set(
+    db.collection('users').doc(userId).collection('weapons').doc(weaponId),
+    {},
+    { merge: true },
+  );
+  batch.set(collectionRef(userId, weaponId).doc(weaponInstanceId), toDocument(weapon));
+  await batch.commit();
 
   return weapon;
 }

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -123,9 +123,4 @@ export async function deleteWeaponInstance(
   weaponInstanceId: UUID,
 ): Promise<void> {
   await collectionRef(userId, weaponId).doc(weaponInstanceId).delete();
-
-  const remaining = await collectionRef(userId, weaponId).limit(1).get();
-  if (remaining.empty) {
-    await db.collection('users').doc(userId).collection('weapons').doc(weaponId).delete();
-  }
 }

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -27,11 +27,9 @@ import {
   listCharacters,
   saveCharacter,
 } from '@/repositories/characters/index.js';
+import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 import { getCharacterById } from '@genshin/game-data';
 import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/types';
-
-const FAKE_UID = 'test-user-123';
-const FAKE_TOKEN = { uid: FAKE_UID } as Awaited<ReturnType<typeof verifyToken>>;
 
 const FAKE_CHARACTER: CollectionCharacter = {
   characterId: 'albedo',
@@ -39,20 +37,6 @@ const FAKE_CHARACTER: CollectionCharacter = {
   createdAt: '2026-01-01T00:00:00.000Z' as CollectionCharacter['createdAt'],
   updatedAt: '2026-03-13T00:00:00.000Z' as CollectionCharacter['updatedAt'],
 };
-
-function authedRequest(method: string, path: string, body?: unknown) {
-  const init: RequestInit = {
-    method,
-    headers: { Authorization: 'Bearer valid-token' },
-  };
-
-  if (body !== undefined) {
-    init.body = JSON.stringify(body);
-    init.headers = { ...init.headers, 'Content-Type': 'application/json' };
-  }
-
-  return new Request(`http://localhost${path}`, init);
-}
 
 describe('Character routes', () => {
   beforeEach(() => {

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -91,6 +91,13 @@ describe('Weapon routes', () => {
   });
 
   describe('GET /api/weapons/:weaponId', () => {
+    beforeEach(() => {
+      vi.mocked(getWeaponById).mockReturnValue({
+        id: 'mistsplitter-reforged',
+        name: 'Mistsplitter Reforged',
+      } as ReturnType<typeof getWeaponById>);
+    });
+
     it('returns 200 with instances of specific weapon', async () => {
       vi.mocked(listWeaponInstances).mockResolvedValue([FAKE_WEAPON]);
 
@@ -109,6 +116,16 @@ describe('Weapon routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual([]);
+    });
+
+    it('returns 400 for unknown weapon ID', async () => {
+      vi.mocked(getWeaponById).mockReturnValue(undefined);
+
+      const res = await app.request(authedRequest('GET', '/api/weapons/not-a-weapon'));
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Unknown weapon: not-a-weapon');
     });
   });
 
@@ -240,6 +257,13 @@ describe('Weapon routes', () => {
   });
 
   describe('PUT /api/weapons/:weaponId/:weaponInstanceId', () => {
+    beforeEach(() => {
+      vi.mocked(getWeaponById).mockReturnValue({
+        id: 'mistsplitter-reforged',
+        name: 'Mistsplitter Reforged',
+      } as ReturnType<typeof getWeaponById>);
+    });
+
     it('returns 200 when weapon instance is updated', async () => {
       vi.mocked(updateWeaponInstance).mockResolvedValue(FAKE_WEAPON);
 
@@ -310,9 +334,30 @@ describe('Weapon routes', () => {
         3,
       );
     });
+
+    it('returns 400 for unknown weapon ID', async () => {
+      vi.mocked(getWeaponById).mockReturnValue(undefined);
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/weapons/not-a-weapon/instance-uuid-1', {
+          refinementLevel: 1,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Unknown weapon: not-a-weapon');
+    });
   });
 
   describe('DELETE /api/weapons/:weaponId/:weaponInstanceId', () => {
+    beforeEach(() => {
+      vi.mocked(getWeaponById).mockReturnValue({
+        id: 'mistsplitter-reforged',
+        name: 'Mistsplitter Reforged',
+      } as ReturnType<typeof getWeaponById>);
+    });
+
     it('returns 204 with no body', async () => {
       vi.mocked(deleteWeaponInstance).mockResolvedValue();
 
@@ -322,6 +367,18 @@ describe('Weapon routes', () => {
 
       expect(res.status).toBe(204);
       expect(await res.text()).toBe('');
+    });
+
+    it('returns 400 for unknown weapon ID', async () => {
+      vi.mocked(getWeaponById).mockReturnValue(undefined);
+
+      const res = await app.request(
+        authedRequest('DELETE', '/api/weapons/not-a-weapon/instance-uuid-1'),
+      );
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Unknown weapon: not-a-weapon');
     });
   });
 });

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionWeapon, UUID } from '@genshin/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/firebase/auth.js', () => ({
+  verifyToken: vi.fn(),
+}));
+
+vi.mock('@/repositories/weapons/index.js', () => ({
+  listWeapons: vi.fn(),
+  listWeaponInstances: vi.fn(),
+  createWeaponInstance: vi.fn(),
+  updateWeaponInstance: vi.fn(),
+  deleteWeaponInstance: vi.fn(),
+}));
+
+vi.mock('@genshin/game-data', () => ({
+  getWeaponById: vi.fn(),
+}));
+
+import { app } from '@/app.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
+import {
+  createWeaponInstance,
+  deleteWeaponInstance,
+  listWeaponInstances,
+  listWeapons,
+  updateWeaponInstance,
+} from '@/repositories/weapons/index.js';
+import { FAKE_TOKEN, FAKE_UID, authedRequest } from '@/test/auth-requests.js';
+import { getWeaponById } from '@genshin/game-data';
+import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/types';
+
+const FAKE_WEAPON: CollectionWeapon = {
+  weaponInstanceId: 'instance-uuid-1' as UUID,
+  weaponId: 'mistsplitter-reforged',
+  refinementLevel: 1,
+  createdAt: '2026-01-01T00:00:00.000Z' as CollectionWeapon['createdAt'],
+  updatedAt: '2026-03-13T00:00:00.000Z' as CollectionWeapon['updatedAt'],
+};
+
+describe('Weapon routes', () => {
+  beforeEach(() => {
+    vi.mocked(verifyToken).mockResolvedValue(FAKE_TOKEN);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 without Authorization header', async () => {
+      const res = await app.request('/api/weapons');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with malformed Authorization header', async () => {
+      const res = await app.request('/api/weapons', {
+        headers: { Authorization: 'NotBearer token' },
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/weapons', () => {
+    it('returns 200 with weapon list', async () => {
+      vi.mocked(listWeapons).mockResolvedValue([FAKE_WEAPON]);
+
+      const res = await app.request(authedRequest('GET', '/api/weapons'));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([FAKE_WEAPON]);
+    });
+
+    it('returns 200 with empty list when no weapons', async () => {
+      vi.mocked(listWeapons).mockResolvedValue([]);
+
+      const res = await app.request(authedRequest('GET', '/api/weapons'));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([]);
+    });
+  });
+
+  describe('GET /api/weapons/:weaponId', () => {
+    it('returns 200 with instances of specific weapon', async () => {
+      vi.mocked(listWeaponInstances).mockResolvedValue([FAKE_WEAPON]);
+
+      const res = await app.request(authedRequest('GET', '/api/weapons/mistsplitter-reforged'));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([FAKE_WEAPON]);
+    });
+
+    it('returns 200 with empty list when no instances', async () => {
+      vi.mocked(listWeaponInstances).mockResolvedValue([]);
+
+      const res = await app.request(authedRequest('GET', '/api/weapons/mistsplitter-reforged'));
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([]);
+    });
+  });
+
+  describe('POST /api/weapons/:weaponId', () => {
+    beforeEach(() => {
+      vi.mocked(getWeaponById).mockReturnValue({
+        id: 'mistsplitter-reforged',
+        name: 'Mistsplitter Reforged',
+      } as ReturnType<typeof getWeaponById>);
+    });
+
+    it('returns 201 when weapon instance is created', async () => {
+      vi.mocked(createWeaponInstance).mockResolvedValue(FAKE_WEAPON);
+
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+          refinementLevel: 1,
+        }),
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body).toEqual(FAKE_WEAPON);
+    });
+
+    it('returns 400 for unknown weapon ID', async () => {
+      vi.mocked(getWeaponById).mockReturnValue(undefined);
+
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/not-a-weapon', {
+          refinementLevel: 1,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Unknown weapon: not-a-weapon');
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const res = await app.request(
+        new Request('http://localhost/api/weapons/mistsplitter-reforged', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+          body: 'not-json',
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when refinementLevel is missing', async () => {
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {}),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when refinementLevel is not a number', async () => {
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+          refinementLevel: 'R5',
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when refinementLevel is below minimum', async () => {
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+          refinementLevel: MIN_REFINEMENT_LEVEL - 1,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when refinementLevel is above maximum', async () => {
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+          refinementLevel: MAX_REFINEMENT_LEVEL + 1,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when refinementLevel is not an integer', async () => {
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+          refinementLevel: 2.5,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts refinementLevel at minimum boundary', async () => {
+      vi.mocked(createWeaponInstance).mockResolvedValue({
+        ...FAKE_WEAPON,
+        refinementLevel: MIN_REFINEMENT_LEVEL,
+      });
+
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+          refinementLevel: MIN_REFINEMENT_LEVEL,
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('accepts refinementLevel at maximum boundary', async () => {
+      vi.mocked(createWeaponInstance).mockResolvedValue({
+        ...FAKE_WEAPON,
+        refinementLevel: MAX_REFINEMENT_LEVEL,
+      });
+
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+          refinementLevel: MAX_REFINEMENT_LEVEL,
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('PUT /api/weapons/:weaponId/:weaponInstanceId', () => {
+    it('returns 200 when weapon instance is updated', async () => {
+      vi.mocked(updateWeaponInstance).mockResolvedValue(FAKE_WEAPON);
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+          refinementLevel: 1,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual(FAKE_WEAPON);
+    });
+
+    it('returns 404 when weapon instance not found', async () => {
+      vi.mocked(updateWeaponInstance).mockResolvedValue(null);
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/nonexistent', {
+          refinementLevel: 1,
+        }),
+      );
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Weapon instance not found');
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const res = await app.request(
+        new Request('http://localhost/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+          method: 'PUT',
+          headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+          body: 'not-json',
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when refinementLevel is invalid', async () => {
+      const res = await app.request(
+        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+          refinementLevel: 0,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('updates refinementLevel', async () => {
+      vi.mocked(updateWeaponInstance).mockResolvedValue({
+        ...FAKE_WEAPON,
+        refinementLevel: 3,
+      });
+
+      const res = await app.request(
+        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+          refinementLevel: 3,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(updateWeaponInstance).toHaveBeenCalledWith(
+        FAKE_UID,
+        'mistsplitter-reforged',
+        'instance-uuid-1',
+        3,
+      );
+    });
+  });
+
+  describe('DELETE /api/weapons/:weaponId/:weaponInstanceId', () => {
+    it('returns 204 with no body', async () => {
+      vi.mocked(deleteWeaponInstance).mockResolvedValue();
+
+      const res = await app.request(
+        authedRequest('DELETE', '/api/weapons/mistsplitter-reforged/instance-uuid-1'),
+      );
+
+      expect(res.status).toBe(204);
+      expect(await res.text()).toBe('');
+    });
+  });
+});

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -67,24 +67,26 @@ describe('Weapon routes', () => {
   });
 
   describe('GET /api/weapons', () => {
-    it('returns 200 with weapon list', async () => {
-      vi.mocked(listWeapons).mockResolvedValue([FAKE_WEAPON]);
+    it('returns 200 with weapons grouped by weaponId', async () => {
+      vi.mocked(listWeapons).mockResolvedValue({
+        'mistsplitter-reforged': [FAKE_WEAPON],
+      });
 
       const res = await app.request(authedRequest('GET', '/api/weapons'));
 
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body).toEqual([FAKE_WEAPON]);
+      expect(body).toEqual({ 'mistsplitter-reforged': [FAKE_WEAPON] });
     });
 
-    it('returns 200 with empty list when no weapons', async () => {
-      vi.mocked(listWeapons).mockResolvedValue([]);
+    it('returns 200 with empty object when no weapons', async () => {
+      vi.mocked(listWeapons).mockResolvedValue({});
 
       const res = await app.request(authedRequest('GET', '/api/weapons'));
 
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body).toEqual([]);
+      expect(body).toEqual({});
     });
   });
 

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -32,12 +32,12 @@ interface UpdateWeaponBody {
   refinementLevel?: unknown;
 }
 
-// GET /api/weapons — List all weapon instances
+// GET /api/weapons — List all weapon instances grouped by weaponId
 weapons.get('/', async (c) => {
   const userId = c.get('user').uid;
-  const items = await listWeapons(userId);
+  const grouped = await listWeapons(userId);
 
-  return c.json(items);
+  return c.json(grouped);
 });
 
 // GET /api/weapons/:weaponId — List instances of specific weapon

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { AuthVariables } from '@/middleware/auth.js';
+import { auth } from '@/middleware/auth.js';
+import {
+  createWeaponInstance,
+  deleteWeaponInstance,
+  listWeaponInstances,
+  listWeapons,
+  updateWeaponInstance,
+} from '@/repositories/weapons/index.js';
+import { getWeaponById } from '@genshin/game-data';
+import {
+  MAX_REFINEMENT_LEVEL,
+  MIN_REFINEMENT_LEVEL,
+  isValidRefinementLevel,
+  type UUID,
+} from '@genshin/types';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+export const weapons = new Hono<{ Variables: AuthVariables }>();
+
+weapons.use('*', auth);
+
+interface CreateWeaponBody {
+  refinementLevel?: unknown;
+}
+
+interface UpdateWeaponBody {
+  refinementLevel?: unknown;
+}
+
+// GET /api/weapons — List all weapon instances
+weapons.get('/', async (c) => {
+  const userId = c.get('user').uid;
+  const items = await listWeapons(userId);
+
+  return c.json(items);
+});
+
+// GET /api/weapons/:weaponId — List instances of specific weapon
+weapons.get('/:weaponId', async (c) => {
+  const userId = c.get('user').uid;
+  const { weaponId } = c.req.param();
+
+  const instances = await listWeaponInstances(userId, weaponId);
+
+  return c.json(instances);
+});
+
+// POST /api/weapons/:weaponId — Create new weapon instance
+weapons.post('/:weaponId', async (c) => {
+  const userId = c.get('user').uid;
+  const { weaponId } = c.req.param();
+
+  // Verify weaponId exists in game data
+  if (!getWeaponById(weaponId)) {
+    throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
+  }
+
+  let body: CreateWeaponBody;
+  try {
+    body = await c.req.json<CreateWeaponBody>();
+  } catch {
+    throw new HTTPException(400, { message: 'Invalid or missing JSON body' });
+  }
+
+  const { refinementLevel } = body;
+
+  if (!isValidRefinementLevel(refinementLevel)) {
+    throw new HTTPException(400, {
+      message: `refinementLevel must be an integer between ${MIN_REFINEMENT_LEVEL} and ${MAX_REFINEMENT_LEVEL}`,
+    });
+  }
+
+  const weapon = await createWeaponInstance(userId, weaponId, refinementLevel);
+
+  return c.json(weapon, 201);
+});
+
+// PUT /api/weapons/:weaponId/:weaponInstanceId — Update weapon instance
+weapons.put('/:weaponId/:weaponInstanceId', async (c) => {
+  const userId = c.get('user').uid;
+  const { weaponId } = c.req.param();
+  const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
+
+  let body: UpdateWeaponBody;
+  try {
+    body = await c.req.json<UpdateWeaponBody>();
+  } catch {
+    throw new HTTPException(400, { message: 'Invalid or missing JSON body' });
+  }
+
+  const { refinementLevel } = body;
+
+  if (!isValidRefinementLevel(refinementLevel)) {
+    throw new HTTPException(400, {
+      message: `refinementLevel must be an integer between ${MIN_REFINEMENT_LEVEL} and ${MAX_REFINEMENT_LEVEL}`,
+    });
+  }
+
+  const weapon = await updateWeaponInstance(userId, weaponId, weaponInstanceId, refinementLevel);
+
+  if (!weapon) {
+    throw new HTTPException(404, { message: 'Weapon instance not found' });
+  }
+
+  return c.json(weapon);
+});
+
+// DELETE /api/weapons/:weaponId/:weaponInstanceId — Delete weapon instance
+weapons.delete('/:weaponId/:weaponInstanceId', async (c) => {
+  const userId = c.get('user').uid;
+  const { weaponId } = c.req.param();
+  const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
+
+  await deleteWeaponInstance(userId, weaponId, weaponInstanceId);
+
+  return c.body(null, 204);
+});

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -45,6 +45,10 @@ weapons.get('/:weaponId', async (c) => {
   const userId = c.get('user').uid;
   const { weaponId } = c.req.param();
 
+  if (!getWeaponById(weaponId)) {
+    throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
+  }
+
   const instances = await listWeaponInstances(userId, weaponId);
 
   return c.json(instances);
@@ -86,6 +90,10 @@ weapons.put('/:weaponId/:weaponInstanceId', async (c) => {
   const { weaponId } = c.req.param();
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
 
+  if (!getWeaponById(weaponId)) {
+    throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
+  }
+
   let body: UpdateWeaponBody;
   try {
     body = await c.req.json<UpdateWeaponBody>();
@@ -115,6 +123,10 @@ weapons.delete('/:weaponId/:weaponInstanceId', async (c) => {
   const userId = c.get('user').uid;
   const { weaponId } = c.req.param();
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
+
+  if (!getWeaponById(weaponId)) {
+    throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
+  }
 
   await deleteWeaponInstance(userId, weaponId, weaponInstanceId);
 

--- a/apps/api/src/test/auth-requests.ts
+++ b/apps/api/src/test/auth-requests.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { verifyToken } from '@/lib/firebase/auth.js';
+
+export const FAKE_UID = 'test-user-123';
+export const FAKE_TOKEN = { uid: FAKE_UID } as Awaited<ReturnType<typeof verifyToken>>;
+
+export function authedRequest(method: string, path: string, body?: unknown) {
+  const init: RequestInit = {
+    method,
+    headers: { Authorization: 'Bearer valid-token' },
+  };
+
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { ...init.headers, 'Content-Type': 'application/json' };
+  }
+
+  return new Request(`http://localhost${path}`, init);
+}

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/test/"]
 }

--- a/packages/types/src/collectionWeapon.ts
+++ b/packages/types/src/collectionWeapon.ts
@@ -1,0 +1,27 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+import type { Weapon } from '@genshin/game-data';
+
+import type { ISOTimestamp } from './isoTimestamp.js';
+import type { UUID } from './uuid.js';
+
+export const MIN_REFINEMENT_LEVEL = 1;
+export const MAX_REFINEMENT_LEVEL = 5;
+
+export interface CollectionWeapon {
+  weaponInstanceId: UUID;
+  weaponId: Weapon['id'];
+  refinementLevel: number;
+  createdAt: ISOTimestamp;
+  updatedAt: ISOTimestamp;
+}
+
+export function isValidRefinementLevel(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= MIN_REFINEMENT_LEVEL &&
+    value <= MAX_REFINEMENT_LEVEL
+  );
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,12 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 export {
+  isValidConstellationLevel,
   MAX_CONSTELLATION_LEVEL,
   MIN_CONSTELLATION_LEVEL,
-  isValidConstellationLevel,
   type CollectionCharacter,
 } from './collectionCharacter.js';
+export {
+  isValidRefinementLevel,
+  MAX_REFINEMENT_LEVEL,
+  MIN_REFINEMENT_LEVEL,
+  type CollectionWeapon,
+} from './collectionWeapon.js';
 export type { ISOTimestamp } from './isoTimestamp.js';
 export type { Team, TeamSlot } from './team.js';
 export type { ArtifactPlan, TeamMember } from './teamMember.js';
 export type { User } from './user.js';
+export type { UUID } from './uuid.js';

--- a/packages/types/src/uuid.ts
+++ b/packages/types/src/uuid.ts
@@ -1,0 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+declare const __brand: unique symbol;
+
+export type UUID = string & { readonly [__brand]: 'UUID' };


### PR DESCRIPTION
## Summary

Implements weapon collection-of-collections CRUD API, allowing users to own multiple instances of the same weapon with individual refinement levels.

Closes #45

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/weapons/:weaponId` | Create new weapon instance |
| GET | `/api/weapons` | List all weapon instances |
| GET | `/api/weapons/:weaponId` | List instances of specific weapon |
| PUT | `/api/weapons/:weaponId/:weaponInstanceId` | Update refinement level |
| DELETE | `/api/weapons/:weaponId/:weaponInstanceId` | Delete instance |

## New files

- `packages/types/src/collectionWeapon.ts` — `CollectionWeapon` type, refinement level validator
- `packages/types/src/uuid.ts` — branded `UUID` type for type-safe instance IDs
- `apps/api/src/repositories/weapons/` — Firestore repository (`users/{uid}/weapons/{weaponId}/instances`)
- `apps/api/src/routes/weapons.ts` — route handler
- `apps/api/src/routes/weapons.test.ts` — 22 integration tests
- `apps/api/src/test/auth-requests.ts` — shared test helper extracted from characters + weapons tests

## Modified files

- `apps/api/src/app.ts` — register `/api/weapons` route
- `packages/types/src/index.ts` — export new types
- `apps/api/src/routes/characters.test.ts` — use shared `auth-requests` helper
- `apps/api/tsconfig.build.json` — exclude `src/test/` from production build

## Design decisions

- **Collection-of-collections**: hierarchical Firestore path supports multiple instances per weapon
- **Branded UUID**: `weaponInstanceId` uses a branded `UUID` type for compile-time safety
- **Level deferred**: weapon level tracking moved to #453 (mirrors characters approach in #444)
- **MVP scope**: tracks refinement level (R1–R5) only; validates against game-data weapon IDs