### PR TITLE
feat(api): add resource discovery to API root endpoint

### DIFF
--- a/apps/api/scripts/verify-deployment.ts
+++ b/apps/api/scripts/verify-deployment.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'node:child_process';
 
 type HealthResponse = {
   status?: string;
+  version?: string;
   sha?: string | null;
 };
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import type { AuthVariables } from '@/middleware/auth.js';
+import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
 import { characters } from '@/routes/characters.js';
 import { profiles } from '@/routes/profiles.js';
+import { root } from '@/routes/root.js';
 import { schemas } from '@/routes/schemas.js';
 import { userProfile } from '@/routes/userProfile.js';
 import { weapons } from '@/routes/weapons.js';
@@ -19,7 +21,7 @@ const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.me
 
 export const PROBLEM_JSON = { 'Content-Type': 'application/problem+json' };
 
-export const app = new Hono<{ Variables: Partial<AuthVariables> }>();
+export const app = new Hono<{ Variables: Partial<AuthVariables> & NegotiatedContentVariables }>();
 
 // Request logging middleware
 app.use('*', logger());
@@ -77,16 +79,10 @@ app.notFound((c) =>
   ),
 );
 
-app.get('/', (c) =>
-  c.json({
-    message: 'Genshin API',
-    version: packageJson.version,
-  }),
-);
-
 app.get('/health', (c) =>
   c.json({
     status: 'ok',
+    version: packageJson.version,
     sha: process.env.APP_GIT_SHA ?? null,
   }),
 );
@@ -97,3 +93,6 @@ app.route('/profiles', profiles);
 app.route('/api/characters', characters);
 app.route('/api/profile', userProfile);
 app.route('/api/weapons', weapons);
+
+// Root must be registered after all other routes so it can discover them
+app.route('/', root(app));

