### PR TITLE
feat(api): integrate Firestore persistence for dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,8 @@ pnpm dev
 ```
 
 > **Note:** The API starts without Google Cloud credentials. Routes that don't
-> use Firestore (health check, schemas, static game data) work immediately.
-> Routes that read or write Firestore (profiles, teams) return 500 until you
+> use Firestore (health check, schemas) work immediately. Routes that read or
+> write Firestore (profiles, teams, characters, weapons) return 500 until you
 > configure credentials. See
 > [Configure Firestore credentials](docs/how-tos/configure-firestore-credentials.md)
 > for setup instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,13 @@ pnpm install
 pnpm dev
 ```
 
+> **Note:** The API starts without Google Cloud credentials. Routes that don't
+> use Firestore (health check, schemas, static game data) work immediately.
+> Routes that read or write Firestore (profiles, teams) return 500 until you
+> configure credentials. See
+> [Configure Firestore credentials](docs/how-tos/configure-firestore-credentials.md)
+> for setup instructions.
+
 ### Building and running the Docker image
 
 To build the API Docker image locally:
@@ -217,7 +224,7 @@ When creating release branches, derive the name from the root `package.json` ver
 This project runs on Windows, macOS, and Linux.
 
 - Use Node.js `path` module for paths, not hardcoded `/` or `\`
-- Use cross-platform packages like `rimraf` for file operations, not `rm -rf`
+- Use cross-platform approaches for file operations
 - Avoid OS-specific environment variables
 
 ### Detailed guides

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,11 +13,12 @@
   },
   "dependencies": {
     "@genshin/collection-json": "workspace:*",
-    "@genshin/game-data": "workspace:*",
     "@genshin/domain": "workspace:*",
+    "@genshin/game-data": "workspace:*",
     "@hono/node-server": "1.19.11",
     "ajv": "8.18.0",
     "firebase-admin": "13.7.0",
+    "google-gax": "4.6.1",
     "hono": "4.12.7",
     "negotiator": "1.0.0",
     "semver": "7.7.4"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import { firestoreErrorToHttpException } from '@/repositories/firestore-error.js';
 import { characters } from '@/routes/characters.js';
 import { profiles } from '@/routes/profiles.js';
 import { root } from '@/routes/root.js';
@@ -10,6 +11,7 @@ import { schemas } from '@/routes/schemas.js';
 import { teams } from '@/routes/teams.js';
 import { userProfile } from '@/routes/userProfile.js';
 import { weapons } from '@/routes/weapons.js';
+import { GoogleError } from 'google-gax';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
@@ -43,19 +45,21 @@ app.use(
 
 // Error handling middleware — RFC 9457 Problem Details
 app.onError((err, c) => {
-  if (err instanceof HTTPException) {
+  const resolved = err instanceof GoogleError ? firestoreErrorToHttpException(err) : err;
+
+  if (resolved instanceof HTTPException) {
     return c.json(
       {
         type: 'about:blank',
-        title: STATUS_CODES[err.status] ?? 'Unknown Error',
-        status: err.status,
-        detail: err.message,
+        title: STATUS_CODES[resolved.status] ?? 'Unknown Error',
+        status: resolved.status,
+        detail: resolved.message,
       },
-      { status: err.status, headers: PROBLEM_JSON },
+      { status: resolved.status, headers: PROBLEM_JSON },
     );
   }
 
-  console.error('Unexpected error:', err);
+  console.error('Unexpected error:', resolved);
   return c.json(
     {
       type: 'about:blank',

--- a/apps/api/src/lib/firebase/app.ts
+++ b/apps/api/src/lib/firebase/app.ts
@@ -3,7 +3,10 @@
 
 import { getApp, getApps, initializeApp } from 'firebase-admin/app';
 
-// Initialize with Application Default Credentials (ADC).
+const projectId = process.env.GOOGLE_CLOUD_PROJECT?.trim() || undefined;
+
+console.log(`Firebase: projectId=${projectId ?? '(not set)'}`);
 // In GCP, credentials are provided automatically.
-// Locally, set the GOOGLE_APPLICATION_CREDENTIALS environment variable.
-export const app = getApps().length > 0 ? getApp() : initializeApp();
+// Locally, run `gcloud auth application-default login` and set GOOGLE_CLOUD_PROJECT.
+export const app =
+  getApps().length > 0 ? getApp() : initializeApp(projectId ? { projectId } : undefined);

--- a/apps/api/src/lib/firebase/firestore.ts
+++ b/apps/api/src/lib/firebase/firestore.ts
@@ -4,4 +4,13 @@
 import { app } from '@/lib/firebase/app.js';
 import { getFirestore } from 'firebase-admin/firestore';
 
-export const db = getFirestore(app);
+const rawDatabaseId = process.env.FIRESTORE_DATABASE_ID ?? '(default)';
+const databaseId = rawDatabaseId.trim();
+
+if (databaseId === '') {
+  throw new Error('FIRESTORE_DATABASE_ID must not be empty when set.');
+}
+
+console.log(`Firestore: database=${databaseId}`);
+
+export const db = getFirestore(app, databaseId);

--- a/apps/api/src/repositories/firestore-error.ts
+++ b/apps/api/src/repositories/firestore-error.ts
@@ -14,6 +14,7 @@ const GRPC_TO_HTTP: Partial<Record<Status, ContentfulStatusCode>> = {
 
 export function firestoreErrorToHttpException(err: GoogleError): HTTPException {
   const httpStatus = (err.code !== undefined && GRPC_TO_HTTP[err.code]) || 500;
-  console.error(`Firestore error [gRPC ${Status[err.code!] ?? err.code}]:`, err.message);
+  const label = err.code !== undefined ? (Status[err.code] ?? String(err.code)) : '(unknown)';
+  console.error(`Firestore error [gRPC ${label}]:`, err.message);
   return new HTTPException(httpStatus, { message: 'An unexpected error occurred' });
 }

--- a/apps/api/src/repositories/firestore-error.ts
+++ b/apps/api/src/repositories/firestore-error.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { GoogleError, Status } from 'google-gax';
+import { HTTPException } from 'hono/http-exception';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+
+// Firestore gRPC errors are internal failures from the user's perspective.
+// Only transient conditions get non-500 status codes to enable client retry.
+const GRPC_TO_HTTP: Partial<Record<Status, ContentfulStatusCode>> = {
+  [Status.RESOURCE_EXHAUSTED]: 429,
+  [Status.UNAVAILABLE]: 503,
+};
+
+export function firestoreErrorToHttpException(err: GoogleError): HTTPException {
+  const httpStatus = (err.code !== undefined && GRPC_TO_HTTP[err.code]) || 500;
+  console.error(`Firestore error [gRPC ${Status[err.code!] ?? err.code}]:`, err.message);
+  return new HTTPException(httpStatus, { message: 'An unexpected error occurred' });
+}

--- a/docs/how-tos/configure-firestore-credentials.md
+++ b/docs/how-tos/configure-firestore-credentials.md
@@ -41,7 +41,8 @@ Start the API and confirm the startup log shows the expected project and
 database:
 
 ```text
