### PR TITLE
feat(web): add CharacterCard compact tile component

### DIFF
--- a/apps/web/src/components/CharacterCard.tsx
+++ b/apps/web/src/components/CharacterCard.tsx
@@ -66,9 +66,10 @@ export function CharacterCard({
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-semibold text-card-foreground">{character.name}</p>
-        <span className="text-xs text-geo-dark" aria-label={`${character.rarity}-star`}>
+        <span className="text-xs text-geo-dark" aria-hidden="true">
           {'\u2605'.repeat(character.rarity)}
         </span>
+        <span className="sr-only">{character.rarity}-star</span>
       </div>
 
       {owned && (

--- a/apps/web/src/components/CharacterCard.tsx
+++ b/apps/web/src/components/CharacterCard.tsx
@@ -31,7 +31,7 @@ interface CharacterCardProps {
   owned?: boolean;
   constellationLevel?: number;
   selected?: boolean;
-  onSelect?: (characterId: string) => void;
+  onSelect?: (characterId: Character['id']) => void;
 }
 
 export function CharacterCard({
@@ -46,11 +46,12 @@ export function CharacterCard({
   return (
     <motion.button
       type="button"
+      aria-pressed={selected}
       whileHover={{ scale: 1.03, transition: { duration: 0.2 } }}
       whileTap={{ scale: 0.97 }}
       onClick={() => onSelect?.(character.id)}
       className={cn(
-        'relative flex items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
+        'relative flex items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         ELEMENT_BORDER_COLORS[character.element],
         !owned && 'opacity-40 grayscale',
         selected &&

--- a/apps/web/src/components/CharacterCard.tsx
+++ b/apps/web/src/components/CharacterCard.tsx
@@ -27,6 +27,16 @@ const ELEMENT_SELECTED_RINGS: Record<Element, string> = {
   Dendro: 'ring-dendro',
 };
 
+const ELEMENT_FOCUS_RINGS: Record<Element, string> = {
+  Pyro: 'focus-visible:ring-pyro',
+  Hydro: 'focus-visible:ring-hydro',
+  Electro: 'focus-visible:ring-electro',
+  Cryo: 'focus-visible:ring-cryo',
+  Anemo: 'focus-visible:ring-anemo',
+  Geo: 'focus-visible:ring-geo',
+  Dendro: 'focus-visible:ring-dendro',
+};
+
 interface CharacterCardProps {
   character: Character;
   owned?: boolean;
@@ -43,34 +53,21 @@ export function CharacterCard({
   onSelect,
 }: CharacterCardProps) {
   const elementIconSrc = `/elements/${character.element.toLowerCase()}.png`;
-  const elementRing = ELEMENT_SELECTED_RINGS[character.element];
 
-  return (
-    <motion.button
-      type="button"
-      aria-pressed={selected}
-      whileHover={{ scale: 1.03, transition: { duration: 0.2 } }}
-      whileTap={{ scale: 0.97 }}
-      onClick={() => onSelect?.(character.id)}
-      className={cn(
-        'relative flex items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
-        ELEMENT_BORDER_COLORS[character.element],
-        !owned && 'opacity-40 grayscale',
-        selected
-          ? cn(
-              'ring-2 ring-offset-2 ring-offset-background',
-              elementRing,
-              `focus-visible:${elementRing}`,
-            )
-          : 'focus-visible:ring-ring',
-      )}
-    >
+  const sharedClassName = cn(
+    'relative flex items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
+    ELEMENT_BORDER_COLORS[character.element],
+    !owned && 'opacity-40 grayscale',
+  );
+
+  const content = (
+    <>
       <img src={elementIconSrc} alt={character.element} className="h-6 w-6 shrink-0" />
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-semibold text-card-foreground">{character.name}</p>
         <span className="text-xs text-geo-dark" aria-label={`${character.rarity}-star`}>
-          {'★'.repeat(character.rarity)}
+          {'\u2605'.repeat(character.rarity)}
         </span>
       </div>
 
@@ -82,6 +79,33 @@ export function CharacterCard({
           C{constellationLevel}
         </span>
       )}
+    </>
+  );
+
+  if (!onSelect) {
+    return <div className={sharedClassName}>{content}</div>;
+  }
+
+  return (
+    <motion.button
+      type="button"
+      aria-pressed={selected}
+      whileHover={{ scale: 1.03, transition: { duration: 0.2 } }}
+      whileTap={{ scale: 0.97 }}
+      onClick={() => onSelect(character.id)}
+      className={cn(
+        sharedClassName,
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+        selected
+          ? cn(
+              'ring-2 ring-offset-2 ring-offset-background',
+              ELEMENT_SELECTED_RINGS[character.element],
+              ELEMENT_FOCUS_RINGS[character.element],
+            )
+          : 'focus-visible:ring-ring',
+      )}
+    >
+      {content}
     </motion.button>
   );
 }

--- a/apps/web/src/components/CharacterCard.tsx
+++ b/apps/web/src/components/CharacterCard.tsx
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Character, Element } from '@genshin/game-data';
+import { motion } from 'framer-motion';
+
+import { cn } from '@/lib/utils';
+
+const ELEMENT_BORDER_COLORS: Record<Element, string> = {
+  Pyro: 'border-l-pyro',
+  Hydro: 'border-l-hydro',
+  Electro: 'border-l-electro',
+  Cryo: 'border-l-cryo',
+  Anemo: 'border-l-anemo',
+  Geo: 'border-l-geo',
+  Dendro: 'border-l-dendro',
+};
+
+const ELEMENT_SELECTED_RINGS: Record<Element, string> = {
+  Pyro: 'ring-pyro',
+  Hydro: 'ring-hydro',
+  Electro: 'ring-electro',
+  Cryo: 'ring-cryo',
+  Anemo: 'ring-anemo',
+  Geo: 'ring-geo',
+  Dendro: 'ring-dendro',
+};
+
+interface CharacterCardProps {
+  character: Character;
+  owned?: boolean;
+  constellationLevel?: number;
+  selected?: boolean;
+  onSelect?: (characterId: string) => void;
+}
+
+export function CharacterCard({
+  character,
+  owned = false,
+  constellationLevel,
+  selected = false,
+  onSelect,
+}: CharacterCardProps) {
+  const elementIconSrc = `/elements/${character.element.toLowerCase()}.png`;
+
+  return (
+    <motion.button
+      type="button"
+      whileHover={{ scale: 1.03, transition: { duration: 0.2 } }}
+      whileTap={{ scale: 0.97 }}
+      onClick={() => onSelect?.(character.id)}
+      className={cn(
+        'relative flex items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
+        ELEMENT_BORDER_COLORS[character.element],
+        !owned && 'opacity-40 grayscale',
+        selected &&
+          cn(
+            'ring-2 ring-offset-2 ring-offset-background',
+            ELEMENT_SELECTED_RINGS[character.element],
+          ),
+      )}
+    >
+      <img src={elementIconSrc} alt={character.element} className="h-6 w-6 shrink-0" />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-card-foreground">{character.name}</p>
+        <span className="text-xs text-geo-dark" aria-label={`${character.rarity}-star`}>
+          {'★'.repeat(character.rarity)}
+        </span>
+      </div>
+
+      {owned && constellationLevel !== undefined && (
+        <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold text-muted-foreground">
+          C{constellationLevel}
+        </span>
+      )}
+    </motion.button>
+  );
+}

--- a/apps/web/src/components/CharacterCard.tsx
+++ b/apps/web/src/components/CharacterCard.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { Character, Element } from '@genshin/game-data';
+import { MIN_CONSTELLATION_LEVEL } from '@genshin/types';
 import { motion } from 'framer-motion';
 
 import { cn } from '@/lib/utils';
@@ -37,11 +38,12 @@ interface CharacterCardProps {
 export function CharacterCard({
   character,
   owned = false,
-  constellationLevel,
+  constellationLevel = MIN_CONSTELLATION_LEVEL,
   selected = false,
   onSelect,
 }: CharacterCardProps) {
   const elementIconSrc = `/elements/${character.element.toLowerCase()}.png`;
+  const elementRing = ELEMENT_SELECTED_RINGS[character.element];
 
   return (
     <motion.button
@@ -51,14 +53,16 @@ export function CharacterCard({
       whileTap={{ scale: 0.97 }}
       onClick={() => onSelect?.(character.id)}
       className={cn(
-        'relative flex items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'relative flex items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
         ELEMENT_BORDER_COLORS[character.element],
         !owned && 'opacity-40 grayscale',
-        selected &&
-          cn(
-            'ring-2 ring-offset-2 ring-offset-background',
-            ELEMENT_SELECTED_RINGS[character.element],
-          ),
+        selected
+          ? cn(
+              'ring-2 ring-offset-2 ring-offset-background',
+              elementRing,
+              `focus-visible:${elementRing}`,
+            )
+          : 'focus-visible:ring-ring',
       )}
     >
       <img src={elementIconSrc} alt={character.element} className="h-6 w-6 shrink-0" />
@@ -70,8 +74,11 @@ export function CharacterCard({
         </span>
       </div>
 
-      {owned && constellationLevel !== undefined && (
-        <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold text-muted-foreground">
+      {owned && (
+        <span
+          className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold text-muted-foreground"
+          aria-label={`Constellation level ${constellationLevel}`}
+        >
           C{constellationLevel}
         </span>
       )}


### PR DESCRIPTION
Create reusable `CharacterCard` component for character roster display.

## What

Adds `apps/web/src/components/CharacterCard.tsx` — a compact tile component for showing characters in a grid (collection page, character pool).

### Display
- Element icon with element-colored left border
- Character name, rarity stars, constellation badge (C0–C6)
- Owned/unowned visual states (grayscale + reduced opacity)

### Interactions
- Framer Motion hover (scale 1.03) and tap (scale 0.97) animations
- Click to select/deselect via `onSelect` callback
- Element-colored selection ring for visual feedback

## Design decision

Per the design note on #40, this implements the **compact tile** variant first. A richer card variant (portrait area, equipped weapon with refinement) can be added as `variant="full"` when the team builder (#47) needs it.

Closes #40