### PR TITLE
feat(web): add zustand collection store with localStorage persistence

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
+    "@genshin/types": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "5.90.21",

--- a/apps/web/src/features/collection/useCollectionStore.ts
+++ b/apps/web/src/features/collection/useCollectionStore.ts
@@ -13,7 +13,7 @@ interface CollectionEntry {
 type CharacterId = CollectionCharacter['characterId'];
 
 interface CollectionState {
-  characters: Record<string, CollectionEntry>;
+  characters: Record<CharacterId, CollectionEntry>;
   addCharacter: (characterId: CharacterId) => void;
   removeCharacter: (characterId: CharacterId) => void;
   setConstellationLevel: (characterId: CharacterId, level: number) => void;
@@ -27,6 +27,8 @@ export const useCollectionStore = create<CollectionState>()(
       characters: {},
 
       addCharacter: (characterId) => {
+        if (get().characters[characterId]) return;
+
         set((state) => ({
           characters: {
             ...state.characters,

--- a/apps/web/src/features/collection/useCollectionStore.ts
+++ b/apps/web/src/features/collection/useCollectionStore.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionCharacter } from '@genshin/types';
+import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/types';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface CollectionEntry {
+  constellationLevel: number;
+}
+
+type CharacterId = CollectionCharacter['characterId'];
+
+interface CollectionState {
+  characters: Record<string, CollectionEntry>;
+  addCharacter: (characterId: CharacterId) => void;
+  removeCharacter: (characterId: CharacterId) => void;
+  setConstellationLevel: (characterId: CharacterId, level: number) => void;
+  isOwned: (characterId: CharacterId) => boolean;
+  getCharacter: (characterId: CharacterId) => CollectionEntry | undefined;
+}
+
+export const useCollectionStore = create<CollectionState>()(
+  persist(
+    (set, get) => ({
+      characters: {},
+
+      addCharacter: (characterId) => {
+        set((state) => ({
+          characters: {
+            ...state.characters,
+            [characterId]: {
+              constellationLevel: MIN_CONSTELLATION_LEVEL,
+            },
+          },
+        }));
+      },
+
+      removeCharacter: (characterId) => {
+        set((state) => {
+          const characters = { ...state.characters };
+          delete characters[characterId];
+          return { characters };
+        });
+      },
+
+      setConstellationLevel: (characterId, level) => {
+        if (!isValidConstellationLevel(level)) return;
+
+        const entry = get().characters[characterId];
+        if (!entry) return;
+
+        set((state) => ({
+          characters: {
+            ...state.characters,
+            [characterId]: { ...entry, constellationLevel: level },
+          },
+        }));
+      },
+
+      isOwned: (characterId) => {
+        return characterId in get().characters;
+      },
+
+      getCharacter: (characterId) => {
+        return get().characters[characterId];
+      },
+    }),
+    {
+      name: 'genshin-collection',
+    },
+  ),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@genshin/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

Create `useCollectionStore` zustand store that manages character collection state (owned characters and constellation levels) client-side with `localStorage` persistence.

## Changes

- **New file**: `apps/web/src/features/collection/useCollectionStore.ts`
- **State**: `characters` map keyed by `characterId` → `{ constellationLevel }`
- **Actions**: `addCharacter` (adds at C0), `removeCharacter`, `setConstellationLevel` (validated via `isValidConstellationLevel`)
- **Selectors**: `isOwned`, `getCharacter`
- **Persistence**: zustand `persist` middleware with `localStorage` key `genshin-collection`

## Notes

- Uses types from `@genshin/types` (`CollectionCharacter`, `isValidConstellationLevel`, `MIN_CONSTELLATION_LEVEL`) — no new package dependencies needed.
- This store is the local source of truth until the character CRUD API (#42) lands, at which point it becomes the optimistic cache layer for TanStack Query.

Closes #485