### PR TITLE
Add collection+json representation layer and @genshin/collection-json package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Build
         run: pnpm turbo run build --filter=@genshin/api
 
-  packages:
-    name: Packages
+  game-data:
+    name: Game Data
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -81,15 +81,62 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      - name: Build packages
-        run: pnpm turbo run build --filter="./packages/**"
+      - name: Build
+        run: pnpm turbo run build --filter=@genshin/game-data
 
-      - name: Typecheck packages
-        run: pnpm turbo run typecheck --filter="./packages/**"
+      - name: Typecheck
+        run: pnpm turbo run typecheck --filter=@genshin/game-data
+
+  types:
+    name: Types
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Build
+        run: pnpm turbo run build --filter=@genshin/types
+
+      - name: Typecheck
+        run: pnpm turbo run typecheck --filter=@genshin/types
+
+  collection-json:
+    name: Collection JSON
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Test
+        run: pnpm turbo run test --filter=@genshin/collection-json -- --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/collection-json/coverage/lcov.info
+          flags: collection-json
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/collection-json/test-results/junit.xml
+          flags: collection-json
+          report_type: test_results
+          fail_ci_if_error: false
 
 # ---------------------------------------------------------------------------
 # Maintenance notes
-# - Add a new job when new apps are added.
-# - Package builds are grouped under the Packages job.
+# - Add a new job when new apps or packages are added.
 # - Keep caching strategy aligned with package manager changes.
 # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,12 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
