### PR TITLE
feat(web): add authenticated API client and shared ProblemDetail type

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,6 +11,7 @@ import { schemas } from '@/routes/schemas.js';
 import { teams } from '@/routes/teams.js';
 import { userProfile } from '@/routes/userProfile.js';
 import { weapons } from '@/routes/weapons.js';
+import type { ProblemDetail } from '@genshin/domain';
 import { GoogleError } from 'google-gax';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
@@ -54,7 +55,7 @@ app.onError((err, c) => {
         title: STATUS_CODES[resolved.status] ?? 'Unknown Error',
         status: resolved.status,
         detail: resolved.message,
-      },
+      } satisfies ProblemDetail,
       { status: resolved.status, headers: PROBLEM_JSON },
     );
   }
@@ -66,7 +67,7 @@ app.onError((err, c) => {
       title: 'Internal Server Error',
       status: 500,
       detail: 'An unexpected error occurred',
-    },
+    } satisfies ProblemDetail,
     { status: 500, headers: PROBLEM_JSON },
   );
 });
@@ -79,7 +80,7 @@ app.notFound((c) =>
       title: 'Not Found',
       status: 404,
       detail: 'The requested resource does not exist',
-    },
+    } satisfies ProblemDetail,
     { status: 404, headers: PROBLEM_JSON },
   ),
 );

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,3 +12,7 @@ VITE_FIREBASE_PROJECT_ID=
 VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
+
+# API base URL — the origin of the API server (no trailing slash).
+# Set per environment at build time; this default targets the local API server.
+VITE_API_BASE_URL=http://localhost:8080

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -10,6 +10,7 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_STORAGE_BUCKET: string;
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
   readonly VITE_FIREBASE_APP_ID: string;
