### PR TITLE
feat(api): flatten weapon Firestore storage from subcollection to UUID-keyed documents

### DIFF
--- a/apps/api/src/repositories/weapons/document.ts
+++ b/apps/api/src/repositories/weapons/document.ts
@@ -4,19 +4,16 @@
 import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/types';
 
 export interface DocumentData {
+  weaponId: string;
   refinementLevel: number;
   createdAt: string;
   updatedAt: string;
 }
 
-export function fromDocument(
-  weaponInstanceId: UUID,
-  weaponId: string,
-  data: DocumentData,
-): CollectionWeapon {
+export function fromDocument(weaponInstanceId: UUID, data: DocumentData): CollectionWeapon {
   return {
     weaponInstanceId,
-    weaponId,
+    weaponId: data.weaponId,
     refinementLevel: data.refinementLevel,
     createdAt: data.createdAt as ISOTimestamp,
     updatedAt: data.updatedAt as ISOTimestamp,
@@ -25,6 +22,7 @@ export function fromDocument(
 
 export function toDocument(weapon: CollectionWeapon): DocumentData {
   return {
+    weaponId: weapon.weaponId,
     refinementLevel: weapon.refinementLevel,
     createdAt: weapon.createdAt,
     updatedAt: weapon.updatedAt,

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -7,58 +7,33 @@ import { randomUUID } from 'node:crypto';
 
 import { fromDocument, toDocument, type DocumentData } from './document.js';
 
-function collectionRef(userId: string, weaponId: string) {
-  return db
-    .collection('users')
-    .doc(userId)
-    .collection('weapons')
-    .doc(weaponId)
-    .collection('instances');
+function collectionRef(userId: string) {
+  return db.collection('users').doc(userId).collection('weapons');
 }
 
-export async function listWeapons(userId: string): Promise<CollectionWeapon[]> {
-  const weaponsRef = db.collection('users').doc(userId).collection('weapons');
-  const weaponDocs = await weaponsRef.listDocuments();
+export async function listWeapons(userId: string, weaponId?: string): Promise<CollectionWeapon[]> {
+  const ref = weaponId
+    ? collectionRef(userId).where('weaponId', '==', weaponId)
+    : collectionRef(userId);
+  const snapshot = await ref.get();
 
-  const results: CollectionWeapon[] = [];
-
-  for (const weaponDoc of weaponDocs) {
-    const snapshot = await weaponDoc.collection('instances').get();
-    const instances = snapshot.docs.map((doc) =>
-      fromDocument(doc.id as UUID, weaponDoc.id, doc.data() as DocumentData),
-    );
-    results.push(...instances);
-  }
-
-  return results;
+  return snapshot.docs.map((doc) => fromDocument(doc.id as UUID, doc.data() as DocumentData));
 }
 
-export async function listWeaponInstances(
+export async function getWeapon(
   userId: string,
-  weaponId: string,
-): Promise<CollectionWeapon[]> {
-  const snapshot = await collectionRef(userId, weaponId).get();
-
-  return snapshot.docs.map((doc) =>
-    fromDocument(doc.id as UUID, weaponId, doc.data() as DocumentData),
-  );
-}
-
-export async function getWeaponInstance(
-  userId: string,
-  weaponId: string,
   weaponInstanceId: UUID,
 ): Promise<CollectionWeapon | null> {
-  const doc = await collectionRef(userId, weaponId).doc(weaponInstanceId).get();
+  const doc = await collectionRef(userId).doc(weaponInstanceId).get();
 
   if (!doc.exists) {
     return null;
   }
 
-  return fromDocument(weaponInstanceId as UUID, weaponId, doc.data() as DocumentData);
+  return fromDocument(weaponInstanceId, doc.data() as DocumentData);
 }
 
-export async function createWeaponInstance(
+export async function createWeapon(
   userId: string,
   weaponId: string,
   refinementLevel: number,
@@ -74,28 +49,17 @@ export async function createWeaponInstance(
     updatedAt: now,
   };
 
-  // Batch write: create the parent weapon doc so listWeapons() can discover it
-  // via listDocuments(), then create the instance doc. The parent doc is an
-  // empty anchor; see #455 for the planned collectionGroup redesign.
-  const batch = db.batch();
-  batch.set(
-    db.collection('users').doc(userId).collection('weapons').doc(weaponId),
-    {},
-    { merge: true },
-  );
-  batch.set(collectionRef(userId, weaponId).doc(weaponInstanceId), toDocument(weapon));
-  await batch.commit();
+  await collectionRef(userId).doc(weaponInstanceId).set(toDocument(weapon));
 
   return weapon;
 }
 
-export async function updateWeaponInstance(
+export async function updateWeapon(
   userId: string,
-  weaponId: string,
   weaponInstanceId: UUID,
   refinementLevel: number,
 ): Promise<CollectionWeapon | null> {
-  const docRef = collectionRef(userId, weaponId).doc(weaponInstanceId);
+  const docRef = collectionRef(userId).doc(weaponInstanceId);
   const existing = await docRef.get();
 
   if (!existing.exists) {
@@ -107,7 +71,7 @@ export async function updateWeaponInstance(
 
   const weapon: CollectionWeapon = {
     weaponInstanceId,
-    weaponId,
+    weaponId: existingData.weaponId,
     refinementLevel,
     createdAt: existingData.createdAt as ISOTimestamp,
     updatedAt: now,
@@ -118,10 +82,6 @@ export async function updateWeaponInstance(
   return weapon;
 }
 
-export async function deleteWeaponInstance(
-  userId: string,
-  weaponId: string,
-  weaponInstanceId: UUID,
-): Promise<void> {
-  await collectionRef(userId, weaponId).doc(weaponInstanceId).delete();
+export async function deleteWeapon(userId: string, weaponInstanceId: UUID): Promise<void> {
+  await collectionRef(userId).doc(weaponInstanceId).delete();
 }

--- a/apps/api/src/representations/collection-json/weapons.ts
+++ b/apps/api/src/representations/collection-json/weapons.ts
@@ -31,14 +31,14 @@ const WEAPON_TEMPLATE: Template = {
 };
 
 export function weaponItemHref(baseUrl: string, weapon: CollectionWeapon): string {
-  return `${baseUrl}/api/weapons/${weapon.weaponId}/${weapon.weaponInstanceId}`;
+  return `${baseUrl}/api/weapons/${weapon.weaponInstanceId}`;
 }
 
 export function weaponToItem(weapon: CollectionWeapon, baseUrl: string): Item {
   const links: Link[] = [
     {
       rel: 'collection',
-      href: `${baseUrl}/api/weapons/${weapon.weaponId}`,
+      href: `${baseUrl}/api/weapons?weaponId=${weapon.weaponId}`,
       prompt: `All instances of ${weapon.weaponId}`,
     },
   ];
@@ -62,18 +62,6 @@ export function weaponListDocument(
 ): CollectionDocument {
   return buildCollection(
     `${baseUrl}/api/weapons`,
-    weapons.map((w) => weaponToItem(w, baseUrl)),
-    { template: WEAPON_TEMPLATE },
-  );
-}
-
-export function weaponInstanceListDocument(
-  weapons: CollectionWeapon[],
-  weaponId: string,
-  baseUrl: string,
-): CollectionDocument {
-  return buildCollection(
-    `${baseUrl}/api/weapons/${weaponId}`,
     weapons.map((w) => weaponToItem(w, baseUrl)),
     { template: WEAPON_TEMPLATE },
   );

--- a/apps/api/src/representations/collection-json/weapons.ts
+++ b/apps/api/src/representations/collection-json/weapons.ts
@@ -38,7 +38,7 @@ export function weaponToItem(weapon: CollectionWeapon, baseUrl: string): Item {
   const links: Link[] = [
     {
       rel: 'collection',
-      href: `${baseUrl}/api/weapons?weaponId=${weapon.weaponId}`,
+      href: `${baseUrl}/api/weapons?weaponId=${encodeURIComponent(weapon.weaponId)}`,
       prompt: `All instances of ${weapon.weaponId}`,
     },
   ];

--- a/apps/api/src/routes/userProfile.test.ts
+++ b/apps/api/src/routes/userProfile.test.ts
@@ -71,6 +71,16 @@ describe('Profile routes', () => {
 
       expect(res.status).toBe(401);
     });
+
+    it('returns 401 when token is expired', async () => {
+      vi.mocked(verifyToken).mockRejectedValue({ code: 'auth/id-token-expired' });
+
+      const res = await app.request(authedRequest('GET', '/api/profile'));
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Invalid or expired token');
+    });
   });
 
   describe('GET /api/profile', () => {

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -167,6 +167,14 @@ describe('Weapon routes', () => {
       const body = (await res.json()) as { detail: string };
       expect(body.detail).toBe('Unknown weapon: not-a-weapon');
     });
+
+    it('returns 400 for empty weaponId', async () => {
+      const res = await app.request(authedRequest('GET', '/api/weapons?weaponId='));
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('weaponId query parameter must not be empty');
+    });
   });
 
   describe('POST /api/weapons', () => {

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -10,10 +10,10 @@ vi.mock('@/lib/firebase/auth.js', () => ({
 
 vi.mock('@/repositories/weapons/index.js', () => ({
   listWeapons: vi.fn(),
-  listWeaponInstances: vi.fn(),
-  createWeaponInstance: vi.fn(),
-  updateWeaponInstance: vi.fn(),
-  deleteWeaponInstance: vi.fn(),
+  getWeapon: vi.fn(),
+  createWeapon: vi.fn(),
+  updateWeapon: vi.fn(),
+  deleteWeapon: vi.fn(),
 }));
 
 vi.mock('@genshin/game-data', () => ({
@@ -23,11 +23,11 @@ vi.mock('@genshin/game-data', () => ({
 import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
 import {
-  createWeaponInstance,
-  deleteWeaponInstance,
-  listWeaponInstances,
+  createWeapon,
+  deleteWeapon,
+  getWeapon,
   listWeapons,
-  updateWeaponInstance,
+  updateWeapon,
 } from '@/repositories/weapons/index.js';
 import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
@@ -59,32 +59,6 @@ describe('Weapon routes', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  describe('authentication', () => {
-    it('returns 401 without Authorization header', async () => {
-      const res = await app.request('/api/weapons');
-
-      expect(res.status).toBe(401);
-    });
-
-    it('returns 401 with malformed Authorization header', async () => {
-      const res = await app.request('/api/weapons', {
-        headers: { Authorization: 'NotBearer token' },
-      });
-
-      expect(res.status).toBe(401);
-    });
-
-    it('returns 401 when token is expired', async () => {
-      vi.mocked(verifyToken).mockRejectedValue({ code: 'auth/id-token-expired' });
-
-      const res = await app.request(authedRequest('GET', '/api/weapons'));
-
-      expect(res.status).toBe(401);
-      const body = (await res.json()) as { detail: string };
-      expect(body.detail).toBe('Invalid or expired token');
-    });
   });
 
   describe('GET /api/weapons', () => {
@@ -138,7 +112,7 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('GET /api/weapons/:weaponId', () => {
+  describe('GET /api/weapons?weaponId=', () => {
     let res: Response;
     let body: CollectionDocument;
 
@@ -147,8 +121,8 @@ describe('Weapon routes', () => {
         id: 'mistsplitter-reforged',
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
-      vi.mocked(listWeaponInstances).mockResolvedValue([FAKE_WEAPON]);
-      res = await app.request(authedRequest('GET', '/api/weapons/mistsplitter-reforged'));
+      vi.mocked(listWeapons).mockResolvedValue([FAKE_WEAPON]);
+      res = await app.request(authedRequest('GET', '/api/weapons?weaponId=mistsplitter-reforged'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -174,9 +148,11 @@ describe('Weapon routes', () => {
     });
 
     it('returns empty items when no instances exist', async () => {
-      vi.mocked(listWeaponInstances).mockResolvedValue([]);
+      vi.mocked(listWeapons).mockResolvedValue([]);
 
-      const res = await app.request(authedRequest('GET', '/api/weapons/mistsplitter-reforged'));
+      const res = await app.request(
+        authedRequest('GET', '/api/weapons?weaponId=mistsplitter-reforged'),
+      );
 
       const body = (await res.json()) as CollectionDocument;
       expect(body.collection.items).toEqual([]);
@@ -185,7 +161,7 @@ describe('Weapon routes', () => {
     it('returns 400 for unknown weapon ID', async () => {
       vi.mocked(getWeaponById).mockReturnValue(undefined);
 
-      const res = await app.request(authedRequest('GET', '/api/weapons/not-a-weapon'));
+      const res = await app.request(authedRequest('GET', '/api/weapons?weaponId=not-a-weapon'));
 
       expect(res.status).toBe(400);
       const body = (await res.json()) as { detail: string };
@@ -193,7 +169,7 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('POST /api/weapons/:weaponId', () => {
+  describe('POST /api/weapons', () => {
     let res: Response;
     let body: CollectionDocument;
 
@@ -202,9 +178,10 @@ describe('Weapon routes', () => {
         id: 'mistsplitter-reforged',
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
-      vi.mocked(createWeaponInstance).mockResolvedValue(FAKE_WEAPON);
+      vi.mocked(createWeapon).mockResolvedValue(FAKE_WEAPON);
       res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: 1,
         }),
       );
@@ -220,9 +197,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns Location header pointing to created instance', () => {
-      expect(res.headers.get('location')).toBe(
-        'http://localhost/api/weapons/mistsplitter-reforged/instance-uuid-1',
-      );
+      expect(res.headers.get('location')).toBe('http://localhost/api/weapons/instance-uuid-1');
     });
 
     it('returns single-item collection', () => {
@@ -237,7 +212,8 @@ describe('Weapon routes', () => {
       vi.mocked(getWeaponById).mockReturnValue(undefined);
 
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/not-a-weapon', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'not-a-weapon',
           refinementLevel: 1,
         }),
       );
@@ -249,7 +225,7 @@ describe('Weapon routes', () => {
 
     it('returns 400 when body is not valid JSON', async () => {
       const res = await app.request(
-        new Request('http://localhost/api/weapons/mistsplitter-reforged', {
+        new Request('http://localhost/api/weapons', {
           method: 'POST',
           headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
           body: 'not-json',
@@ -259,9 +235,21 @@ describe('Weapon routes', () => {
       expect(res.status).toBe(400);
     });
 
+    it('returns 422 when weaponId is missing', async () => {
+      const res = await app.request(
+        authedRequest('POST', '/api/weapons', {
+          refinementLevel: 1,
+        }),
+      );
+
+      expect(res.status).toBe(422);
+    });
+
     it('returns 422 when refinementLevel is missing', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {}),
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
+        }),
       );
 
       expect(res.status).toBe(422);
@@ -269,7 +257,8 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is not a number', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: 'R5',
         }),
       );
@@ -279,7 +268,8 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is below minimum', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: MIN_REFINEMENT_LEVEL - 1,
         }),
       );
@@ -289,7 +279,8 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is above maximum', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: MAX_REFINEMENT_LEVEL + 1,
         }),
       );
@@ -299,7 +290,8 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is not an integer', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: 2.5,
         }),
       );
@@ -309,7 +301,8 @@ describe('Weapon routes', () => {
 
     it('returns 422 when body contains extra properties', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: 1,
           extra: true,
         }),
@@ -319,13 +312,14 @@ describe('Weapon routes', () => {
     });
 
     it('accepts refinementLevel at minimum boundary', async () => {
-      vi.mocked(createWeaponInstance).mockResolvedValue({
+      vi.mocked(createWeapon).mockResolvedValue({
         ...FAKE_WEAPON,
         refinementLevel: MIN_REFINEMENT_LEVEL,
       });
 
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: MIN_REFINEMENT_LEVEL,
         }),
       );
@@ -334,13 +328,14 @@ describe('Weapon routes', () => {
     });
 
     it('accepts refinementLevel at maximum boundary', async () => {
-      vi.mocked(createWeaponInstance).mockResolvedValue({
+      vi.mocked(createWeapon).mockResolvedValue({
         ...FAKE_WEAPON,
         refinementLevel: MAX_REFINEMENT_LEVEL,
       });
 
       const res = await app.request(
-        authedRequest('POST', '/api/weapons/mistsplitter-reforged', {
+        authedRequest('POST', '/api/weapons', {
+          weaponId: 'mistsplitter-reforged',
           refinementLevel: MAX_REFINEMENT_LEVEL,
         }),
       );
@@ -349,18 +344,51 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('PUT /api/weapons/:weaponId/:weaponInstanceId', () => {
+  describe('GET /api/weapons/:weaponInstanceId', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(getWeaponById).mockReturnValue({
-        id: 'mistsplitter-reforged',
-        name: 'Mistsplitter Reforged',
-      } as ReturnType<typeof getWeaponById>);
-      vi.mocked(updateWeaponInstance).mockResolvedValue(FAKE_WEAPON);
+      vi.mocked(getWeapon).mockResolvedValue(FAKE_WEAPON);
+      res = await app.request(authedRequest('GET', '/api/weapons/instance-uuid-1'));
+      body = (await res.json()) as CollectionDocument;
+    });
+
+    it('returns 200', () => {
+      expect(res.status).toBe(200);
+    });
+
+    it('returns collection+json content type', () => {
+      expect(res.headers.get('content-type')).toBe(EXPECTED_CONTENT_TYPE);
+    });
+
+    it('returns single-item collection', () => {
+      expect(body.collection.items).toHaveLength(1);
+    });
+
+    it('includes weapon domain data', () => {
+      expect(body.collection.items[0].data).toEqual(FAKE_WEAPON_ITEM_DATA);
+    });
+
+    it('returns 404 when weapon instance not found', async () => {
+      vi.mocked(getWeapon).mockResolvedValue(null);
+
+      const res = await app.request(authedRequest('GET', '/api/weapons/nonexistent'));
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { detail: string };
+      expect(body.detail).toBe('Weapon instance not found');
+    });
+  });
+
+  describe('PATCH /api/weapons/:weaponInstanceId', () => {
+    let res: Response;
+    let body: CollectionDocument;
+
+    beforeEach(async () => {
+      vi.mocked(updateWeapon).mockResolvedValue(FAKE_WEAPON);
       res = await app.request(
-        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
           refinementLevel: 1,
         }),
       );
@@ -384,10 +412,10 @@ describe('Weapon routes', () => {
     });
 
     it('returns 404 when weapon instance not found', async () => {
-      vi.mocked(updateWeaponInstance).mockResolvedValue(null);
+      vi.mocked(updateWeapon).mockResolvedValue(null);
 
       const res = await app.request(
-        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/nonexistent', {
+        authedRequest('PATCH', '/api/weapons/nonexistent', {
           refinementLevel: 1,
         }),
       );
@@ -399,8 +427,8 @@ describe('Weapon routes', () => {
 
     it('returns 400 when body is not valid JSON', async () => {
       const res = await app.request(
-        new Request('http://localhost/api/weapons/mistsplitter-reforged/instance-uuid-1', {
-          method: 'PUT',
+        new Request('http://localhost/api/weapons/instance-uuid-1', {
+          method: 'PATCH',
           headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
           body: 'not-json',
         }),
@@ -411,7 +439,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is invalid', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
           refinementLevel: 0,
         }),
       );
@@ -421,7 +449,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when body contains extra properties', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
           refinementLevel: 1,
           extra: true,
         }),
@@ -431,64 +459,29 @@ describe('Weapon routes', () => {
     });
 
     it('updates refinementLevel', async () => {
-      vi.mocked(updateWeaponInstance).mockResolvedValue({
+      vi.mocked(updateWeapon).mockResolvedValue({
         ...FAKE_WEAPON,
         refinementLevel: 3,
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/weapons/mistsplitter-reforged/instance-uuid-1', {
+        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
           refinementLevel: 3,
         }),
       );
 
       expect(res.status).toBe(200);
     });
-
-    it('returns 400 for unknown weapon ID', async () => {
-      vi.mocked(getWeaponById).mockReturnValue(undefined);
-
-      const res = await app.request(
-        authedRequest('PUT', '/api/weapons/not-a-weapon/instance-uuid-1', {
-          refinementLevel: 1,
-        }),
-      );
-
-      expect(res.status).toBe(400);
-      const body = (await res.json()) as { detail: string };
-      expect(body.detail).toBe('Unknown weapon: not-a-weapon');
-    });
   });
 
-  describe('DELETE /api/weapons/:weaponId/:weaponInstanceId', () => {
-    beforeEach(() => {
-      vi.mocked(getWeaponById).mockReturnValue({
-        id: 'mistsplitter-reforged',
-        name: 'Mistsplitter Reforged',
-      } as ReturnType<typeof getWeaponById>);
-    });
-
+  describe('DELETE /api/weapons/:weaponInstanceId', () => {
     it('returns 204 with no body', async () => {
-      vi.mocked(deleteWeaponInstance).mockResolvedValue();
+      vi.mocked(deleteWeapon).mockResolvedValue();
 
-      const res = await app.request(
-        authedRequest('DELETE', '/api/weapons/mistsplitter-reforged/instance-uuid-1'),
-      );
+      const res = await app.request(authedRequest('DELETE', '/api/weapons/instance-uuid-1'));
 
       expect(res.status).toBe(204);
       expect(await res.text()).toBe('');
-    });
-
-    it('returns 400 for unknown weapon ID', async () => {
-      vi.mocked(getWeaponById).mockReturnValue(undefined);
-
-      const res = await app.request(
-        authedRequest('DELETE', '/api/weapons/not-a-weapon/instance-uuid-1'),
-      );
-
-      expect(res.status).toBe(400);
-      const body = (await res.json()) as { detail: string };
-      expect(body.detail).toBe('Unknown weapon: not-a-weapon');
     });
   });
 });

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -46,7 +46,11 @@ weapons.get('/', async (c) => {
   const weaponId = c.req.query('weaponId');
   const baseUrl = new URL(c.req.url).origin;
 
-  if (weaponId) {
+  if (weaponId !== undefined) {
+    if (!weaponId) {
+      throw new HTTPException(400, { message: 'weaponId query parameter must not be empty' });
+    }
+
     if (!getWeaponById(weaponId)) {
       throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
     }

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -6,20 +6,19 @@ import { auth } from '@/middleware/auth.js';
 import type { ValidatedBodyVariables } from '@/middleware/validate-body.js';
 import { validateBody } from '@/middleware/validate-body.js';
 import {
-  createWeaponInstance,
-  deleteWeaponInstance,
-  listWeaponInstances,
+  createWeapon,
+  deleteWeapon,
+  getWeapon,
   listWeapons,
-  updateWeaponInstance,
+  updateWeapon,
 } from '@/repositories/weapons/index.js';
 import {
-  weaponInstanceListDocument,
   weaponItemDocument,
   weaponItemHref,
   weaponListDocument,
 } from '@/representations/collection-json/weapons.js';
+import weaponPatchSchema from '@/schemas/weapons/patch/1.0.0.json' with { type: 'json' };
 import weaponPostSchema from '@/schemas/weapons/post/1.0.0.json' with { type: 'json' };
-import weaponPutSchema from '@/schemas/weapons/put/1.0.0.json' with { type: 'json' };
 import { COLLECTION_JSON } from '@genshin/collection-json';
 import { getWeaponById } from '@genshin/game-data';
 import type { UUID } from '@genshin/types';
@@ -33,6 +32,7 @@ weapons.use('*', auth);
 const PROFILE_PATH = '/profiles/weapons/1.0.0.json';
 
 interface CreateWeaponBody {
+  weaponId: string;
   refinementLevel: number;
 }
 
@@ -40,50 +40,44 @@ interface UpdateWeaponBody {
   refinementLevel: number;
 }
 
-// GET /api/weapons — List all weapon instances as a flat collection
+// GET /api/weapons — List all weapon instances, optionally filtered by weaponId
 weapons.get('/', async (c) => {
   const userId = c.get('user').uid;
-  const items = await listWeapons(userId);
+  const weaponId = c.req.query('weaponId');
   const baseUrl = new URL(c.req.url).origin;
+
+  if (weaponId) {
+    if (!getWeaponById(weaponId)) {
+      throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
+    }
+
+    const instances = await listWeapons(userId, weaponId);
+
+    return c.body(JSON.stringify(weaponListDocument(instances, baseUrl)), {
+      headers: { 'Content-Type': `${COLLECTION_JSON}; profile="${baseUrl}${PROFILE_PATH}"` },
+    });
+  }
+
+  const items = await listWeapons(userId);
 
   return c.body(JSON.stringify(weaponListDocument(items, baseUrl)), {
     headers: { 'Content-Type': `${COLLECTION_JSON}; profile="${baseUrl}${PROFILE_PATH}"` },
   });
 });
 
-// GET /api/weapons/:weaponId — List instances of specific weapon
-weapons.get('/:weaponId', async (c) => {
+// POST /api/weapons — Create new weapon instance
+weapons.post('/', validateBody(weaponPostSchema), async (c) => {
   const userId = c.get('user').uid;
-  const { weaponId } = c.req.param();
+  const { weaponId, refinementLevel } = c.get('validatedBody') as CreateWeaponBody;
 
   if (!getWeaponById(weaponId)) {
     throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
   }
 
-  const instances = await listWeaponInstances(userId, weaponId);
+  const weapon = await createWeapon(userId, weaponId, refinementLevel);
   const baseUrl = new URL(c.req.url).origin;
 
-  return c.body(JSON.stringify(weaponInstanceListDocument(instances, weaponId, baseUrl)), {
-    headers: { 'Content-Type': `${COLLECTION_JSON}; profile="${baseUrl}${PROFILE_PATH}"` },
-  });
-});
-
-// POST /api/weapons/:weaponId — Create new weapon instance
-weapons.post('/:weaponId', validateBody(weaponPostSchema), async (c) => {
-  const userId = c.get('user').uid;
-  const { weaponId } = c.req.param();
-
-  // Verify weaponId exists in game data
-  if (!getWeaponById(weaponId)) {
-    throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
-  }
-
-  const { refinementLevel } = c.get('validatedBody') as CreateWeaponBody;
-
-  const weapon = await createWeaponInstance(userId, weaponId, refinementLevel);
-  const baseUrl = new URL(c.req.url).origin;
-
-  return c.body(JSON.stringify(weaponInstanceListDocument([weapon], weaponId, baseUrl)), {
+  return c.body(JSON.stringify(weaponListDocument([weapon], baseUrl)), {
     status: 201,
     headers: {
       'Content-Type': `${COLLECTION_JSON}; profile="${baseUrl}${PROFILE_PATH}"`,
@@ -92,19 +86,12 @@ weapons.post('/:weaponId', validateBody(weaponPostSchema), async (c) => {
   });
 });
 
-// PUT /api/weapons/:weaponId/:weaponInstanceId — Update weapon instance
-weapons.put('/:weaponId/:weaponInstanceId', validateBody(weaponPutSchema), async (c) => {
+// GET /api/weapons/:weaponInstanceId — Get single weapon instance
+weapons.get('/:weaponInstanceId', async (c) => {
   const userId = c.get('user').uid;
-  const { weaponId } = c.req.param();
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
 
-  if (!getWeaponById(weaponId)) {
-    throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
-  }
-
-  const { refinementLevel } = c.get('validatedBody') as UpdateWeaponBody;
-
-  const weapon = await updateWeaponInstance(userId, weaponId, weaponInstanceId, refinementLevel);
+  const weapon = await getWeapon(userId, weaponInstanceId);
 
   if (!weapon) {
     throw new HTTPException(404, { message: 'Weapon instance not found' });
@@ -117,17 +104,32 @@ weapons.put('/:weaponId/:weaponInstanceId', validateBody(weaponPutSchema), async
   });
 });
 
-// DELETE /api/weapons/:weaponId/:weaponInstanceId — Delete weapon instance
-weapons.delete('/:weaponId/:weaponInstanceId', async (c) => {
+// PATCH /api/weapons/:weaponInstanceId — Update weapon instance
+weapons.patch('/:weaponInstanceId', validateBody(weaponPatchSchema), async (c) => {
   const userId = c.get('user').uid;
-  const { weaponId } = c.req.param();
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
 
-  if (!getWeaponById(weaponId)) {
-    throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
+  const { refinementLevel } = c.get('validatedBody') as UpdateWeaponBody;
+
+  const weapon = await updateWeapon(userId, weaponInstanceId, refinementLevel);
+
+  if (!weapon) {
+    throw new HTTPException(404, { message: 'Weapon instance not found' });
   }
 
-  await deleteWeaponInstance(userId, weaponId, weaponInstanceId);
+  const baseUrl = new URL(c.req.url).origin;
+
+  return c.body(JSON.stringify(weaponItemDocument(weapon, baseUrl)), {
+    headers: { 'Content-Type': `${COLLECTION_JSON}; profile="${baseUrl}${PROFILE_PATH}"` },
+  });
+});
+
+// DELETE /api/weapons/:weaponInstanceId — Delete weapon instance
+weapons.delete('/:weaponInstanceId', async (c) => {
+  const userId = c.get('user').uid;
+  const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
+
+  await deleteWeapon(userId, weaponInstanceId);
 
   return c.body(null, 204);
 });

--- a/apps/api/src/schemas/weapons/patch/1.0.0.json
+++ b/apps/api/src/schemas/weapons/patch/1.0.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://api.genshin.dungeon.studio/schemas/weapons/put/1.0.0.json",
+  "$id": "https://api.genshin.dungeon.studio/schemas/weapons/patch/1.0.0.json",
   "title": "Update Weapon Instance Request",
   "description": "Request body for updating an existing weapon instance in the user's collection",
   "type": "object",

--- a/apps/api/src/schemas/weapons/post/1.0.0.json
+++ b/apps/api/src/schemas/weapons/post/1.0.0.json
@@ -5,6 +5,11 @@
   "description": "Request body for creating a new weapon instance in the user's collection",
   "type": "object",
   "properties": {
+    "weaponId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the weapon from game data"
+    },
     "refinementLevel": {
       "type": "integer",
       "minimum": 1,
@@ -12,6 +17,6 @@
       "description": "Refinement rank of the weapon instance"
     }
   },
-  "required": ["refinementLevel"],
+  "required": ["weaponId", "refinementLevel"],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

Flattens weapon Firestore storage from nested subcollections to flat UUID-keyed documents, as described in #471.

## Changes

### Storage
- Replace nested subcollection `users/{uid}/weapons/{weaponId}/instances/{instanceId}` with flat collection `users/{uid}/weapons/{weaponInstanceId}`
- Store `weaponId` as a field inside each document

### API surface
- All endpoints use `/api/weapons` and `/api/weapons/:weaponInstanceId` (flat URLs)
- `POST /api/weapons` for creation (server generates UUID, body includes `weaponId`)
- `PATCH /api/weapons/:weaponInstanceId` for updates (replaces PUT)
- `GET /api/weapons?weaponId=` for filtering by weapon type
- `GET /api/weapons/:weaponInstanceId` for single instance retrieval
- `DELETE /api/weapons/:weaponInstanceId` for deletion

### Repository
- Rename functions: drop `Instance` suffix (`getWeapon`, `createWeapon`, `updateWeapon`, `deleteWeapon`)
- Merge `listWeaponInstances` into `listWeapons` with optional `weaponId` parameter
- Simplify all CRUD — single collection reads/writes, no batch operations

### Schemas
- Replace `put/1.0.0.json` with `patch/1.0.0.json`
- Add `weaponId` to `post/1.0.0.json`

### Tests
- Move auth middleware tests to profile (where they belong)
- Add expired-token test to profile tests
- Rewrite all weapon route tests for new API shape

Closes #471