+      - name: Build
+        run: pnpm turbo run build --filter=@genshin/collection-json
+
+      - name: Typecheck
+        run: pnpm turbo run typecheck --filter=@genshin/collection-json
+
       - name: Test
         run: pnpm turbo run test --filter=@genshin/collection-json -- --coverage
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit && tsc --project tsconfig.scripts.json --noEmit"
   },
   "dependencies": {
+    "@genshin/collection-json": "workspace:*",
     "@genshin/game-data": "workspace:*",
     "@genshin/types": "workspace:*",
     "@hono/node-server": "1.19.11",

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -16,20 +16,18 @@ function collectionRef(userId: string, weaponId: string) {
     .collection('instances');
 }
 
-export async function listWeapons(userId: string): Promise<Record<string, CollectionWeapon[]>> {
+export async function listWeapons(userId: string): Promise<CollectionWeapon[]> {
   const weaponsRef = db.collection('users').doc(userId).collection('weapons');
   const weaponDocs = await weaponsRef.listDocuments();
 
-  const results: Record<string, CollectionWeapon[]> = {};
+  const results: CollectionWeapon[] = [];
 
   for (const weaponDoc of weaponDocs) {
     const snapshot = await weaponDoc.collection('instances').get();
     const instances = snapshot.docs.map((doc) =>
       fromDocument(doc.id as UUID, weaponDoc.id, doc.data() as DocumentData),
     );
-    if (instances.length > 0) {
-      results[weaponDoc.id] = instances;
-    }
+    results.push(...instances);
   }
 
   return results;

--- a/apps/api/src/representations/collection-json/characters.ts
+++ b/apps/api/src/representations/collection-json/characters.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/**
+ * Character domain → Collection+JSON representation.
+ *
+ * Maps CollectionCharacter domain objects to the collection+json wire format.
+ * No framework dependencies — only domain types and collection+json builders.
+ */
+
+import type { CollectionCharacter } from '@genshin/types';
+import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/types';
+
+import {
+  buildCollection,
+  buildItem,
+  type CollectionDocument,
+  type CollectionJsonRepresentation,
+  type Item,
+  type Template,
+} from '@genshin/collection-json';
+
+const CHARACTER_TEMPLATE: Template = {
+  data: [
+    {
+      name: 'constellationLevel',
+      prompt: `Constellation level (${MIN_CONSTELLATION_LEVEL}-${MAX_CONSTELLATION_LEVEL})`,
+    },
+  ],
+};
+
+export function characterToItem(character: CollectionCharacter, baseUrl: string): Item {
+  return buildItem(`${baseUrl}/api/characters/${character.characterId}`, [
+    { name: 'characterId', value: character.characterId },
+    { name: 'constellationLevel', value: character.constellationLevel },
+    { name: 'createdAt', value: character.createdAt },
+    { name: 'updatedAt', value: character.updatedAt },
+  ]);
+}
+
+export function characterListDocument(
+  characters: CollectionCharacter[],
+  baseUrl: string,
+): CollectionDocument {
+  return buildCollection(
+    `${baseUrl}/api/characters`,
+    characters.map((c) => characterToItem(c, baseUrl)),
+    { template: CHARACTER_TEMPLATE },
+  );
+}
+
+export function characterItemDocument(
+  character: CollectionCharacter,
+  baseUrl: string,
+): CollectionDocument {
+  return buildCollection(
+    `${baseUrl}/api/characters/${character.characterId}`,
+    [characterToItem(character, baseUrl)],
+    { template: CHARACTER_TEMPLATE },
+  );
+}
+
+// Compile-time enforcement: every required mapping function exists and has the right shape.
+const _characterRepresentation = {
+  toItem: characterToItem,
+  listDocument: characterListDocument,
+  itemDocument: characterItemDocument,
+} satisfies CollectionJsonRepresentation<CollectionCharacter>;
+void _characterRepresentation;

--- a/apps/api/src/representations/collection-json/weapons.ts
+++ b/apps/api/src/representations/collection-json/weapons.ts
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/**
+ * Weapon domain → Collection+JSON representation.
+ *
+ * Maps CollectionWeapon domain objects to the collection+json wire format.
+ * No framework dependencies — only domain types and collection+json builders.
+ */
+
+import type { CollectionWeapon } from '@genshin/types';
+import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/types';
+
+import {
+  buildCollection,
+  buildItem,
+  type CollectionDocument,
+  type CollectionJsonRepresentation,
+  type Item,
+  type Link,
+  type Template,
+} from '@genshin/collection-json';
+
+const WEAPON_TEMPLATE: Template = {
+  data: [
+    {
+      name: 'refinementLevel',
+      prompt: `Refinement level (${MIN_REFINEMENT_LEVEL}-${MAX_REFINEMENT_LEVEL})`,
+    },
+  ],
+};
+
+function weaponItemHref(baseUrl: string, weapon: CollectionWeapon): string {
+  return `${baseUrl}/api/weapons/${weapon.weaponId}/${weapon.weaponInstanceId}`;
+}
+
+export function weaponToItem(weapon: CollectionWeapon, baseUrl: string): Item {
+  const links: Link[] = [
+    {
+      rel: 'collection',
+      href: `${baseUrl}/api/weapons/${weapon.weaponId}`,
+      prompt: `All instances of ${weapon.weaponId}`,
+    },
+  ];
+
+  return buildItem(
+    weaponItemHref(baseUrl, weapon),
+    [
+      { name: 'weaponInstanceId', value: weapon.weaponInstanceId },
+      { name: 'weaponId', value: weapon.weaponId },
+      { name: 'refinementLevel', value: weapon.refinementLevel },
+      { name: 'createdAt', value: weapon.createdAt },
+      { name: 'updatedAt', value: weapon.updatedAt },
+    ],
+    links,
+  );
+}
+
+export function weaponListDocument(
+  weapons: CollectionWeapon[],
+  baseUrl: string,
+): CollectionDocument {
+  return buildCollection(
+    `${baseUrl}/api/weapons`,
+    weapons.map((w) => weaponToItem(w, baseUrl)),
+    {
+      template: WEAPON_TEMPLATE,
+      queries: [
+        {
+          rel: 'search',
+          href: `${baseUrl}/api/weapons`,
+          prompt: 'Filter by weapon',
+          data: [{ name: 'weaponId', prompt: 'Weapon ID' }],
+        },
+      ],
+    },
+  );
+}
+
+export function weaponInstanceListDocument(
+  weapons: CollectionWeapon[],
+  weaponId: string,
+  baseUrl: string,
+): CollectionDocument {
+  return buildCollection(
+    `${baseUrl}/api/weapons/${weaponId}`,
+    weapons.map((w) => weaponToItem(w, baseUrl)),
+    { template: WEAPON_TEMPLATE },
+  );
+}
+
+export function weaponItemDocument(weapon: CollectionWeapon, baseUrl: string): CollectionDocument {
+  return buildCollection(weaponItemHref(baseUrl, weapon), [weaponToItem(weapon, baseUrl)], {
+    template: WEAPON_TEMPLATE,
+  });
+}
+
+// Compile-time enforcement: every required mapping function exists and has the right shape.
+// Resource-specific extras (weaponInstanceListDocument) live outside the contract.
+const _weaponRepresentation = {
+  toItem: weaponToItem,
+  listDocument: weaponListDocument,
+  itemDocument: weaponItemDocument,
+} satisfies CollectionJsonRepresentation<CollectionWeapon>;
+void _weaponRepresentation;

--- a/apps/api/src/representations/collection-json/weapons.ts
+++ b/apps/api/src/representations/collection-json/weapons.ts
@@ -30,7 +30,7 @@ const WEAPON_TEMPLATE: Template = {
   ],
 };
 
-function weaponItemHref(baseUrl: string, weapon: CollectionWeapon): string {
+export function weaponItemHref(baseUrl: string, weapon: CollectionWeapon): string {
   return `${baseUrl}/api/weapons/${weapon.weaponId}/${weapon.weaponInstanceId}`;
 }
 
@@ -63,17 +63,7 @@ export function weaponListDocument(
   return buildCollection(
     `${baseUrl}/api/weapons`,
     weapons.map((w) => weaponToItem(w, baseUrl)),
-    {
-      template: WEAPON_TEMPLATE,
-      queries: [
-        {
-          rel: 'search',
-          href: `${baseUrl}/api/weapons`,
-          prompt: 'Filter by weapon',
-          data: [{ name: 'weaponId', prompt: 'Weapon ID' }],
-        },
-      ],
-    },
+    { template: WEAPON_TEMPLATE },
   );
 }
 

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -28,6 +28,7 @@ import {
   saveCharacter,
 } from '@/repositories/characters/index.js';
 import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
+import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 import { getCharacterById } from '@genshin/game-data';
 import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/types';
 
@@ -61,39 +62,98 @@ describe('Character routes', () => {
 
       expect(res.status).toBe(401);
     });
-  });
 
-  describe('GET /api/characters', () => {
-    it('returns 200 with character list', async () => {
-      vi.mocked(listCharacters).mockResolvedValue([FAKE_CHARACTER]);
+    it('returns 401 when token is expired', async () => {
+      vi.mocked(verifyToken).mockRejectedValue({ code: 'auth/id-token-expired' });
 
       const res = await app.request(authedRequest('GET', '/api/characters'));
 
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual([FAKE_CHARACTER]);
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Invalid or expired token');
+    });
+  });
+
+  describe('GET /api/characters', () => {
+    let res: Response;
+    let body: CollectionDocument;
+
+    beforeEach(async () => {
+      vi.mocked(listCharacters).mockResolvedValue([FAKE_CHARACTER]);
+      res = await app.request(authedRequest('GET', '/api/characters'));
+      body = (await res.json()) as CollectionDocument;
     });
 
-    it('returns 200 with empty list when no characters', async () => {
+    it('returns 200', () => {
+      expect(res.status).toBe(200);
+    });
+
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
+    });
+
+    it('returns one item per character', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes character domain data', () => {
+      expect(body.collection.items[0].data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'characterId', value: 'albedo' }),
+          expect.objectContaining({ name: 'constellationLevel', value: 2 }),
+        ]),
+      );
+    });
+
+    it('returns empty items when no characters exist', async () => {
       vi.mocked(listCharacters).mockResolvedValue([]);
 
       const res = await app.request(authedRequest('GET', '/api/characters'));
 
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual([]);
+      const body = (await res.json()) as CollectionDocument;
+      expect(body.collection.items).toEqual([]);
+    });
+
+    it('returns 500 when repository throws', async () => {
+      vi.mocked(listCharacters).mockRejectedValue(new Error('Firestore unavailable'));
+
+      const res = await app.request(authedRequest('GET', '/api/characters'));
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('An unexpected error occurred');
     });
   });
 
   describe('GET /api/characters/:characterId', () => {
-    it('returns 200 with character', async () => {
+    let res: Response;
+    let body: CollectionDocument;
+
+    beforeEach(async () => {
       vi.mocked(getCharacter).mockResolvedValue(FAKE_CHARACTER);
+      res = await app.request(authedRequest('GET', '/api/characters/albedo'));
+      body = (await res.json()) as CollectionDocument;
+    });
 
-      const res = await app.request(authedRequest('GET', '/api/characters/albedo'));
-
+    it('returns 200', () => {
       expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual(FAKE_CHARACTER);
+    });
+
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
+    });
+
+    it('returns single-item collection', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes character domain data', () => {
+      expect(body.collection.items[0].data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'characterId', value: 'albedo' }),
+          expect.objectContaining({ name: 'constellationLevel', value: 2 }),
+        ]),
+      );
     });
 
     it('returns 404 when character not in collection', async () => {
@@ -115,19 +175,39 @@ describe('Character routes', () => {
       } as ReturnType<typeof getCharacterById>);
     });
 
