### PR TITLE
docs: document field naming, validation status codes, and testing conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,8 @@
 
 - Use the [REST API conventions reference](../docs/reference/rest-api-conventions.md) as guidance for API route shape, methods, status codes, error format, pagination, and auth handling.
 - All error responses use RFC 9457 Problem Details (`application/problem+json`). Always include a `detail` field, even for generic errors, to keep a stable schema for clients.
+- Validate API success responses against the published JSON Schema in tests using AJV, not just individual field assertions. Keep one sanity-check assertion per test for a specific value.
+- Prefer explicit types over type munging. For example, define `ProfileUpdate` rather than using `Partial<Pick<UserProfile, 'name'>>` inline.
 
 ## Frontend rules
 

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -59,6 +59,7 @@ SWC
 # API and architecture
 API
 APIs
+AJV
 cacheable
 CLI
 CI/CD
@@ -76,6 +77,7 @@ roadmaps
 semver
 typechecking
 unversioned
+Unprocessable
 validators
 
 # Cloud infrastructure

--- a/apps/api/src/routes/userProfile.ts
+++ b/apps/api/src/routes/userProfile.ts
@@ -18,6 +18,10 @@ userProfile.use('*', auth);
 
 const GET_SCHEMA_PATH = '/schemas/profile/get/1.0.0.json';
 
+// Cherry-pick identity fields rather than spreading the full DecodedIdToken.
+// The token carries ~15 internal JWT fields (iss, aud, exp, firebase metadata,
+// custom claims) that are not part of the API contract and would make the
+// response shape unpredictable.
 function compositeResponse(decoded: DecodedIdToken, profile: UserProfile) {
   return {
     uid: decoded.uid,

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -75,6 +75,19 @@ Resources that combine data from multiple authorities define field ownership at 
 
 `PATCH` endpoints use `additionalProperties: false` in their JSON Schema to reject fields outside the mutable set.
 
+### 10. Field naming
+
+Use camelCase for all API response fields. When projecting fields from upstream types that use different conventions (for example, `DecodedIdToken.email_verified`), normalize casing at the translation boundary so clients see a consistent naming convention across all endpoints.
+
+### 11. Validation status codes
+
+Distinguish request parsing failures from schema validation failures:
+
+- **400 Bad Request**: the server can't parse the request body as JSON.
+- **422 Unprocessable Content**: the body is valid JSON but fails schema validation, such as a wrong shape, missing required fields, or extra properties.
+
+See [RFC9110], Section 15.5.21: <https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content>
+
 ## Repository scope
 
 These principles guide route design, method semantics, status code usage, error shape, pagination, authentication header handling, and timestamp format for `apps/api`.


### PR DESCRIPTION
## Summary

Documents API design learnings from the profile ownership contract work (#347 / #474).

## Changes

### Inline comment
- Add comment to `compositeResponse` in `apps/api/src/routes/userProfile.ts` explaining why identity fields are cherry-picked rather than spreading the full `DecodedIdToken`.

### REST API conventions (`docs/reference/rest-api-conventions.md`)
- **Principle 10 (field naming)**: camelCase for all API fields; normalize upstream types at the translation boundary.
- **Principle 11 (validation status codes)**: 400 for unparseable JSON, 422 for schema validation failures.

### Copilot instructions (`.github/copilot-instructions.md`)
- Validate API success responses against the published JSON Schema in tests using AJV, not individual field assertions.
- Prefer explicit types over type munging.

### Vale vocabulary
- Add AJV and Unprocessable to `.styles/config/vocabularies/Project/accept.txt`.