### PR TITLE
docs: add schema module conventions to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,14 @@
 - Validate API success responses against the published JSON Schema in tests using AJV, not just individual field assertions. Keep one sanity-check assertion per test for a specific value.
 - Prefer explicit types over type munging. For example, define `ProfileUpdate` rather than using `Partial<Pick<UserProfile, 'name'>>` inline.
 
+## Schema module conventions
+
+- Define each JSON Schema as a typed TypeScript module in `apps/api/src/schemas/{module}/`, not a `.json` file.
+- Export a single `const` using `as const satisfies JsonSchemaProfile` from `@/schemas/json-schema-profile.js`.
+- Name files `{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). The serving path mirrors the filename: `/schemas/{module}/{direction}-v{n}.json`.
+- Register every schema module in `apps/api/src/schemas/registry.ts`. The registry completeness test discovers files on disk and asserts the registry contains each one.
+- The schema route stamps `$id` from the request origin at serve time. Don't declare `$id` in schema modules.
+
 ## Frontend rules
 
 - Prefer composition over inheritance and use early returns for conditional rendering.

--- a/apps/api/src/schemas/json-schema-profile.ts
+++ b/apps/api/src/schemas/json-schema-profile.ts
@@ -16,6 +16,10 @@
 export interface JsonSchemaProfile {
   /** Absolute URL path where the schema is served (e.g. `/schemas/profile/get-response-v1.json`). */
   readonly path: string;
+  // Intentionally `Record<string, unknown>` rather than AJV's `SchemaObject`
+  // to keep this interface free of validation-library coupling. The
+  // `as const satisfies` pattern on each module preserves literal types, and
+  // `Record<string, unknown>` is assignable to `SchemaObject` at call sites.
   /** The JSON Schema object. */
   readonly schema: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Document the schema module conventions established in #492 so they're discoverable by AI assistants and contributors.

## Changes

- **Inline comment** on `JsonSchemaProfile.schema` explaining why it uses `Record<string, unknown>` instead of AJV's `SchemaObject` (avoids coupling the data-description interface to a validation library).
- **Schema module conventions** section in `copilot-instructions.md` covering:
  - Typed TypeScript modules over `.json` files
  - `as const satisfies JsonSchemaProfile` pattern
  - File naming: `{direction}-v{n}.ts`
  - Registry registration and completeness test
  - `$id` stamped at serve time, not declared in source