-    it('returns 201 when character is newly added', async () => {
+    let res: Response;
+    let body: CollectionDocument;
+
+    beforeEach(async () => {
       vi.mocked(saveCharacter).mockResolvedValue({
         character: FAKE_CHARACTER,
         created: true,
       });
-
-      const res = await app.request(
+      res = await app.request(
         authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2 }),
       );
+      body = (await res.json()) as CollectionDocument;
+    });
 
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
+    });
+
+    it('returns single-item collection', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes character domain data', () => {
+      expect(body.collection.items[0].data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'characterId', value: 'albedo' }),
+          expect.objectContaining({ name: 'constellationLevel', value: 2 }),
+        ]),
+      );
+    });
+
+    it('returns 201 when character is newly added', () => {
       expect(res.status).toBe(201);
-      const body = await res.json();
-      expect(body).toEqual(FAKE_CHARACTER);
     });
 
     it('returns 200 when character is updated', async () => {
@@ -141,8 +221,6 @@ describe('Character routes', () => {
       );
 
       expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual(FAKE_CHARACTER);
     });
 
     it('returns 400 for unknown character ID', async () => {
@@ -250,6 +328,14 @@ describe('Character routes', () => {
 
       expect(res.status).toBe(204);
       expect(await res.text()).toBe('');
+    });
+
+    it('returns 204 when character does not exist', async () => {
+      vi.mocked(deleteCharacter).mockResolvedValue();
+
+      const res = await app.request(authedRequest('DELETE', '/api/characters/nonexistent'));
+
+      expect(res.status).toBe(204);
     });
   });
 });

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -9,6 +9,11 @@ import {
   listCharacters,
   saveCharacter,
 } from '@/repositories/characters/index.js';