-Firebase initialized: project=dungeon-studio-genshin-dev, database=(default)
+Firebase: projectId=dungeon-studio-genshin-dev
+Firestore: database=(default)
 ```
 
 Check `http://localhost:8080/health` returns `{"status":"ok"}`.

--- a/docs/how-tos/configure-firestore-credentials.md
+++ b/docs/how-tos/configure-firestore-credentials.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Configure Firestore credentials for the API
+
+This guide is for maintainers and operators with access to the
+`dungeon-studio-genshin-*` GCP projects. External contributors don't need
+Firestore credentials to work on most features.
+
+## Prerequisites
+
+- Access to a GCP project such as `dungeon-studio-genshin-dev`
+- The `gcloud` CLI installed (pre-installed in DevContainers)
+
+## Authenticate with Google Cloud
+
+```bash
+gcloud auth application-default login
+```
+
+This creates Application Default Credentials that the Firebase Admin SDK
+picks up automatically.
+
+## Set required environment variables
+
+```bash
+# Required: GCP project ID used by Firebase Admin SDK
+export GOOGLE_CLOUD_PROJECT="dungeon-studio-genshin-dev"
+
+# Optional: Firestore database ID (defaults to "(default)")
+# export FIRESTORE_DATABASE_ID="(default)"
+```
+
+Set these in your shell profile or a local `.env` file. Don't commit the `.env` file.
+
+## Verify connectivity
+
+Start the API and confirm the startup log shows the expected project and
+database:
+
+```text
+Firebase initialized: project=dungeon-studio-genshin-dev, database=(default)
+```
+
+Check `http://localhost:8080/health` returns `{"status":"ok"}`.
+
+## Environment variable reference
+
+| Variable                | Required | Default     | Description                           |
+| ----------------------- | -------- | ----------- | ------------------------------------- |
+| `GOOGLE_CLOUD_PROJECT`  | Yes      | —           | GCP project ID for Firebase Admin SDK |
+| `FIRESTORE_DATABASE_ID` | No       | `(default)` | Firestore database ID                 |

