### PR TITLE
docs: document API conventions and documentation strategy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,9 @@
 - Use ISO 8601 strings for timestamps such as `createdAt` and `updatedAt`, not `Date` objects.
 - Maintain game-data accuracy when working with `packages/game-data`.
 - Test alongside code when possible; the API has Vitest coverage, but web and UI testing is planned and not yet implemented.
+- Each branded type in `packages/types/` gets its own file (for example, `uuid.ts`, `isoTimestamp.ts`).
+- Shared API test utilities go in `apps/api/src/test/` with descriptive names (not generic names like "helpers"). This directory is excluded from production builds via `tsconfig.build.json`.
+- Use descriptive, specific file names. Avoid generic names like "helpers."
 
 ## Build and CI rules
 
@@ -72,10 +75,12 @@
 
 ## Documentation rules
 
-- Put information in the right place:
-  - `CONTRIBUTING.md` for human workflow guidance.
-  - `.github/copilot-instructions.md` for AI decision rules.
-  - `docs/` for task-specific how-tos and deeper explanations.
+- Put information in the right place, in this priority order:
+  1. Inline comments explaining _why_ code works a certain way.
+  2. Documentation strings on functions or modules.
+  3. `docs/` for how-tos, references, and explanations following [Diátaxis](https://diataxis.fr/).
+  4. `CONTRIBUTING.md` for human workflow guidance.
+  5. `.github/copilot-instructions.md` for AI decision rules.
 - Prefer this order when documenting decisions: inline comments, documentation strings, updates to existing docs, then new long-form docs.
 - Keep docs accurate to `HEAD`: verify dependencies, command availability, and feature status.
 - Run Vale through pre-commit (`pre-commit run vale --all-files`), not `vale .`. Vale has no directory-ignore mechanism and scans everything, including `node_modules`. For targeted checks on specific files, use `vale <filename>` directly.
@@ -103,6 +108,8 @@
 - Never use `git commit --amend` or `git push --force`.
 - Fixes after hook failures should be new commits; squash merge handles cleanup.
 - For GitHub issues, track dependencies only with native issue relationships (`blocked by` / `is blocking`), not issue body text or comments.
+- Prefer filing follow-up issues for out-of-scope concerns over expanding a PR.
+- Evaluate automated PR review suggestions critically. Verify that a suggestion actually solves the stated problem before applying it.
 
 ## Shell script rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,30 @@ For complex logic, decisions, or subtle patterns:
 - Performance-sensitive code—explain the optimization
 - External dependencies—integration quirks or API specifics
 
+### Documentation strategy
+
+When documenting decisions or conventions, prefer the highest-priority location that fits:
+
+1. **Inline comments**: explain _why_ code works a certain way.
+2. **Documentation strings**: explain module or function purpose when the name isn't sufficient.
+3. **`docs/`**: task-specific how-tos, references, and explanations following the [Diátaxis](https://diataxis.fr/) framework.
+4. **`CONTRIBUTING.md`**: high-level human workflow guidance and project conventions.
+5. **`.github/copilot-instructions.md`**: AI-specific decision rules.
+
+Avoid duplicating the same guidance across multiple locations. Place it once at the most appropriate level and link to it from others.
+
+### Naming conventions
+
+Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`.
+
+### Shared types
+
+Branded types in `packages/types/` each get their own file (for example, `uuid.ts`, `isoTimestamp.ts`). Export both the type and any related validation functions from the same file.
+
+### Test utilities
+
+Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The build excludes this directory via `tsconfig.build.json`.
+
 ---
 
 ## Pull request workflow

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -76,6 +76,9 @@ export async function createWeaponInstance(
     updatedAt: now,
   };
 
+  // Batch write: create the parent weapon doc so listWeapons() can discover it
+  // via listDocuments(), then create the instance doc. The parent doc is an
+  // empty anchor; see #455 for the planned collectionGroup redesign.
   const batch = db.batch();
   batch.set(
     db.collection('users').doc(userId).collection('weapons').doc(weaponId),


### PR DESCRIPTION
Captures lessons learned from the weapon API implementation (#45 / #454) into the appropriate documentation locations, following the documentation strategy priority order.

## Changes

### Inline comment (level 1)
- Added comment on `createWeaponInstance` batch write explaining why the parent weapon doc is created as an anchor for `listDocuments()` discovery, with a reference to #455.

### CONTRIBUTING.md (level 4)
- **Documentation strategy**: Added the 5-level priority order for where to place documentation.
- **Naming conventions**: Prefer descriptive file names over generic ones.
- **Shared types**: Branded types in `packages/types/` each get their own file.
- **Test utilities**: Shared API test utilities live in `apps/api/src/test/`, excluded from builds.

### copilot-instructions.md (level 5)
- Added branded types and test utilities conventions to core coding rules.
- Added descriptive file naming rule.
- Expanded documentation rules with the full 5-level priority order.
- Added workflow guardrails: prefer follow-up issues over scope creep, evaluate automated PR review suggestions critically.