+import {
+  characterItemDocument,
+  characterListDocument,
+} from '@/representations/collection-json/characters.js';
+import { COLLECTION_JSON } from '@genshin/collection-json';
 import { getCharacterById } from '@genshin/game-data';
 import {
   MAX_CONSTELLATION_LEVEL,
@@ -30,8 +35,11 @@ interface SaveCharacterBody {
 characters.get('/', async (c) => {
   const userId = c.get('user').uid;
   const items = await listCharacters(userId);
+  const baseUrl = new URL(c.req.url).origin;
 
-  return c.json(items);
+  return c.body(JSON.stringify(characterListDocument(items, baseUrl)), {
+    headers: { 'Content-Type': COLLECTION_JSON },
+  });
 });
 
 // GET /api/characters/:characterId — Get specific character record
@@ -45,7 +53,11 @@ characters.get('/:characterId', async (c) => {
     throw new HTTPException(404, { message: 'Character not found in collection' });
   }
 
-  return c.json(character);
+  const baseUrl = new URL(c.req.url).origin;
+
+  return c.body(JSON.stringify(characterItemDocument(character, baseUrl)), {
+    headers: { 'Content-Type': COLLECTION_JSON },
+  });
 });
 
 // PUT /api/characters/:characterId — Save/update character (idempotent upsert)
@@ -74,8 +86,12 @@ characters.put('/:characterId', async (c) => {
   }
 
   const { character, created } = await saveCharacter(userId, characterId, constellationLevel);
+  const baseUrl = new URL(c.req.url).origin;
 
-  return c.json(character, created ? 201 : 200);
+  return c.body(JSON.stringify(characterItemDocument(character, baseUrl)), {
+    status: created ? 201 : 200,
+    headers: { 'Content-Type': COLLECTION_JSON },
+  });
 });
 
 // DELETE /api/characters/:characterId — Remove from collection

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -217,6 +217,12 @@ describe('Weapon routes', () => {
       expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
     });
 
+    it('returns Location header pointing to created instance', () => {
+      expect(res.headers.get('location')).toBe(
+        'http://localhost/api/weapons/mistsplitter-reforged/instance-uuid-1',
+      );
+    });
+
     it('returns single-item collection', () => {
       expect(body.collection.items).toHaveLength(1);
     });

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -30,6 +30,7 @@ import {
   updateWeaponInstance,
 } from '@/repositories/weapons/index.js';
 import { FAKE_TOKEN, FAKE_UID, authedRequest } from '@/test/auth-requests.js';
+import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 import { getWeaponById } from '@genshin/game-data';
 import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/types';
 
@@ -40,6 +41,14 @@ const FAKE_WEAPON: CollectionWeapon = {
   createdAt: '2026-01-01T00:00:00.000Z' as CollectionWeapon['createdAt'],
   updatedAt: '2026-03-13T00:00:00.000Z' as CollectionWeapon['updatedAt'],
 };