--- a/docs/how-tos/manual-setup.md
+++ b/docs/how-tos/manual-setup.md
@@ -83,7 +83,14 @@ pre-commit install
 pnpm dev
 ```
 
-The frontend is available at <http://localhost:5173>. The API service is available at <http://localhost:8080> once it exists.
+The frontend is available at <http://localhost:5173>. The API is available at <http://localhost:8080>.
+
+> **Note:** The API starts without Google Cloud credentials. Routes that don't
+> use Firestore (health check, schemas, static game data) work immediately.
+> Routes that read or write Firestore (profiles, teams) return 500 until you
+> configure credentials. See
+> [Configure Firestore credentials](configure-firestore-credentials.md) for
+> setup instructions.
 
 ---
 
@@ -91,6 +98,6 @@ The frontend is available at <http://localhost:5173>. The API service is availab
 
 Open your browser and visit <http://localhost:5173> to verify the frontend is running.
 
-You can check API health once the API service exists.
+Check API health at <http://localhost:8080/health> to verify the API is running.
 
 For more detailed development instructions, see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/how-tos/manual-setup.md
+++ b/docs/how-tos/manual-setup.md
@@ -86,8 +86,8 @@ pnpm dev
 The frontend is available at <http://localhost:5173>. The API is available at <http://localhost:8080>.
 
 > **Note:** The API starts without Google Cloud credentials. Routes that don't
-> use Firestore (health check, schemas, static game data) work immediately.
-> Routes that read or write Firestore (profiles, teams) return 500 until you
+> use Firestore (health check, schemas) work immediately. Routes that read or
+> write Firestore (profiles, teams, characters, weapons) return 500 until you
 > configure credentials. See
 > [Configure Firestore credentials](configure-firestore-credentials.md) for
 > setup instructions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       firebase-admin:
         specifier: 13.7.0
         version: 13.7.0
+      google-gax:
+        specifier: 4.6.1
+        version: 4.6.1
       hono:
         specifier: 4.12.7
         version: 4.12.7
@@ -4048,7 +4051,6 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
-    optional: true
 
   '@grpc/grpc-js@1.9.15':
     dependencies:
@@ -4068,7 +4070,6 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
-    optional: true
 
   '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:
@@ -4113,8 +4114,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-sdsl/ordered-map@4.4.2':
-    optional: true
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -4465,16 +4465,14 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.22': {}
 
-  '@tootallnate/once@2.0.0':
-    optional: true
+  '@tootallnate/once@2.0.0': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@types/caseless@0.12.5':
-    optional: true
+  '@types/caseless@0.12.5': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4494,8 +4492,7 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 25.5.0
 
-  '@types/long@4.0.2':
-    optional: true
+  '@types/long@4.0.2': {}
 
   '@types/ms@2.1.0': {}
 
@@ -4519,12 +4516,10 @@ snapshots:
       '@types/node': 25.5.0
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
-    optional: true
 
   '@types/semver@7.7.1': {}
 
-  '@types/tough-cookie@4.0.5':
-    optional: true
+  '@types/tough-cookie@4.0.5': {}
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4680,7 +4675,6 @@ snapshots:
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
-    optional: true
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -4693,7 +4687,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agent-base@7.1.4: {}
 
@@ -4752,8 +4745,7 @@ snapshots:
       retry: 0.13.1
     optional: true
 
-  asynckit@0.4.0:
-    optional: true
+  asynckit@0.4.0: {}
 
   autoprefixer@10.4.27(postcss@8.5.8):
     dependencies:
@@ -4810,7 +4802,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    optional: true
 
   callsites@3.1.0: {}
 
@@ -4853,7 +4844,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-    optional: true
 
   commander@9.5.0: {}
 
@@ -4895,8 +4885,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  delayed-stream@1.0.0:
-    optional: true
+  delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -4911,7 +4900,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   duplexify@4.1.3:
     dependencies:
@@ -4919,7 +4907,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
-    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -4936,7 +4923,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   enhanced-resolve@5.20.0:
     dependencies:
@@ -4949,18 +4935,15 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-define-property@1.0.1:
-    optional: true
+  es-define-property@1.0.1: {}
 
-  es-errors@1.3.0:
-    optional: true
+  es-errors@1.3.0: {}
 
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-    optional: true
 
   es-set-tostringtag@2.1.0:
     dependencies:
@@ -4968,7 +4951,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-    optional: true
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -5088,8 +5070,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  event-target-shim@5.0.1:
-    optional: true
+  event-target-shim@5.0.1: {}
 
   expect-type@1.3.0: {}
 
@@ -5239,7 +5220,6 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
       safe-buffer: 5.2.1
-    optional: true
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -5259,8 +5239,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2:
-    optional: true
+  function-bind@1.1.2: {}
 
   functional-red-black-tree@1.0.1:
     optional: true
@@ -5275,7 +5254,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   gaxios@7.1.3:
     dependencies:
@@ -5294,7 +5272,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   gcp-metadata@8.1.2:
     dependencies:
@@ -5322,7 +5299,6 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    optional: true
 
   get-nonce@1.0.1: {}
 
@@ -5330,7 +5306,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    optional: true
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -5407,7 +5382,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   google-gax@4.6.1:
     dependencies:
@@ -5426,15 +5400,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
-  google-logging-utils@0.0.2:
-    optional: true
+  google-logging-utils@0.0.2: {}
 
   google-logging-utils@1.1.3: {}
 
-  gopd@1.2.0:
-    optional: true
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -5445,19 +5416,16 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   has-flag@4.0.0: {}
 
   has-flag@5.0.1: {}
 
-  has-symbols@1.1.0:
-    optional: true
+  has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-    optional: true
 
   hashery@1.5.0:
     dependencies:
@@ -5466,7 +5434,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
   hermes-estree@0.25.1: {}
 
@@ -5494,7 +5461,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -5502,7 +5468,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -5526,8 +5491,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
@@ -5551,8 +5515,7 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
-  is-stream@2.0.1:
-    optional: true
+  is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -5815,8 +5778,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  math-intrinsics@1.1.0:
-    optional: true
+  math-intrinsics@1.1.0: {}
 
   mathml-tag-names@4.0.0: {}
 
@@ -5831,13 +5793,11 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mime-db@1.52.0:
-    optional: true
+  mime-db@1.52.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-    optional: true
 
   mime@3.0.0:
     optional: true
@@ -5873,7 +5833,6 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    optional: true
 
   node-fetch@3.3.2:
     dependencies:
@@ -5887,15 +5846,13 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  object-hash@3.0.0:
-    optional: true
+  object-hash@3.0.0: {}
 
   obug@2.1.1: {}
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -5981,7 +5938,6 @@ snapshots:
   proto3-json-serializer@2.0.2:
     dependencies:
       protobufjs: 7.5.4
-    optional: true
 
   protobufjs@7.5.4:
     dependencies:
@@ -6061,7 +6017,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readdirp@3.6.0:
     dependencies:
@@ -6083,7 +6038,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   retry@0.13.1:
     optional: true
@@ -6158,10 +6112,8 @@ snapshots:
   stream-events@1.0.5:
     dependencies:
       stubs: 3.0.0
-    optional: true
 
-  stream-shift@1.0.3:
-    optional: true
+  stream-shift@1.0.3: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6183,7 +6135,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -6196,8 +6147,7 @@ snapshots:
   strnum@2.2.0:
     optional: true
 
-  stubs@3.0.0:
-    optional: true
+  stubs@3.0.0: {}
 
   stylelint-config-recommended@18.0.0(stylelint@17.4.0(typescript@5.9.3)):
     dependencies:
@@ -6292,7 +6242,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   tinybench@2.9.0: {}
 
@@ -6309,8 +6258,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tr46@0.0.3:
-    optional: true
+  tr46@0.0.3: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -6415,8 +6363,7 @@ snapshots:
   uuid@8.3.2:
     optional: true
 
-  uuid@9.0.1:
-    optional: true
+  uuid@9.0.1: {}
 
   vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
@@ -6465,8 +6412,7 @@ snapshots:
 
   web-vitals@4.2.4: {}
 
-  webidl-conversions@3.0.1:
-    optional: true
+  webidl-conversions@3.0.1: {}
 
   websocket-driver@0.7.4:
     dependencies:
@@ -6480,7 +6426,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    optional: true
 
   which@1.3.1:
     dependencies:
@@ -6509,8 +6454,7 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
 
   write-file-atomic@7.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Completes the Firestore integration for the dev environment by adding typed error handling, startup logging, documentation, and contributor guidance.

Closes #315

## Changes

### Error handling
- Add `firestoreErrorToHttpException` in `apps/api/src/repositories/firestore-error.ts` — encapsulates all gRPC-to-HTTP mapping in the repository layer
- Map only retryable gRPC codes to non-500 responses: `RESOURCE_EXHAUSTED` → 429, `UNAVAILABLE` → 503
- Wire `GoogleError` detection into `app.onError` via `instanceof`
- Add `google-gax` as explicit dependency for `GoogleError` class and `Status` enum

### Configuration and startup
- Read `FIRESTORE_DATABASE_ID` directly in `firestore.ts` with fail-fast validation
- Log resolved `projectId` and `databaseId` before SDK initialization for easier debugging
- Default `FIRESTORE_DATABASE_ID` to `(default)` when unset

### Documentation
- Add `docs/how-tos/configure-firestore-credentials.md` for maintainers with GCP access
- Add Firestore note to `CONTRIBUTING.md` quick start: API works without credentials, Firestore routes return 500
- Add same note to `docs/how-tos/manual-setup.md`
- Fix stale "once it exists" API reference in manual-setup.md
- Remove `rimraf` recommendation from CONTRIBUTING.md (not a project dependency)

## Follow-up issues
- #512 — Add `Retry-After` headers for 429 and 503 responses
- #513 — Slim down CONTRIBUTING.md by extracting reference material to `docs/`

## Testing
- All 156 existing tests pass
- Typecheck clean
- Existing route-level error tests cover the integration path (error → 500 with generic message)