### PR TITLE
feat(web): wire up TanStack Query QueryClientProvider

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 
 import { Layout } from './components/Layout';
@@ -11,20 +12,24 @@ import { HomePage } from './pages/HomePage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { TeamsPage } from './pages/TeamsPage';
 
+const queryClient = new QueryClient();
+
 export function App() {
   return (
-    <AuthProvider>
-      <Router>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/collection" element={<CollectionPage />} />
-            <Route path="/teams" element={<TeamsPage />} />
-            <Route path="/chat" element={<ChatPage />} />
-            <Route path="*" element={<NotFoundPage />} />
-          </Route>
-        </Routes>
-      </Router>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <Router>
+          <Routes>
+            <Route element={<Layout />}>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/collection" element={<CollectionPage />} />
+              <Route path="/teams" element={<TeamsPage />} />
+              <Route path="/chat" element={<ChatPage />} />
+              <Route path="*" element={<NotFoundPage />} />
+            </Route>
+          </Routes>
+        </Router>
+      </AuthProvider>
+    </QueryClientProvider>
   );
 }


### PR DESCRIPTION
### Summary

Add `QueryClientProvider` as the outermost provider in `App.tsx` so that `useQuery` and `useMutation` hooks are available throughout the app.

### Changes

- Import `QueryClient` and `QueryClientProvider` from `@tanstack/react-query` (already installed).
- Create a module-level `QueryClient` instance.
- Wrap the existing provider tree (`AuthProvider` → `Router`) inside `QueryClientProvider`.

### Context

One-time infrastructure setup for #41 (character collection list view). This is PR 1 of the [implementation plan](https://github.com/dungeon-studio/genshin.dungeon.studio/issues/41#issuecomment-4085807194).

### Testing

- `pnpm turbo run typecheck --filter=@genshin/web` passes.
- `pnpm --filter @genshin/web lint` passes (one pre-existing warning in `AuthProvider.tsx`, tracked by #516).