+  readonly VITE_API_BASE_URL: string;
 }
 
 interface ImportMeta {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -6,6 +6,8 @@ import type { ProblemDetail } from '@genshin/domain';
 
 export type { ProblemDetail };
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export class ApiError extends Error {
   readonly problem: ProblemDetail;
 
@@ -40,13 +42,13 @@ async function handleResponse(response: Response): Promise<unknown> {
 
 export async function apiGet(path: string): Promise<unknown> {
   const headers = await getAuthHeaders();
-  const response = await fetch(path, { headers });
+  const response = await fetch(`${API_BASE_URL}${path}`, { headers });
   return handleResponse(response);
 }
 
 export async function apiPut(path: string, body: unknown): Promise<unknown> {
   const headers = await getAuthHeaders();
-  const response = await fetch(path, {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
     method: 'PUT',
     headers: { ...headers, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -56,7 +58,7 @@ export async function apiPut(path: string, body: unknown): Promise<unknown> {
 
 export async function apiDelete(path: string): Promise<void> {
   const headers = await getAuthHeaders();
-  const response = await fetch(path, {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
     method: 'DELETE',
     headers,
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { auth } from '@/lib/firebase';
+
+export interface ProblemDetail {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+}
+
+export class ApiError extends Error {
+  readonly problem: ProblemDetail;
+
+  constructor(problem: ProblemDetail) {
+    super(problem.detail);
+    this.name = 'ApiError';
+    this.problem = problem;
+  }
+}
+
+async function getAuthHeaders(): Promise<HeadersInit> {
+  const user = auth.currentUser;
+  if (!user) {
+    throw new ApiError({
+      type: 'about:blank',
+      title: 'Unauthorized',
+      status: 401,
+      detail: 'Not signed in',
+    });
+  }
+
+  const token = await user.getIdToken();
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const problem: ProblemDetail = await response.json();
+    throw new ApiError(problem);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(path, { headers });
+  return handleResponse<T>(response);
+}
+
+export async function apiPut<T>(path: string, body: unknown): Promise<T> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(path, {
+    method: 'PUT',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<T>(response);
+}
+
+export async function apiDelete(path: string): Promise<void> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(path, {
+    method: 'DELETE',
+    headers,
+  });
+  return handleResponse<void>(response);
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,6 +7,9 @@ import type { ProblemDetail } from '@genshin/domain';
 export type { ProblemDetail };
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE_URL) {
+  throw new Error('Missing required environment variable: VITE_API_BASE_URL');
+}
 
 export class ApiError extends Error {
   readonly problem: ProblemDetail;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -41,6 +41,7 @@ async function handleResponse(response: Response): Promise<unknown> {
 
     const text = await response.text();
     throw new ApiError({
+      type: 'about:blank',
       title: response.statusText || 'Unknown Error',
       status: response.status,
       detail: text || `Request failed with status ${response.status}`,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -16,6 +16,7 @@ export class ApiError extends Error {
 
   constructor(problem: ProblemDetail) {
     super(problem.detail);
+    this.name = 'ApiError';
     this.problem = problem;
   }
 }
@@ -32,8 +33,18 @@ async function getAuthHeaders(): Promise<HeadersInit> {
 
 async function handleResponse(response: Response): Promise<unknown> {
   if (!response.ok) {
-    const problem: ProblemDetail = await response.json();
-    throw new ApiError(problem);
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('application/problem+json')) {
+      const problem: ProblemDetail = await response.json();
+      throw new ApiError(problem);
+    }
+
+    const text = await response.text();
+    throw new ApiError({
+      title: response.statusText || 'Unknown Error',
+      status: response.status,
+      detail: text || `Request failed with status ${response.status}`,
+    });
   }
 
   if (response.status === 204) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -56,13 +56,13 @@ async function handleResponse(response: Response): Promise<unknown> {
 
 export async function apiGet(path: string): Promise<unknown> {
   const headers = await getAuthHeaders();
-  const response = await fetch(`${API_BASE_URL}${path}`, { headers });
+  const response = await fetch(new URL(path, API_BASE_URL).href, { headers });
   return handleResponse(response);
 }
 
 export async function apiPut(path: string, body: unknown): Promise<unknown> {
   const headers = await getAuthHeaders();
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  const response = await fetch(new URL(path, API_BASE_URL).href, {
     method: 'PUT',
     headers: { ...headers, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -72,7 +72,7 @@ export async function apiPut(path: string, body: unknown): Promise<unknown> {
 
 export async function apiDelete(path: string): Promise<void> {
   const headers = await getAuthHeaders();
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  const response = await fetch(new URL(path, API_BASE_URL).href, {
     method: 'DELETE',
     headers,
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,20 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 import { auth } from '@/lib/firebase';
+import type { ProblemDetail } from '@genshin/domain';
 
-export interface ProblemDetail {
-  type: string;
-  title: string;
-  status: number;
-  detail: string;
-}
+export type { ProblemDetail };
 
 export class ApiError extends Error {
   readonly problem: ProblemDetail;
 
   constructor(problem: ProblemDetail) {
     super(problem.detail);
-    this.name = 'ApiError';
     this.problem = problem;
   }
 }
@@ -23,45 +18,40 @@ export class ApiError extends Error {
 async function getAuthHeaders(): Promise<HeadersInit> {
   const user = auth.currentUser;
   if (!user) {
-    throw new ApiError({
-      type: 'about:blank',
-      title: 'Unauthorized',
-      status: 401,
-      detail: 'Not signed in',
-    });
+    return {};
   }
 
   const token = await user.getIdToken();
   return { Authorization: `Bearer ${token}` };
 }
 
-async function handleResponse<T>(response: Response): Promise<T> {
+async function handleResponse(response: Response): Promise<unknown> {
   if (!response.ok) {
     const problem: ProblemDetail = await response.json();
     throw new ApiError(problem);
   }
 
   if (response.status === 204) {
-    return undefined as T;
+    return undefined;
   }
 
-  return response.json() as Promise<T>;
+  return response.json();
 }
 
-export async function apiGet<T>(path: string): Promise<T> {
+export async function apiGet(path: string): Promise<unknown> {
   const headers = await getAuthHeaders();
   const response = await fetch(path, { headers });
-  return handleResponse<T>(response);
+  return handleResponse(response);
 }
 
-export async function apiPut<T>(path: string, body: unknown): Promise<T> {
+export async function apiPut(path: string, body: unknown): Promise<unknown> {
   const headers = await getAuthHeaders();
   const response = await fetch(path, {
     method: 'PUT',
     headers: { ...headers, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  return handleResponse<T>(response);
+  return handleResponse(response);
 }
 
 export async function apiDelete(path: string): Promise<void> {
@@ -70,5 +60,5 @@ export async function apiDelete(path: string): Promise<void> {
     method: 'DELETE',
     headers,
   });
-  return handleResponse<void>(response);
+  await handleResponse(response);
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -3,28 +3,29 @@
 
 export type { AuthIdentity } from './authIdentity.js';
 export {
-  MAX_CONSTELLATION_LEVEL,
-  MIN_CONSTELLATION_LEVEL,
   assertCollectionCharacter,
   isValidConstellationLevel,
+  MAX_CONSTELLATION_LEVEL,
+  MIN_CONSTELLATION_LEVEL,
   type CollectionCharacter,
 } from './collectionCharacter.js';
 export {
+  assertCollectionTeam,
+  isValidTeamSlot,
   MAX_TEAM_MEMBERS,
   MAX_TEAM_SLOT,
   MIN_TEAM_SLOT,
-  assertCollectionTeam,
-  isValidTeamSlot,
   type CollectionTeam,
 } from './collectionTeam.js';
 export {
-  MAX_REFINEMENT_LEVEL,
-  MIN_REFINEMENT_LEVEL,
   assertCollectionWeapon,
   isValidRefinementLevel,
+  MAX_REFINEMENT_LEVEL,
+  MIN_REFINEMENT_LEVEL,
   type CollectionWeapon,
 } from './collectionWeapon.js';
 export { isISOTimestamp, type ISOTimestamp } from './isoTimestamp.js';
+export type { ProblemDetail } from './problemDetail.js';
 export {
   characterItemHref,
   characterRepresentation,

--- a/packages/domain/src/problemDetail.ts
+++ b/packages/domain/src/problemDetail.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/**
+ * RFC 9457 Problem Details for HTTP APIs.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9457
+ */
+export interface ProblemDetail {
+  /** A URI reference identifying the problem type. Defaults to "about:blank". */
+  type: string;
+  /** A short, human-readable summary of the problem type. */
+  title: string;
+  /** The HTTP status code. */
+  status: number;
+  /** A human-readable explanation specific to this occurrence. */
+  detail: string;
+  /** A URI reference identifying the specific occurrence. */
+  instance?: string;
+}

--- a/packages/domain/src/problemDetail.ts
+++ b/packages/domain/src/problemDetail.ts
@@ -7,8 +7,8 @@
  * @see https://www.rfc-editor.org/rfc/rfc9457
  */
 export interface ProblemDetail {
-  /** A URI reference identifying the problem type. Defaults to "about:blank". */
-  type: string;
+  /** A URI reference identifying the problem type. Defaults to "about:blank" when omitted. */
+  type?: string;
   /** A short, human-readable summary of the problem type. */
   title: string;
   /** The HTTP status code. */

--- a/packages/domain/src/problemDetail.ts
+++ b/packages/domain/src/problemDetail.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * RFC 9457 Problem Details for HTTP APIs.
+ * Problem Details for HTTP APIs — strict project subset of RFC 9457.
+ *
+ * This interface requires fields that RFC 9457 leaves optional. The shape
+ * will be reassessed when content negotiation and representation parsing
+ * are implemented (see #518, #520).
  *
  * @see https://www.rfc-editor.org/rfc/rfc9457
  */


### PR DESCRIPTION
## Summary

Adds a reusable fetch-based API client for the web app and a shared RFC 9457 `ProblemDetail` type in `@genshin/domain`.

Part of **PR 2** in the [implementation plan](#41 (comment)) for #41.

## Changes

### `apps/web/src/lib/api.ts` (new)
- `apiGet`, `apiPut`, `apiDelete` — transport functions that attach `Authorization: Bearer <token>` from Firebase Auth
- Returns `unknown` — callers narrow at the domain boundary with assertion helpers (e.g. `assertCollectionCharacter`)
- `ApiError` class wraps `ProblemDetail` in a throwable `Error` for TanStack Query error handling
- Handles 204 No Content responses

### `packages/domain/src/problemDetail.ts` (new)
- Shared `ProblemDetail` interface (RFC 9457) used by both API and web

### `apps/api/src/app.ts`
- Error handler objects use `satisfies ProblemDetail` to verify conformance with the shared type

## Design decisions

- **`unknown` return type** instead of generic `<T>`: the client is a transport layer; domain narrowing belongs in the consuming code (TanStack Query hooks in PR 5).
- **No client-side auth guard**: if no user is signed in, the client sends no `Authorization` header and lets the API respond with 401. The API is the authority on auth.
- **Shared `ProblemDetail`**: avoids duplicating the error contract between API and web.

## Related

- Closes no issue (incremental toward #41)
- Depends on: #517 (merged)
- Follow-up: Content-Type/Accept profile parameters tracked in #476
