### PR TITLE
fix(bootstrap): grant firebase.viewer to RO service account

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -80,6 +80,16 @@ resource "google_project_iam_member" "github_deployer_ro_datastore_viewer" {
   member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
 }
 
+# Required for Terraform plan refresh of `google_firebase_web_app`.
+# The custom role includes `firebase.clients.get` and `firebase.projects.get`,
+# but the google-beta provider requires additional permissions covered by this
+# predefined role; track tightening in a follow-up issue.
+resource "google_project_iam_member" "github_deployer_ro_firebase_viewer" {
+  project = google_project.env.project_id
+  role    = "roles/firebase.viewer"
+  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+}
+
 resource "google_storage_bucket_iam_member" "github_deployer_ro_state_bucket" {
   bucket = var.state_bucket_name
   role   = "roles/storage.objectViewer"


### PR DESCRIPTION
## Summary

Grant the predefined `roles/firebase.viewer` role to the read-only (planner) service account so that Terraform plan can refresh `google_firebase_web_app` resources without a 403 error.

## Motivation

The Terraform Plan CI check fails on any PR that triggers a plan against the dev environment because the RO service account lacks sufficient permissions to read Firebase web app state. The custom role includes `firebase.clients.get` and `firebase.projects.get`, but the `google-beta` provider requires additional permissions covered by the predefined `roles/firebase.viewer` role.

## Changes

- Add `google_project_iam_member.github_deployer_ro_firebase_viewer` in the bootstrap module, granting `roles/firebase.viewer` to the RO service account (same pattern as the existing `roles/datastore.viewer` grant).

## Notes

- Already applied manually to `dungeon-studio-genshin-dev`; PR #441 CI now passes.
- Tightening this grant to a narrower set of permissions is tracked in #458.