### PR TITLE
fix(api): add missing collection-json to Dockerfile and smoke-test CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,13 +27,47 @@ jobs:
           context: .
           file: ./apps/api/Dockerfile
           push: false
+          load: true
+          tags: api-smoke:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Smoke-test container startup
+        run: |
+          set -euo pipefail
+
+          docker run -d --name api-smoke \
+            -e PORT=8080 \
+            -e FRONTEND_ORIGIN=http://localhost:5173 \
+            -p 8080:8080 \
+            api-smoke:test
+
+          # Wait for the server to be ready (up to 15 seconds)
+          for i in $(seq 1 15); do
+            if curl -fsSL http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Health check passed on attempt $i"
+              break
+            fi
+            if [ "$i" -eq 15 ]; then
+              echo "Container failed to respond after 15 seconds"
+              docker logs api-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # Verify the response shape
+          curl -fsSL http://localhost:8080/health | jq -e '.status == "ok"'
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs api-smoke 2>&1 || true
 # ---------------------------------------------------------------------------
 # Maintenance notes
 # ---------------------------------------------------------------------------
 # This workflow validates that the Docker image builds successfully on all
-# pull requests. It does not push to any registry.
+# pull requests, then smoke-tests the container by starting it and hitting
+# /health. It does not push to any registry.
 #
 # Read-only permissions prevent any potential security issues from PR code
 # accessing write tokens.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,6 +62,10 @@ jobs:
       - name: Dump container logs on failure
         if: failure()
         run: docker logs api-smoke 2>&1 || true
+
+      - name: Cleanup container
+        if: always()
+        run: docker rm -f api-smoke 2>/dev/null || true
 # ---------------------------------------------------------------------------
 # Maintenance notes
 # ---------------------------------------------------------------------------

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 ---
-name: Docker Build
+name: Docker
 
 on:
   pull_request:
 
 jobs:
   build:
-    name: Build Docker image
+    name: Build and Run
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build Docker image
+      - name: Build image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -65,9 +65,8 @@ jobs:
 # ---------------------------------------------------------------------------
 # Maintenance notes
 # ---------------------------------------------------------------------------
-# This workflow validates that the Docker image builds successfully on all
-# pull requests, then smoke-tests the container by starting it and hitting
-# /health. It does not push to any registry.
+# This workflow validates that the API Docker image builds and starts
+# correctly on pull requests. It does not push to any registry.
 #
 # Read-only permissions prevent any potential security issues from PR code
 # accessing write tokens.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -23,6 +23,7 @@ RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
 # Copy remaining manifests so pnpm resolves the full dependency graph
 COPY pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps/api/package.json ./apps/api/
+COPY packages/collection-json/package.json ./packages/collection-json/
 COPY packages/types/package.json ./packages/types/
 COPY packages/game-data/package.json ./packages/game-data/
 
@@ -47,6 +48,7 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
 COPY --from=builder /app/apps/api/dist ./apps/api/dist
+COPY --from=builder /app/packages/collection-json ./packages/collection-json
 COPY --from=builder /app/packages/types ./packages/types
 COPY --from=builder /app/packages/game-data ./packages/game-data
 


### PR DESCRIPTION
## Problem

The API deploy to Cloud Run has been failing because the container crashes on startup:

> The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable within the allocated timeout.

Root cause: `@genshin/collection-json` is a runtime dependency of the API (imported in character and weapon routes) but was missing from the Dockerfile — both the builder stage manifest copy and the production stage.

## Changes

### Dockerfile fix
- Add `packages/collection-json/package.json` to the builder stage so `pnpm install` resolves it
- Add `COPY --from=builder /app/packages/collection-json` to the production stage so the built package is available at runtime

### CI smoke test
- Extend the Docker Build PR check to actually **run** the container and verify `/health` responds with `{"status": "ok"}`
- On failure, container logs are dumped for easy debugging
- This catches runtime startup failures (missing packages, broken imports) that the build-only check cannot detect