--- a/apps/api/src/routes/root.test.ts
+++ b/apps/api/src/routes/root.test.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { app } from '@/app.js';
+import rootGetSchema from '@/schemas/root/get/1.0.0.json' with { type: 'json' };
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const ajv = new Ajv2020();
+const validateGetSchema = ajv.compile(rootGetSchema);
+
+const EXPECTED_CONTENT_TYPE =
+  'application/json; profile="http://localhost/schemas/root/get/1.0.0.json"';
+
+describe('GET /', () => {
+  let res: Response;
+
+  beforeEach(async () => {
+    res = await app.request('/');
+  });
+
+  it('returns 200 with a response matching the root schema', async () => {
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe(EXPECTED_CONTENT_TYPE);
+    const body = await res.json();
+    expect(validateGetSchema(body)).toBe(true);
+  });
+
+  it('dynamically includes links to registered resources', async () => {
+    const body = (await res.json()) as { links: Record<string, { href: string }> };
+    expect(body.links).toEqual(
+      expect.objectContaining({
+        characters: { href: '/api/characters' },
+        profile: { href: '/api/profile' },
+        weapons: { href: '/api/weapons' },
+        health: { href: '/health' },
+      }),
+    );
+  });
+});

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -10,13 +10,12 @@ import { findTargetHandler, isMiddleware } from 'hono/utils/handler';
 const ROOT_SCHEMA_PATH = '/schemas/root/get/1.0.0.json';
 
 /**
- * Discover top-level resource collection paths from the app's registered
- * routes. Returns GET-accessible paths that represent resource collections
- * (e.g. `/api/characters`) plus infrastructure endpoints like `/health` and
- * `/schemas`.
+ * Discover top-level resource paths from the app's registered routes.
+ * Returns GET-accessible paths that have a discrete handler (e.g.
+ * `/api/characters`, `/health`).
  *
- * Excludes the root path itself, wildcard catch-all routes, and sub-resource
- * paths that contain route parameters.
+ * Excludes the root path itself, wildcard catch-all routes (like `/schemas/*`
+ * and `/profiles/*`), and sub-resource paths that contain route parameters.
  */
 function discoverLinks<E extends Env>(app: HonoApp<E>): Record<string, { href: string }> {
   const seen = new Set<string>();

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import { negotiateContent } from '@/middleware/negotiate-content.js';
+import type { Env, Hono as HonoApp } from 'hono';
+import { Hono } from 'hono';
+import { findTargetHandler, isMiddleware } from 'hono/utils/handler';
+
+const ROOT_SCHEMA_PATH = '/schemas/root/get/1.0.0.json';
+
+/**
+ * Discover top-level resource collection paths from the app's registered
+ * routes. Returns GET-accessible paths that represent resource collections
+ * (e.g. `/api/characters`) plus infrastructure endpoints like `/health` and
+ * `/schemas`.
+ *
+ * Excludes the root path itself, wildcard catch-all routes, and sub-resource
+ * paths that contain route parameters.
+ */
+function discoverLinks<E extends Env>(app: HonoApp<E>): Record<string, { href: string }> {
+  const seen = new Set<string>();
+  const links: Record<string, { href: string }> = {};
+
+  for (const route of app.routes) {
+    if (route.method !== 'GET') continue;
+    if (isMiddleware(findTargetHandler(route.handler))) continue;
+
+    const path = route.path;
+
+    // Skip root, wildcards, and parameterized sub-resources
+    if (path === '/' || path.includes('*') || path.includes(':')) continue;
+    if (seen.has(path)) continue;
+    seen.add(path);
+
+    // Derive a name from the last path segment: /api/characters → characters
+    const segments = path.split('/').filter(Boolean);
+    const name = segments[segments.length - 1];
+    links[name] = { href: path };
+  }
+
+  return links;
+}
+
+export function root<E extends Env>(
+  app: HonoApp<E>,
+): Hono<{ Variables: NegotiatedContentVariables }> {
+  const links = discoverLinks(app);
+  const router = new Hono<{ Variables: NegotiatedContentVariables }>();
+
+  router.get(
+    '/',
+    negotiateContent([{ mediaType: 'application/json', profilePath: ROOT_SCHEMA_PATH }]),
+    (c) => c.json({ links }, 200, { 'Content-Type': c.get('negotiatedMediaType') }),
+  );
+
+  return router;
+}

--- a/apps/api/src/schemas/root/get/1.0.0.json
+++ b/apps/api/src/schemas/root/get/1.0.0.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://api.genshin.dungeon.studio/schemas/root/get/1.0.0.json",
+  "title": "API Root",
+  "description": "Entry point response advertising available API resources for discovery.",
+  "type": "object",
+  "properties": {
+    "links": {
+      "type": "object",
+      "description": "Discoverable resource links keyed by resource name",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Absolute path to the resource"
+          }
+        },
+        "required": ["href"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["links"],
+  "additionalProperties": false
+}

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -111,6 +111,31 @@ Distinguish request parsing failures from schema validation failures:
 
 See [RFC9110], Section 15.5.21: <https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content>
 
+### 12. Resource discovery
+
+The API root (`GET /`) serves as a HATEOAS entry point that advertises available resources. The response contains a `links` object populated dynamically from the app's registered routes at startup using Hono's route introspection (`app.routes`):
+
+```json
+{
+  "links": {
+    "characters": { "href": "/api/characters" },
+    "profile": { "href": "/api/profile" },
+    "weapons": { "href": "/api/weapons" },
+    "health": { "href": "/health" }
+  }
+}
+```
+
+The root response uses `application/json` with a `profile` parameter referencing its published JSON Schema, consistent with other API endpoints.
+
+Design choices:
+
+- **Link format**: a plain `links` object with `href` strings. Each key is the resource name derived from the last path segment. This avoids introducing a separate hypermedia media type for a single endpoint.
+- **Dynamic extraction**: the app's route table at startup populates the links. New resource endpoints appear automatically without manual maintenance. The discovery logic filters to `GET` handlers on top-level paths, excluding the root itself, wildcard routes, and parameterized sub-resource paths.
+- **Visibility**: all resources appear regardless of authentication status. URLs aren't secret; each resource enforces its own authorization.
+- **Versioning**: the `/health` endpoint carries the API version alongside operational metadata like `status` and `sha`, not the root response. The root handles resource discovery only.
+- **Route file**: the handler lives in `apps/api/src/routes/root.ts`. Mount it after all other routes so it can discover them.
+
 ## Repository scope
 
 These principles guide route design, method semantics, status code usage, error shape, pagination, authentication header handling, and timestamp format for `apps/api`.


### PR DESCRIPTION
## Summary

Replace the static `GET /` response with a HATEOAS entry point that dynamically advertises available API resources.

## Changes

- **`apps/api/src/routes/root.ts`** — new route module. Uses Hono's `app.routes` to discover top-level GET resources at startup. Content negotiation with `application/json; profile=...`.
- **`apps/api/src/schemas/root/get/1.0.0.json`** — JSON Schema for the root response (`{ links: { [name]: { href } } }` with `additionalProperties: false`).
- **`apps/api/src/routes/root.test.ts`** — schema validation and dynamic link discovery tests.
- **`apps/api/src/app.ts`** — mounts root route after all others; moves `version` to `/health` response.
- **`apps/api/scripts/verify-deployment.ts`** — adds `version` to `HealthResponse` type.
- **`docs/reference/rest-api-conventions.md`** — documents the resource discovery convention.

## Design decisions

- **Dynamic extraction** over manual listing: new routes appear automatically.
- **Simple `links` format** with published JSON Schema for strictness, rather than Siren or HAL. If we need per-resource media type hints later, JSON Home (`application/json-home`) is the natural upgrade path.
- **Version in `/health`**, not root: health is operational metadata; root is purely resource discovery.

## Follow-ups filed

- #481 — move health to its own route file with tests
- #482 — correct OPTIONS/Allow headers for all endpoints
- #483 — tighten conventions doc for concision

Closes #443