+
+const FAKE_WEAPON_ITEM_DATA = [
+  { name: 'weaponInstanceId', value: 'instance-uuid-1' },
+  { name: 'weaponId', value: 'mistsplitter-reforged' },
+  { name: 'refinementLevel', value: 1 },
+  { name: 'createdAt', value: '2026-01-01T00:00:00.000Z' },
+  { name: 'updatedAt', value: '2026-03-13T00:00:00.000Z' },
+];
 
 describe('Weapon routes', () => {
   beforeEach(() => {
@@ -64,58 +73,111 @@ describe('Weapon routes', () => {
 
       expect(res.status).toBe(401);
     });
+
+    it('returns 401 when token is expired', async () => {
+      vi.mocked(verifyToken).mockRejectedValue({ code: 'auth/id-token-expired' });
+
+      const res = await app.request(authedRequest('GET', '/api/weapons'));
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Invalid or expired token');
+    });
   });
 
   describe('GET /api/weapons', () => {
-    it('returns 200 with weapons grouped by weaponId', async () => {
-      vi.mocked(listWeapons).mockResolvedValue({
-        'mistsplitter-reforged': [FAKE_WEAPON],
-      });
+    let res: Response;
+    let body: CollectionDocument;
 
-      const res = await app.request(authedRequest('GET', '/api/weapons'));
-
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual({ 'mistsplitter-reforged': [FAKE_WEAPON] });
+    beforeEach(async () => {
+      vi.mocked(listWeapons).mockResolvedValue([FAKE_WEAPON]);
+      res = await app.request(authedRequest('GET', '/api/weapons'));
+      body = (await res.json()) as CollectionDocument;
     });
 
-    it('returns 200 with empty object when no weapons', async () => {
-      vi.mocked(listWeapons).mockResolvedValue({});
+    it('returns 200', () => {
+      expect(res.status).toBe(200);
+    });
+
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
+    });
+
+    it('returns one item per weapon', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes weapon domain data', () => {
+      expect(body.collection.items[0].data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'weaponId', value: 'mistsplitter-reforged' }),
+          expect.objectContaining({ name: 'refinementLevel', value: 1 }),
+        ]),
+      );
+    });
+
+    it('returns empty items when no weapons exist', async () => {
+      vi.mocked(listWeapons).mockResolvedValue([]);
 
       const res = await app.request(authedRequest('GET', '/api/weapons'));
 
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual({});
+      const body = (await res.json()) as CollectionDocument;
+      expect(body.collection.items).toEqual([]);
+    });
+
+    it('returns 500 when repository throws', async () => {
+      vi.mocked(listWeapons).mockRejectedValue(new Error('Firestore unavailable'));
+
+      const res = await app.request(authedRequest('GET', '/api/weapons'));
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('An unexpected error occurred');
     });
   });
 
   describe('GET /api/weapons/:weaponId', () => {
-    beforeEach(() => {
+    let res: Response;
+    let body: CollectionDocument;
+
+    beforeEach(async () => {
       vi.mocked(getWeaponById).mockReturnValue({
         id: 'mistsplitter-reforged',
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
-    });
-
-    it('returns 200 with instances of specific weapon', async () => {
       vi.mocked(listWeaponInstances).mockResolvedValue([FAKE_WEAPON]);
-
-      const res = await app.request(authedRequest('GET', '/api/weapons/mistsplitter-reforged'));
-
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual([FAKE_WEAPON]);
+      res = await app.request(authedRequest('GET', '/api/weapons/mistsplitter-reforged'));
+      body = (await res.json()) as CollectionDocument;
     });
 
-    it('returns 200 with empty list when no instances', async () => {
+    it('returns 200', () => {
+      expect(res.status).toBe(200);
+    });
+
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
+    });
+
+    it('returns one item per instance', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes weapon domain data', () => {
+      expect(body.collection.items[0].data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'weaponId', value: 'mistsplitter-reforged' }),
+          expect.objectContaining({ name: 'refinementLevel', value: 1 }),
+        ]),
+      );
+    });
+
+    it('returns empty items when no instances exist', async () => {
       vi.mocked(listWeaponInstances).mockResolvedValue([]);
 
       const res = await app.request(authedRequest('GET', '/api/weapons/mistsplitter-reforged'));
 
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual([]);
+      const body = (await res.json()) as CollectionDocument;
+      expect(body.collection.items).toEqual([]);
     });
 
     it('returns 400 for unknown weapon ID', async () => {
@@ -130,25 +192,37 @@ describe('Weapon routes', () => {
   });
 
   describe('POST /api/weapons/:weaponId', () => {
-    beforeEach(() => {
+    let res: Response;
+    let body: CollectionDocument;
+
+    beforeEach(async () => {
       vi.mocked(getWeaponById).mockReturnValue({
         id: 'mistsplitter-reforged',
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
-    });
-
-    it('returns 201 when weapon instance is created', async () => {
       vi.mocked(createWeaponInstance).mockResolvedValue(FAKE_WEAPON);
-
-      const res = await app.request(
+      res = await app.request(
         authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
           refinementLevel: 1,
         }),
       );
+      body = (await res.json()) as CollectionDocument;
+    });
 
+    it('returns 201', () => {
       expect(res.status).toBe(201);
-      const body = await res.json();
-      expect(body).toEqual(FAKE_WEAPON);
+    });
+
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
+    });
+
+    it('returns single-item collection', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes weapon domain data', () => {
+      expect(body.collection.items[0].data).toEqual(FAKE_WEAPON_ITEM_DATA);
     });
 
     it('returns 400 for unknown weapon ID', async () => {
@@ -257,25 +331,37 @@ describe('Weapon routes', () => {
   });
 
   describe('PUT /api/weapons/:weaponId/:weaponInstanceId', () => {
-    beforeEach(() => {
+    let res: Response;
+    let body: CollectionDocument;
+
+    beforeEach(async () => {
       vi.mocked(getWeaponById).mockReturnValue({
         id: 'mistsplitter-reforged',
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
-    });
-
-    it('returns 200 when weapon instance is updated', async () => {
       vi.mocked(updateWeaponInstance).mockResolvedValue(FAKE_WEAPON);
-
-      const res = await app.request(
+      res = await app.request(
         authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
           refinementLevel: 1,
         }),
       );
+      body = (await res.json()) as CollectionDocument;
+    });
 
+    it('returns 200', () => {
       expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual(FAKE_WEAPON);
+    });
+
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(COLLECTION_JSON);
+    });
+
+    it('returns single-item collection', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes weapon domain data', () => {
+      expect(body.collection.items[0].data).toEqual(FAKE_WEAPON_ITEM_DATA);
     });
 
     it('returns 404 when weapon instance not found', async () => {

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -10,6 +10,12 @@ import {
   listWeapons,
   updateWeaponInstance,
 } from '@/repositories/weapons/index.js';
+import {
+  weaponInstanceListDocument,
+  weaponItemDocument,
+  weaponListDocument,
+} from '@/representations/collection-json/weapons.js';
+import { COLLECTION_JSON } from '@genshin/collection-json';
 import { getWeaponById } from '@genshin/game-data';
 import {
   MAX_REFINEMENT_LEVEL,
@@ -32,12 +38,15 @@ interface UpdateWeaponBody {
   refinementLevel?: unknown;
 }
 
-// GET /api/weapons — List all weapon instances grouped by weaponId
+// GET /api/weapons — List all weapon instances as a flat collection
 weapons.get('/', async (c) => {
   const userId = c.get('user').uid;
-  const grouped = await listWeapons(userId);
+  const items = await listWeapons(userId);
+  const baseUrl = new URL(c.req.url).origin;
 
-  return c.json(grouped);
+  return c.body(JSON.stringify(weaponListDocument(items, baseUrl)), {
+    headers: { 'Content-Type': COLLECTION_JSON },
+  });
 });
 
 // GET /api/weapons/:weaponId — List instances of specific weapon
@@ -50,8 +59,11 @@ weapons.get('/:weaponId', async (c) => {
   }
 
   const instances = await listWeaponInstances(userId, weaponId);
+  const baseUrl = new URL(c.req.url).origin;
 
-  return c.json(instances);
+  return c.body(JSON.stringify(weaponInstanceListDocument(instances, weaponId, baseUrl)), {
+    headers: { 'Content-Type': COLLECTION_JSON },
+  });
 });
 
 // POST /api/weapons/:weaponId — Create new weapon instance
@@ -80,8 +92,12 @@ weapons.post('/:weaponId', async (c) => {
   }
 
   const weapon = await createWeaponInstance(userId, weaponId, refinementLevel);
+  const baseUrl = new URL(c.req.url).origin;
 
-  return c.json(weapon, 201);
+  return c.body(JSON.stringify(weaponItemDocument(weapon, baseUrl)), {
+    status: 201,
+    headers: { 'Content-Type': COLLECTION_JSON },
+  });
 });
 
 // PUT /api/weapons/:weaponId/:weaponInstanceId — Update weapon instance
@@ -115,7 +131,11 @@ weapons.put('/:weaponId/:weaponInstanceId', async (c) => {
     throw new HTTPException(404, { message: 'Weapon instance not found' });
   }
 
-  return c.json(weapon);
+  const baseUrl = new URL(c.req.url).origin;
+
+  return c.body(JSON.stringify(weaponItemDocument(weapon, baseUrl)), {
+    headers: { 'Content-Type': COLLECTION_JSON },
+  });
 });
 
 // DELETE /api/weapons/:weaponId/:weaponInstanceId — Delete weapon instance

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -13,6 +13,7 @@ import {
 import {
   weaponInstanceListDocument,
   weaponItemDocument,
+  weaponItemHref,
   weaponListDocument,
 } from '@/representations/collection-json/weapons.js';
 import { COLLECTION_JSON } from '@genshin/collection-json';
@@ -94,9 +95,12 @@ weapons.post('/:weaponId', async (c) => {
   const weapon = await createWeaponInstance(userId, weaponId, refinementLevel);
   const baseUrl = new URL(c.req.url).origin;
 
-  return c.body(JSON.stringify(weaponItemDocument(weapon, baseUrl)), {
+  return c.body(JSON.stringify(weaponInstanceListDocument([weapon], weaponId, baseUrl)), {
     status: 201,
-    headers: { 'Content-Type': COLLECTION_JSON },
+    headers: {
+      'Content-Type': COLLECTION_JSON,
+      Location: weaponItemHref(baseUrl, weapon),
+    },
   });
 });
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,3 +22,45 @@ flag_management:
     - name: api
       paths:
         - apps/api/src/**
+    - name: collection-json
+      paths:
+        - packages/collection-json/src/**
+
+component_management:
+  individual_components:
+    - component_id: api-routes
+      name: 'API: Routes'
+      paths:
+        - apps/api/src/routes/**
+      flag_regexes:
+        - api
+    - component_id: api-repositories
+      name: 'API: Repositories'
+      paths:
+        - apps/api/src/repositories/**
+      flag_regexes:
+        - api
+    - component_id: api-middleware
+      name: 'API: Middleware'
+      paths:
+        - apps/api/src/middleware/**
+      flag_regexes:
+        - api
+    - component_id: api-representations
+      name: 'API: Representations'
+      paths:
+        - apps/api/src/representations/**
+      flag_regexes:
+        - api
+    - component_id: api-firebase
+      name: 'API: Firebase'
+      paths:
+        - apps/api/src/lib/firebase/**
+      flag_regexes:
+        - api
+    - component_id: collection-json
+      name: Collection JSON
+      paths:
+        - packages/collection-json/src/**
+      flag_regexes:
+        - collection-json

--- a/packages/collection-json/eslint.config.js
+++ b/packages/collection-json/eslint.config.js
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { ignores: ['dist', 'node_modules'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'warn',
+    },
+  },
+];

--- a/packages/collection-json/package.json
+++ b/packages/collection-json/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@genshin/collection-json",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Collection+JSON (application/vnd.collection+json) types and builders",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "10.0.1",
+    "@vitest/coverage-v8": "4.1.0",
+    "eslint": "10.0.3",
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.57.0",
+    "vitest": "4.1.0"
+  }
+}

--- a/packages/collection-json/src/collection-json.test.ts
+++ b/packages/collection-json/src/collection-json.test.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { buildCollection, buildItem, COLLECTION_JSON } from './collection-json.js';
+
+describe('COLLECTION_JSON', () => {
+  it('equals the IANA-registered media type', () => {
+    expect(COLLECTION_JSON).toBe('application/vnd.collection+json');
+  });
+});
+
+describe('buildItem', () => {
+  it('returns an item with href and data', () => {
+    const item = buildItem('http://example.com/items/1', [
+      { name: 'id', value: '1' },
+      { name: 'title', value: 'Test' },
+    ]);
+
+    expect(item).toEqual({
+      href: 'http://example.com/items/1',
+      data: [
+        { name: 'id', value: '1' },
+        { name: 'title', value: 'Test' },
+      ],
+    });
+  });
+
+  it('omits links when not provided', () => {
+    const item = buildItem('http://example.com/items/1', []);
+
+    expect(item).not.toHaveProperty('links');
+  });
+
+  it('omits links when empty array is provided', () => {
+    const item = buildItem('http://example.com/items/1', [], []);
+
+    expect(item).not.toHaveProperty('links');
+  });
+
+  it('includes links when provided', () => {
+    const links = [{ rel: 'collection', href: 'http://example.com/items' }];
+    const item = buildItem('http://example.com/items/1', [], links);
+
+    expect(item.links).toEqual(links);
+  });
+});
+
+describe('buildCollection', () => {
+  it('returns a document with version 1.0', () => {
+    const doc = buildCollection('http://example.com/items', []);
+
+    expect(doc.collection.version).toBe('1.0');
+  });
+
+  it('sets href to the collection URI', () => {
+    const doc = buildCollection('http://example.com/items', []);
+
+    expect(doc.collection.href).toBe('http://example.com/items');
+  });
+
+  it('includes items in the collection', () => {
+    const items = [
+      buildItem('http://example.com/items/1', [{ name: 'id', value: '1' }]),
+      buildItem('http://example.com/items/2', [{ name: 'id', value: '2' }]),
+    ];
+    const doc = buildCollection('http://example.com/items', items);
+
+    expect(doc.collection.items).toHaveLength(2);
+    expect(doc.collection.items).toEqual(items);
+  });
+
+  it('omits template when not provided', () => {
+    const doc = buildCollection('http://example.com/items', []);
+
+    expect(doc.collection).not.toHaveProperty('template');
+  });
+
+  it('includes template when provided', () => {
+    const template = { data: [{ name: 'title', prompt: 'Enter title' }] };
+    const doc = buildCollection('http://example.com/items', [], { template });
+
+    expect(doc.collection.template).toEqual(template);
+  });
+
+  it('omits queries when not provided', () => {
+    const doc = buildCollection('http://example.com/items', []);
+
+    expect(doc.collection).not.toHaveProperty('queries');
+  });
+
+  it('omits queries when empty array is provided', () => {
+    const doc = buildCollection('http://example.com/items', [], { queries: [] });
+
+    expect(doc.collection).not.toHaveProperty('queries');
+  });
+
+  it('includes queries when provided', () => {
+    const queries = [
+      {
+        rel: 'search',
+        href: 'http://example.com/items',
+        data: [{ name: 'q', prompt: 'Search' }],
+      },
+    ];
+    const doc = buildCollection('http://example.com/items', [], { queries });
+
+    expect(doc.collection.queries).toEqual(queries);
+  });
+
+  it('omits links when not provided', () => {
+    const doc = buildCollection('http://example.com/items', []);
+
+    expect(doc.collection).not.toHaveProperty('links');
+  });
+
+  it('omits links when empty array is provided', () => {
+    const doc = buildCollection('http://example.com/items', [], { links: [] });
+
+    expect(doc.collection).not.toHaveProperty('links');
+  });
+
+  it('includes links when provided', () => {
+    const links = [{ rel: 'profile', href: 'http://example.com/schema' }];
+    const doc = buildCollection('http://example.com/items', [], { links });
+
+    expect(doc.collection.links).toEqual(links);
+  });
+});

--- a/packages/collection-json/src/collection-json.ts
+++ b/packages/collection-json/src/collection-json.ts
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/**
+ * Collection+JSON media type types and utilities.
+ *
+ * Implements the Collection+JSON hypermedia type by Mike Amundsen.
+ * Spec: http://amundsen.com/media-types/collection/format/
+ * IANA registration: application/vnd.collection+json
+ *
+ * This module has no framework dependencies. Representation modules
+ * for other media types (HAL, Siren, etc.) can follow the same pattern.
+ */
+
+export const COLLECTION_JSON = 'application/vnd.collection+json';
+
+// --- Types ---
+
+export type DatumValue = string | number | boolean | null;
+
+export interface Datum {
+  name: string;
+  value?: DatumValue;
+  prompt?: string;
+}
+
+export interface Link {
+  rel: string;
+  href: string;
+  name?: string;
+  render?: 'image' | 'link';
+  prompt?: string;
+}
+
+export interface Item {
+  href: string;
+  data: Datum[];
+  links?: Link[];
+}
+
+export interface Query {
+  rel: string;
+  href: string;
+  name?: string;
+  prompt?: string;
+  data?: Datum[];
+}
+
+export interface Template {
+  data: Datum[];
+}
+
+export interface Collection {
+  version: '1.0';
+  href: string;
+  links?: Link[];
+  items: Item[];
+  queries?: Query[];
+  template?: Template;
+}
+
+export interface CollectionDocument {
+  collection: Collection;
+}
+
+// --- Representation contract ---
+
+/**
+ * Core contract for mapping a domain type to collection+json.
+ *
+ * Covers the common kernel every resource needs: single-item serialisation,
+ * list documents, and single-item documents. Resource-specific extras
+ * (e.g. sub-collection lists) live outside this contract as additional exports.
+ */
+export interface CollectionJsonRepresentation<T> {
+  toItem: (entity: T, baseUrl: string) => Item;
+  listDocument: (entities: T[], baseUrl: string) => CollectionDocument;
+  /**
+   * Separate from listDocument because collection.href must reflect the
+   * request URI: the item URI for single-item responses vs the collection
+   * URI for list responses.
+   */
+  itemDocument: (entity: T, baseUrl: string) => CollectionDocument;
+}
+
+// --- Builders ---
+
+export function buildItem(href: string, data: Datum[], links?: Link[]): Item {
+  const item: Item = { href, data };
+  if (links && links.length > 0) {
+    item.links = links;
+  }
+  return item;
+}
+
+export function buildCollection(
+  href: string,
+  items: Item[],
+  options?: {
+    template?: Template;
+    queries?: Query[];
+    links?: Link[];
+  },
+): CollectionDocument {
+  const collection: Collection = {
+    version: '1.0',
+    href,
+    items,
+  };
+
+  if (options?.template) {
+    collection.template = options.template;
+  }
+  if (options?.queries && options.queries.length > 0) {
+    collection.queries = options.queries;
+  }
+  if (options?.links && options.links.length > 0) {
+    collection.links = options.links;
+  }
+
+  return { collection };
+}

--- a/packages/collection-json/src/index.ts
+++ b/packages/collection-json/src/index.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+export {
+  COLLECTION_JSON,
+  buildCollection,
+  buildItem,
+  type Collection,
+  type CollectionDocument,
+  type CollectionJsonRepresentation,
+  type Datum,
+  type DatumValue,
+  type Item,
+  type Link,
+  type Query,
+  type Template,
+} from './collection-json.js';

--- a/packages/collection-json/tsconfig.json
+++ b/packages/collection-json/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/collection-json/vitest.config.ts
+++ b/packages/collection-json/vitest.config.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['dist/**', 'node_modules/**'],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@genshin/collection-json':
+        specifier: workspace:*
+        version: link:../../packages/collection-json
       '@genshin/game-data':
         specifier: workspace:*
         version: link:../../packages/game-data
@@ -187,6 +190,27 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+
+  packages/collection-json:
+    devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.0.3(jiti@2.6.1))
+      '@vitest/coverage-v8':
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)))
+      eslint:
+        specifier: 10.0.3
+        version: 10.0.3(jiti@2.6.1)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: 8.57.0
+        version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
 
   packages/game-data:
     devDependencies:


### PR DESCRIPTION
## Summary

Introduces a representation layer between API routes and response serialization using the **collection+json** (`application/vnd.collection+json`) hypermedia media type. This partially addresses #456 — JSON Schema infrastructure will follow in a separate PR.

## Changes

### New: `@genshin/collection-json` package (`packages/collection-json/`)
- Types and builders for the [collection+json](http://amundsen.com/media-types/collection/) media type
- `COLLECTION_JSON` content-type constant
- `CollectionJsonRepresentation<T>` interface for compile-time contract enforcement
- 16 unit tests with 100% coverage

### New: Representation mappers (`apps/api/src/representations/`)
- `collection-json/characters.ts` — maps `CollectionCharacter` → collection+json
- `collection-json/weapons.ts` — maps `CollectionWeapon` → collection+json
- Both enforce the representation contract via `satisfies CollectionJsonRepresentation<T>`

### Modified: API routes
- Character and weapon routes now serve `application/vnd.collection+json` responses
- Uses `c.body(JSON.stringify(...))` with explicit `Content-Type` header (since `c.json()` forces `application/json`)

### Modified: Weapon repository
- `listWeapons()` returns flat `CollectionWeapon[]` instead of `Record<string, CollectionWeapon[]>`

### Modified: Route tests
- Restructured to property-based style: endpoint invariants tested via `beforeEach`, edge cases inline
- Added sad path coverage: expired tokens → 401, repository errors → 500, DELETE idempotency → 204
- 69 API tests + 16 package tests = **85 tests total**

### Modified: CI and Codecov
- Split monolithic `packages` CI job into per-package jobs (`game-data`, `types`, `collection-json`)
- Added Codecov flags (`api`, `collection-json`) and per-directory components

## Follow-up issues
- #460 — Remove `/api` prefix from routes
- #461 — Error handler returns `application/json` instead of `application/problem+json`
- #462 — Content negotiation for multiple response media types
- #463 — Move `apps/api/src/lib/firebase/` to `apps/api/src/firebase/`

## How to test
```bash
pnpm turbo run build typecheck test
```