### PR TITLE
docs: add DSGEP-005 formalizing schema direction segment convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@
 
 - Define each JSON Schema as a typed TypeScript module in `apps/api/src/schemas/{module}/`, not a `.json` file.
 - Export a single `const` using `as const satisfies JsonSchemaProfile` from `@/schemas/json-schema-profile.js`.
-- Name files `{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). The serving path mirrors the filename: `/schemas/{module}/{direction}-v{n}.json`.
+- Name files `{method}-{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). `{method}` is the lowercase HTTP method and `{direction}` is `request` or `response`. The serving path mirrors the filename: `/schemas/{module}/{method}-{direction}-v{n}.json`. See [DSGEP-005](../docs/explanation/dsgep-005-schema-direction-segment.md).
 - Register every schema module in `apps/api/src/schemas/registry.ts`. The registry completeness test discovers files on disk and asserts the registry contains each one.
 - The schema route stamps `$id` from the request origin at serve time. Don't declare `$id` in schema modules.
 

--- a/docs/explanation/dsgep-003-json-schema-strategy.md
+++ b/docs/explanation/dsgep-003-json-schema-strategy.md
@@ -7,7 +7,7 @@
 
 <!-- vale Microsoft.HeadingAcronyms = YES -->
 
-- **Status**: Draft
+- **Status**: Accepted
 - **Created**: 2026-03-01
 - **Authors**: Alex Brandt
 

