### PR TITLE
feat(api): implement content negotiation and RFC 9457 errors for profile API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,10 +19,12 @@
     "ajv": "8.18.0",
     "firebase-admin": "13.7.0",
     "hono": "4.12.7",
+    "negotiator": "1.0.0",
     "semver": "7.7.4"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@types/negotiator": "0.6.4",
     "@types/node": "25.5.0",
     "@types/semver": "7.7.1",
     "@vitest/coverage-v8": "4.1.0",

--- a/apps/api/src/middleware/negotiate-content.test.ts
+++ b/apps/api/src/middleware/negotiate-content.test.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import type { NegotiatedContentVariables, SupportedRepresentation } from './negotiate-content.js';
+import { negotiateContent, toMediaTypeString } from './negotiate-content.js';
+
+const ORIGIN = 'http://localhost';
+
+const jsonWithProfile: SupportedRepresentation = {
+  mediaType: 'application/json',
+  profilePath: '/schemas/profile/get/1.0.0.json',
+};
+
+const jsonWithoutProfile: SupportedRepresentation = {
+  mediaType: 'application/json',
+};
+
+describe('toMediaTypeString', () => {
+  it('returns bare media type when no profilePath is set', () => {
+    expect(toMediaTypeString(jsonWithoutProfile, ORIGIN)).toBe('application/json');
+  });
+
+  it('appends profile parameter with absolute URI', () => {
+    expect(toMediaTypeString(jsonWithProfile, ORIGIN)).toBe(
+      'application/json; profile="http://localhost/schemas/profile/get/1.0.0.json"',
+    );
+  });
+
+  it('uses the provided origin in the profile URI', () => {
+    expect(toMediaTypeString(jsonWithProfile, 'https://api.example.com')).toBe(
+      'application/json; profile="https://api.example.com/schemas/profile/get/1.0.0.json"',
+    );
+  });
+});
+
+describe('negotiateContent middleware', () => {
+  const supported: SupportedRepresentation[] = [
+    { mediaType: 'application/json', profilePath: '/schemas/test/1.0.0.json' },
+  ];
+
+  function createApp() {
+    const app = new Hono<{ Variables: NegotiatedContentVariables }>();
+    app.use('*', negotiateContent(supported));
+    app.get('/', (c) => c.body(null, 200, { 'Content-Type': c.get('negotiatedMediaType') }));
+    return app;
+  }
+
+  it('sets negotiatedMediaType when Accept matches', async () => {
+    const res = await createApp().request(
+      new Request('http://localhost/', { headers: { Accept: 'application/json' } }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe(
+      'application/json; profile="http://localhost/schemas/test/1.0.0.json"',
+    );
+  });
+
+  it('defaults to first representation when no Accept header is provided', async () => {
+    const res = await createApp().request('http://localhost/');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe(
+      'application/json; profile="http://localhost/schemas/test/1.0.0.json"',
+    );
+  });
+
+  it('returns 406 when no supported representation matches', async () => {
+    const res = await createApp().request(
+      new Request('http://localhost/', { headers: { Accept: 'text/html' } }),
+    );
+
+    expect(res.status).toBe(406);
+  });
+});

--- a/apps/api/src/middleware/negotiate-content.ts
+++ b/apps/api/src/middleware/negotiate-content.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { MiddlewareHandler } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import Negotiator from 'negotiator';
+
+/**
+ * A representation the endpoint can produce.
+ *
+ * @example
+ * // JSON with a schema profile
+ * { mediaType: 'application/json', profilePath: '/schemas/profile/get/1.0.0.json' }
+ *
+ * // Plain JSON without a profile
+ * { mediaType: 'application/json' }
+ */
+export interface SupportedRepresentation {
+  mediaType: string;
+  /** Absolute URL path (starting with `/`) resolved against the request origin. */
+  profilePath?: string;
+}
+
+export type NegotiatedContentVariables = {
+  negotiatedMediaType: string;
+};
+
+/**
+ * Build the full media type string for negotiation, including the profile
+ * parameter when declared.
+ */
+export function toMediaTypeString(representation: SupportedRepresentation, origin: string): string {
+  if (!representation.profilePath) return representation.mediaType;
+  return `${representation.mediaType}; profile="${origin}${representation.profilePath}"`;
+}
+
+/**
+ * Content negotiation middleware.
+ *
+ * Declare the representations the endpoint can produce. The middleware uses
+ * negotiator to match the client's Accept header (including quality values,
+ * wildcards, and extension parameters like profile) against the supported list.
+ *
+ * - No Accept header → pass through (serve first representation).
+ * - Accept matches a supported media type (with or without profile) → pass through.
+ * - Accept doesn't match any supported representation → 406.
+ *
+ * Sets `negotiatedMediaType` on the context — the full media type string
+ * (including profile parameter when present) that the handler should use for
+ * `Content-Type`.
+ */
+export function negotiateContent(supported: SupportedRepresentation[]): MiddlewareHandler {
+  return async (c, next) => {
+    const origin = new URL(c.req.url).origin;
+    const available = supported.map((s) => toMediaTypeString(s, origin));
+    const acceptHeader = c.req.header('Accept');
+
+    // No Accept header = accept anything (RFC 9110 §12.5.1), serve first
+    if (!acceptHeader) {
+      c.set('negotiatedMediaType', available[0]);
+      await next();
+      return;
+    }
+
+    const negotiator = new Negotiator({ headers: { accept: acceptHeader } });
+    const preferred = negotiator.mediaTypes(available);
+
+    if (preferred.length === 0) {
+      const types = available.join(', ');
+      throw new HTTPException(406, {
+        message: `This endpoint only serves: ${types}`,
+      });
+    }
+
+    c.set('negotiatedMediaType', preferred[0]);
+    await next();
+  };
+}

--- a/apps/api/src/routes/userProfile.ts
+++ b/apps/api/src/routes/userProfile.ts
@@ -3,6 +3,8 @@
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
+import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import { negotiateContent } from '@/middleware/negotiate-content.js';
 import type { ValidatedBodyVariables } from '@/middleware/validate-body.js';
 import { validateBody } from '@/middleware/validate-body.js';
 import { getProfile, updateProfile } from '@/repositories/profile/index.js';
@@ -12,11 +14,17 @@ import type { DecodedIdToken } from 'firebase-admin/auth';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
-export const userProfile = new Hono<{ Variables: AuthVariables & ValidatedBodyVariables }>();
-
-userProfile.use('*', auth);
+export const userProfile = new Hono<{
+  Variables: AuthVariables & NegotiatedContentVariables & ValidatedBodyVariables;
+}>();
 
 const GET_SCHEMA_PATH = '/schemas/profile/get/1.0.0.json';
+
+userProfile.use('*', auth);
+userProfile.use(
+  '*',
+  negotiateContent([{ mediaType: 'application/json', profilePath: GET_SCHEMA_PATH }]),
+);
 
 // Cherry-pick identity fields rather than spreading the full DecodedIdToken.
 // The token carries ~15 internal JWT fields (iss, aud, exp, firebase metadata,
@@ -42,7 +50,7 @@ userProfile.get('/', async (c) => {
   }
 
   return c.json(compositeResponse(decoded, profile), 200, {
-    'Content-Type': `application/json; profile="${new URL(c.req.url).origin}${GET_SCHEMA_PATH}"`,
+    'Content-Type': c.get('negotiatedMediaType'),
   });
 });
 
@@ -53,6 +61,6 @@ userProfile.patch('/', validateBody(profilePatchSchema), async (c) => {
   const updated = await updateProfile(decoded.uid, body);
 
   return c.json(compositeResponse(decoded, updated), 200, {
-    'Content-Type': `application/json; profile="${new URL(c.req.url).origin}${GET_SCHEMA_PATH}"`,
+    'Content-Type': c.get('negotiatedMediaType'),
   });
 });

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -39,6 +39,29 @@ See [RFC9110], Section 12: <https://www.rfc-editor.org/rfc/rfc9110.html#name-con
 
 See [JSONSchema2020-12]: <https://json-schema.org/draft/2020-12>
 
+#### `profile` parameter negotiation
+
+Clients request a specific representation version using the `profile` parameter on the `Accept` header, referencing the schema URI that describes the expected response shape:
+
+```http
+GET /api/profile HTTP/1.1
+Accept: application/json; profile="https://api.genshin.dungeon.studio/schemas/profile/get/1.0.0.json"
+```
+
+The API confirms the schema used in the response `Content-Type`:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json; profile="https://api.genshin.dungeon.studio/schemas/profile/get/1.0.0.json"
+```
+
+Negotiation rules:
+
+- **Profile omitted**: the API serves the latest representation version.
+- **Profile matches a supported version**: the API responds with that representation.
+- **Profile doesn't match any supported version**: the API responds with `406 Not Acceptable` using the RFC 9457 error format.
+- **`Accept` doesn't include `application/json`** (or a wildcard): the API responds with `406 Not Acceptable`.
+
 ### 5. Consistent error contract
 
 Use the Problem Details standard for machine-readable error responses. Return `application/problem+json` with stable fields and consistent extension members where needed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       hono:
         specifier: 4.12.7
         version: 4.12.7
+      negotiator:
+        specifier: 1.0.0
+        version: 1.0.0
       semver:
         specifier: 7.7.4
         version: 7.7.4
@@ -63,6 +66,9 @@ importers:
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.0.3(jiti@2.6.1))
+      '@types/negotiator':
+        specifier: 0.6.4
+        version: 0.6.4
       '@types/node':
         specifier: 25.5.0
         version: 25.5.0
@@ -1370,6 +1376,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/negotiator@0.6.4':
+    resolution: {integrity: sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -2608,6 +2617,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -4477,6 +4490,8 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/negotiator@0.6.4': {}
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -5841,6 +5856,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   node-domexception@1.0.0: {}
 


### PR DESCRIPTION
## Summary

Add Accept header content negotiation for the profile API using the `negotiator` library, with RFC 6906 profile media type parameter support.

## Changes

- **New middleware** (`negotiate-content.ts`): declares supported representations, matches the client's `Accept` header via `negotiator`, returns 406 if incompatible, and sets the negotiated media type on the Hono context.
- **Profile routes** (`userProfile.ts`): wired `negotiateContent` middleware; GET and PATCH handlers read `c.get('negotiatedMediaType')` for Content-Type.
- **Tests** (`negotiate-content.test.ts`): unit tests for `toMediaTypeString` and integration tests for middleware behavior (Accept match wiring, no-Accept default, and 406 on no match).
- **Documentation** (`rest-api-conventions.md`): added profile parameter negotiation subsection under Principle 4.

## Acceptance criteria from #369

- [x] Negotiation is deterministic and documented
- [x] Failures return `application/problem+json` per RFC 9457
- [x] Typecheck and lint pass

Closes #369