--- a/docs/explanation/dsgep-005-schema-direction-segment.md
+++ b/docs/explanation/dsgep-005-schema-direction-segment.md
@@ -1,0 +1,158 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- vale Microsoft.HeadingAcronyms = NO -->
+
+# DSGEP-005: Schema paths include request/response direction segment
+
+<!-- vale Microsoft.HeadingAcronyms = YES -->
+
+- **Status**: Draft
+- **Created**: 2026-03-15
+- **Authors**: Alex Brandt
+- **Amends**: [DSGEP-003](dsgep-003-json-schema-strategy.md)
+
+## Abstract
+
+This Dungeon Studio Genshin Enhancement Proposal (DSGEP) amends the schema path convention established in [DSGEP-003](dsgep-003-json-schema-strategy.md). The original convention uses `/schemas/{module}/{name}/{version}.json`, where `{name}` is a method-scoped identifier like `get` or `patch`. The HTTP method alone doesn't distinguish request from response. This DSGEP replaces that convention with `/schemas/{module}/{method}-{direction}-v{n}.json`, embedding both the HTTP method and the message direction (`request` or `response`) in the schema name. This matches the convention already implemented in the codebase.
+
+## Problem statement
+
+DSGEP-003 defines schema paths as `/schemas/{module}/{name}/{version}.json`. The `{name}` segment carries only the HTTP method (for example, `get`, `patch`). This works when each method has at most one schema, but breaks down when a method needs both a request and a response schema. For example, a PATCH operation may have a distinct request schema (the partial update body) and a distinct response schema (the full resource representation). Without a direction component, there is no slot to distinguish between them.
+
+## Context
+
+DSGEP-003 was accepted with the path convention `/schemas/{module}/{name}/{version}.json` and a source file layout using nested directories per module and name. During implementation, the codebase adopted a flatter convention: schema files live directly under `apps/api/src/schemas/{module}/` with filenames like `get-response-v1.ts` and serving paths like `/schemas/profile/get-response-v1.json`. This embeds both the HTTP method and the direction in the filename, making request and response schemas distinguishable without additional directory nesting.
+
+The codebase has six schema modules across four domain modules (`root`, `profile`, `characters`, `weapons`). This gap between the DSGEP-003 convention and the implementation surfaced during review of PR #478.
+
+## Decision
+
+Amend the DSGEP-003 path convention from:
+
+```text
+/schemas/{module}/{name}/{version}.json
+```
+
+to:
+
+```text
+/schemas/{module}/{method}-{direction}-v{n}.json
+```
+
+Where:
+
+- `{module}` matches the domain module name (for example, `profile`, `characters`)
+- `{method}` is the lowercase HTTP method (for example, `get`, `put`, `patch`, `post`)
+- `{direction}` is either `request` or `response`
+- `{n}` is a shorthand version number (for example, `1`, `2`)
+
+### Examples
+
+```text
+GET /schemas/profile/get-response-v1.json       → profile GET response schema v1
+GET /schemas/profile/patch-request-v1.json       → profile PATCH request body schema v1
+GET /schemas/characters/put-request-v1.json      → character PUT request body schema v1
+GET /schemas/weapons/post-request-v1.json        → weapon creation request schema v1
+GET /schemas/weapons/patch-request-v1.json       → weapon update request schema v1
+GET /schemas/root/get-response-v1.json           → API root response schema v1
+```
+
+### Source file layout
+
+Schema source files under `apps/api/src/schemas/` use a flat layout per module:
+
+```text
+apps/api/src/schemas/
+├── characters/
+│   └── put-request-v1.ts
+├── profile/
+│   ├── get-response-v1.ts
+│   └── patch-request-v1.ts
+├── root/
+│   └── get-response-v1.ts
+├── weapons/
+│   ├── patch-request-v1.ts
+│   └── post-request-v1.ts
+├── json-schema-profile.ts
+├── registry.ts
+└── registry.test.ts
+```
+
+File names use the pattern `{method}-{direction}-v{n}.ts`. The serving path mirrors the filename: `/schemas/{module}/{method}-{direction}-v{n}.json`.
+
+### Schema `$id` values
+
+The schema route stamps `$id` at serve time using the request origin, as established in DSGEP-003:
+
+```json
+{
+  "$id": "https://api.genshin.dungeon.studio/schemas/profile/get-response-v1.json"
+}
+```
+
+### Unchanged decisions
+
+All other decisions from DSGEP-003 remain in effect:
+
+- Schema hosting at dedicated API endpoints
+- `Content-Type: application/schema+json` for schema responses
+- Discovery via `profile` media type parameter on `Content-Type` and `Accept`
+- Stability contract using Semantic Versioning 2.0.0
+- Major version transition process
+
+## Rationale
+
+### Why embed direction in the filename
+
+The direction is a necessary discriminator: a PATCH endpoint may define both a request schema and a response schema. Including `request` or `response` in the name makes each schema self-describing. The flat layout avoids extra directory nesting while keeping paths short and readable.
+
+### Why `request` and `response`
+
+These terms are unambiguous in an HTTP context and match the language used in RFC 9110. Alternatives like `input`/`output` or `body`/`result` are less standard.
+
+### Why a flat layout instead of nested directories
+
+DSGEP-003 proposed nested directories (`{module}/{name}/{version}.json`). The flat layout with descriptive filenames (`{module}/{method}-{direction}-v{n}.ts`) is simpler: fewer directories, shorter import paths, and each filename is self-describing without needing to inspect the parent directory. The tradeoff is that filenames are longer, but they remain concise and regular.
+
+## Consequences
+
+### Positive
+
+- **Unambiguous**: Every schema path communicates both the HTTP method and the message direction
+- **Flat**: No extra directory nesting beyond the module level
+- **Self-describing**: Filenames convey method, direction, and version at a glance
+- **Already implemented**: The codebase already follows this convention, so no migration is needed
+
+### Negative
+
+- **Longer filenames**: Names like `patch-request-v1.ts` are longer than DSGEP-003's `patch/1.0.0.json`
+- **No semver in path**: The shorthand `v{n}` in the path doesn't express minor or patch versions. The stability contract from DSGEP-003 still applies, and a breaking change requires a new file (for example, `get-response-v2.ts`)
+
+## Alternatives considered
+
+### Alternative 1: Nested directory per method with a direction subdirectory
+
+**Approach**: `/schemas/{module}/{method}/{direction}/{version}.json` with directories like `profile/get/response/1.0.0.json`.
+
+**Rejected because**: adds two levels of nesting beyond the module. The flat layout achieves the same disambiguation with less structural complexity.
+
+### Alternative 2: Keep DSGEP-003 convention and rely on implicit direction
+
+**Approach**: continue using `/schemas/{module}/{name}/{version}.json` where `get` implicitly means the response and methods with request bodies use names like `patch-body`.
+
+**Rejected because**: implicit conventions create ambiguity. A new contributor wouldn't know whether `patch/1.0.0.json` is the request or response schema without checking the file contents.
+
+## Implementation notes
+
+This DSGEP formalizes the convention already implemented in the codebase. No code changes are necessary.
+
+## References
+
+- [DSGEP-003: JSON Schema presentation and discovery strategy](dsgep-003-json-schema-strategy.md): The base decision this DSGEP amends
+- [Issue #479](https://github.com/dungeon-studio/genshin.dungeon.studio/issues/479): Schema paths include request/response direction segment
+- [PR #478 discussion](https://github.com/dungeon-studio/genshin.dungeon.studio/pull/478#discussion_r2935894001): Where the ambiguity was identified
+
+## Revision history
+
+- 2026-03-15: Initial draft (DSGEP-005)


### PR DESCRIPTION
## Summary

Finalize DSGEP-003 (Draft → Accepted) and create DSGEP-005 to amend its path convention. DSGEP-005 documents the `{method}-{direction}-v{n}` naming pattern already implemented in the codebase, making request and response schemas unambiguously distinguishable.

## Changes

- **DSGEP-003**: Status changed from Draft to Accepted
- **DSGEP-005**: New DSGEP amending the path convention from `/schemas/{module}/{name}/{version}.json` to `/schemas/{module}/{method}-{direction}-v{n}.json`
- **Copilot instructions**: Updated schema module conventions to reference DSGEP-005 and use clearer `{method}-{direction}` terminology

No code changes — the codebase already follows this convention.

Closes #479