### PR TITLE
feat(web): add filters, search, and sort to character collection

### DIFF
--- a/.github/actions/test-and-upload-coverage/action.yml
+++ b/.github/actions/test-and-upload-coverage/action.yml
@@ -1,0 +1,48 @@
+---
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Test and upload coverage
+description: Run vitest with coverage and upload results to Codecov
+
+inputs:
+  filter:
+    description: 'Turborepo filter (e.g. @genshin/api)'
+    required: true
+  coverage-file:
+    description: 'Path to lcov.info coverage file'
+    required: true
+  results-file:
+    description: 'Path to junit.xml test results file'
+    required: true
+  flag:
+    description: 'Codecov flag name'
+    required: true
+  codecov-token:
+    description: 'Codecov upload token'
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Test
+      shell: bash
+      run: pnpm turbo run test --filter=${{ inputs.filter }} -- --coverage
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ inputs.codecov-token }}
+        files: ${{ inputs.coverage-file }}
+        flags: ${{ inputs.flag }}
+        fail_ci_if_error: false
+
+    - name: Upload test results to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ inputs.codecov-token }}
+        files: ${{ inputs.results-file }}
+        flags: ${{ inputs.flag }}
+        report_type: test_results
+        fail_ci_if_error: false

--- a/.github/actions/test-and-upload-coverage/action.yml
+++ b/.github/actions/test-and-upload-coverage/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Test
       shell: bash
-      run: pnpm turbo run test --filter=${{ inputs.filter }} -- --coverage
+      run: pnpm turbo run test --filter="${{ inputs.filter }}" -- --coverage
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,6 +66,7 @@
 
 - Prefer composition over inheritance and use early returns for conditional rendering.
 - Use semantic HTML: proper heading hierarchy, structural elements, and native interactive elements.
+- Mark decorative Lucide icons with `aria-hidden="true"` and `focusable={false}`. Icons inside labeled buttons, or adjacent to labeled inputs, are decorative.
 - Use aliases such as `@/components`, `@/components/ui`, `@/lib`, and `@/lib/utils`.
 - `shadcn/ui` gotchas:
   - Use ESM imports in Tailwind or Vite config (`import ...`), not `require()`.
@@ -126,6 +127,7 @@
 - Start Bash scripts with `set -euo pipefail` and `set -x`.
 - Use `curl -fsSL` for network fetches.
 - Never hard-code secrets; use environment variables.
+- Quote `${{ inputs.* }}` expansions in GitHub Actions composite action `run` steps to prevent shell word-splitting.
 - Add new DevContainer provisioning steps in `.devcontainer/postCreateCommand.sh`.
 
 ## Playwright MCP rules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,25 +47,13 @@ jobs:
       - name: Typecheck
         run: pnpm turbo run typecheck --filter=@genshin/api
 
-      - name: Test
-        run: pnpm turbo run test --filter=@genshin/api -- --coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+      - uses: ./.github/actions/test-and-upload-coverage
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: apps/api/coverage/lcov.info
-          flags: api
-          fail_ci_if_error: false
-
-      - name: Upload test results to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: apps/api/test-results/junit.xml
-          flags: api
-          report_type: test_results
-          fail_ci_if_error: false
+          filter: '@genshin/api'
+          coverage-file: apps/api/coverage/lcov.info
+          results-file: apps/api/test-results/junit.xml
+          flag: api
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build
         run: pnpm turbo run build --filter=@genshin/api
@@ -86,6 +74,14 @@ jobs:
 
       - name: Typecheck
         run: pnpm turbo run typecheck --filter=@genshin/game-data
+
+      - uses: ./.github/actions/test-and-upload-coverage
+        with:
+          filter: '@genshin/game-data'
+          coverage-file: packages/game-data/coverage/lcov.info
+          results-file: packages/game-data/test-results/junit.xml
+          flag: game-data
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   domain:
     name: Domain
@@ -121,25 +117,13 @@ jobs:
       - name: Typecheck
         run: pnpm turbo run typecheck --filter=@genshin/collection-json
 
-      - name: Test
-        run: pnpm turbo run test --filter=@genshin/collection-json -- --coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+      - uses: ./.github/actions/test-and-upload-coverage
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/collection-json/coverage/lcov.info
-          flags: collection-json
-          fail_ci_if_error: false
-
-      - name: Upload test results to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/collection-json/test-results/junit.xml
-          flags: collection-json
-          report_type: test_results
-          fail_ci_if_error: false
+          filter: '@genshin/collection-json'
+          coverage-file: packages/collection-json/coverage/lcov.info
+          results-file: packages/collection-json/test-results/junit.xml
+          flag: collection-json
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
 # ---------------------------------------------------------------------------
 # Maintenance notes

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -53,6 +53,7 @@ gcloud
 
 # Other tools and libraries
 Babel
+Lucide
 OXC
 SWC
 

--- a/apps/web/src/components/CharacterCard.tsx
+++ b/apps/web/src/components/CharacterCard.tsx
@@ -14,6 +14,7 @@ import {
   ELEMENT_FOCUS_RINGS,
   ELEMENT_SELECTED_RINGS,
 } from '@/lib/elementStyles';
+import { getElementIconPath } from '@/lib/elements';
 import { cn } from '@/lib/utils';
 
 const CONSTELLATION_LEVELS = Array.from(
@@ -41,7 +42,7 @@ export function CharacterCard({
   onConstellationChange,
 }: CharacterCardProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const elementIconSrc = `/elements/${character.element.toLowerCase()}.png`;
+  const elementIconSrc = getElementIconPath(character.element);
 
   const borderColors = owned ? ELEMENT_BORDER_COLORS : ELEMENT_BORDER_COLORS_DIM;
 

--- a/apps/web/src/components/CharacterFilters.tsx
+++ b/apps/web/src/components/CharacterFilters.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Character, Element } from '@genshin/game-data';
+import type { Character, Element, Rarity } from '@genshin/game-data';
 import { compareVersions, ELEMENTS } from '@genshin/game-data';
-import { ArrowDown, ArrowUp, Search } from 'lucide-react';
+import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,7 +18,7 @@ export type SortDirection = 'asc' | 'desc';
 export interface CharacterFilterState {
   search: string;
   elements: Set<Element>;
-  rarities: Set<4 | 5>;
+  rarities: Set<Rarity>;
   ownership: OwnershipFilter;
   sortField: SortField;
   sortDirection: SortDirection;
@@ -34,7 +34,7 @@ interface CharacterFiltersProps {
 }
 
 const ELEMENT_VALUES = Object.values(ELEMENTS);
-const RARITY_VALUES: (4 | 5)[] = [5, 4];
+const RARITY_VALUES: Rarity[] = [5, 4];
 
 const SORT_LABELS: Record<SortField, string> = {
   release: 'Release',
@@ -51,7 +51,7 @@ export function filterCharacters(
   const result = characters.filter((c) => {
     if (searchLower && !c.name.toLowerCase().includes(searchLower)) return false;
     if (filters.elements.size > 0 && !filters.elements.has(c.element)) return false;
-    if (filters.rarities.size > 0 && !filters.rarities.has(c.rarity as 4 | 5)) return false;
+    if (filters.rarities.size > 0 && !filters.rarities.has(c.rarity)) return false;
     if (filters.ownership === 'owned' && !ownedIds.has(c.id)) return false;
     if (filters.ownership === 'unowned' && ownedIds.has(c.id)) return false;
     return true;
@@ -61,7 +61,7 @@ export function filterCharacters(
     let cmp = 0;
     switch (filters.sortField) {
       case 'release':
-        cmp = compareVersions(b.version, a.version);
+        cmp = compareVersions(a.version, b.version);
         break;
       case 'name':
         cmp = a.name.localeCompare(b.name);
@@ -91,7 +91,7 @@ export function CharacterFilters({
     onChange({ ...filters, elements: next });
   }
 
-  function toggleRarity(rarity: 4 | 5) {
+  function toggleRarity(rarity: Rarity) {
     const next = new Set(filters.rarities);
     if (next.has(rarity)) {
       next.delete(rarity);
@@ -230,9 +230,9 @@ export function CharacterFilters({
             className="-ml-px rounded-l-none px-1.5"
           >
             {filters.sortDirection === 'asc' ? (
-              <ArrowDown className="h-3.5 w-3.5" />
+              <ArrowUpNarrowWide className="h-3.5 w-3.5" />
             ) : (
-              <ArrowUp className="h-3.5 w-3.5" />
+              <ArrowDownWideNarrow className="h-3.5 w-3.5" />
             )}
           </Button>
         </div>

--- a/apps/web/src/components/CharacterFilters.tsx
+++ b/apps/web/src/components/CharacterFilters.tsx
@@ -108,7 +108,7 @@ export function CharacterFilters({
     const fields: SortField[] = ['release', 'name'];
     const currentIndex = fields.indexOf(filters.sortField);
     const nextField = fields[(currentIndex + 1) % fields.length];
-    onChange({ ...filters, sortField: nextField, sortDirection: 'asc' });
+    onChange({ ...filters, sortField: nextField });
   }
 
   function toggleSortDirection() {

--- a/apps/web/src/components/CharacterFilters.tsx
+++ b/apps/web/src/components/CharacterFilters.tsx
@@ -62,6 +62,9 @@ export function filterCharacters(
     switch (filters.sortField) {
       case 'release':
         cmp = compareVersions(a.version, b.version);
+        if (cmp === 0) {
+          cmp = a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+        }
         break;
       case 'name':
         cmp = a.name.localeCompare(b.name);

--- a/apps/web/src/components/CharacterFilters.tsx
+++ b/apps/web/src/components/CharacterFilters.tsx
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Character, Element } from '@genshin/game-data';
+import { compareVersions, ELEMENTS } from '@genshin/game-data';
+import { ArrowDown, ArrowUp, Search } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ELEMENT_BG_COLORS } from '@/lib/elementStyles';
+import { getElementIconPath } from '@/lib/elements';
+import { cn } from '@/lib/utils';
+
+export type OwnershipFilter = 'all' | 'owned' | 'unowned';
+export type SortField = 'release' | 'name';
+export type SortDirection = 'asc' | 'desc';
+
+export interface CharacterFilterState {
+  search: string;
+  elements: Set<Element>;
+  rarities: Set<4 | 5>;
+  ownership: OwnershipFilter;
+  sortField: SortField;
+  sortDirection: SortDirection;
+}
+
+interface CharacterFiltersProps {
+  filters: CharacterFilterState;
+  onChange: (filters: CharacterFilterState) => void;
+  filteredCount: number;
+  totalCount: number;
+  ownedCount: number;
+  filteredOwnedCount: number;
+}
+
+const ELEMENT_VALUES = Object.values(ELEMENTS);
+const RARITY_VALUES: (4 | 5)[] = [5, 4];
+
+const SORT_LABELS: Record<SortField, string> = {
+  release: 'Release',
+  name: 'Name',
+};
+
+export function filterCharacters(
+  characters: readonly Character[],
+  filters: CharacterFilterState,
+  ownedIds: Set<Character['id']>,
+): Character[] {
+  const searchLower = filters.search.toLowerCase();
+
+  const result = characters.filter((c) => {
+    if (searchLower && !c.name.toLowerCase().includes(searchLower)) return false;
+    if (filters.elements.size > 0 && !filters.elements.has(c.element)) return false;
+    if (filters.rarities.size > 0 && !filters.rarities.has(c.rarity as 4 | 5)) return false;
+    if (filters.ownership === 'owned' && !ownedIds.has(c.id)) return false;
+    if (filters.ownership === 'unowned' && ownedIds.has(c.id)) return false;
+    return true;
+  });
+
+  result.sort((a, b) => {
+    let cmp = 0;
+    switch (filters.sortField) {
+      case 'release':
+        cmp = compareVersions(b.version, a.version);
+        break;
+      case 'name':
+        cmp = a.name.localeCompare(b.name);
+        break;
+    }
+    return filters.sortDirection === 'desc' ? -cmp : cmp;
+  });
+
+  return result;
+}
+
+export function CharacterFilters({
+  filters,
+  onChange,
+  filteredCount,
+  totalCount,
+  ownedCount,
+  filteredOwnedCount,
+}: CharacterFiltersProps) {
+  function toggleElement(element: Element) {
+    const next = new Set(filters.elements);
+    if (next.has(element)) {
+      next.delete(element);
+    } else {
+      next.add(element);
+    }
+    onChange({ ...filters, elements: next });
+  }
+
+  function toggleRarity(rarity: 4 | 5) {
+    const next = new Set(filters.rarities);
+    if (next.has(rarity)) {
+      next.delete(rarity);
+    } else {
+      next.add(rarity);
+    }
+    onChange({ ...filters, rarities: next });
+  }
+
+  function cycleSortField() {
+    const fields: SortField[] = ['release', 'name'];
+    const currentIndex = fields.indexOf(filters.sortField);
+    const nextField = fields[(currentIndex + 1) % fields.length];
+    onChange({ ...filters, sortField: nextField, sortDirection: 'asc' });
+  }
+
+  function toggleSortDirection() {
+    onChange({
+      ...filters,
+      sortDirection: filters.sortDirection === 'asc' ? 'desc' : 'asc',
+    });
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {/* Row 1: Filters */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {/* Ownership filters */}
+        {(['all', 'owned', 'unowned'] as const).map((value) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onChange({ ...filters, ownership: value })}
+            className={cn(
+              'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
+              filters.ownership === value
+                ? 'bg-foreground text-background'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            )}
+            aria-pressed={filters.ownership === value}
+          >
+            {value}
+          </button>
+        ))}
+
+        <span className="self-center text-border" aria-hidden="true">
+          |
+        </span>
+
+        {/* Rarity filters */}
+        {RARITY_VALUES.map((rarity) => (
+          <button
+            key={rarity}
+            type="button"
+            onClick={() => toggleRarity(rarity)}
+            className={cn(
+              'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+              filters.rarities.has(rarity)
+                ? 'bg-geo-dark text-white'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            )}
+            aria-pressed={filters.rarities.has(rarity)}
+            aria-label={`Filter by ${rarity}-star`}
+          >
+            {rarity}★
+          </button>
+        ))}
+
+        <span className="self-center text-border" aria-hidden="true">
+          |
+        </span>
+
+        {/* Element filters */}
+        {ELEMENT_VALUES.map((element) => (
+          <button
+            key={element}
+            type="button"
+            onClick={() => toggleElement(element)}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+              filters.elements.has(element)
+                ? ELEMENT_BG_COLORS[element]
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            )}
+            aria-pressed={filters.elements.has(element)}
+            aria-label={`Filter by ${element}`}
+          >
+            <img
+              src={getElementIconPath(element)}
+              alt=""
+              className="h-3.5 w-3.5"
+              aria-hidden="true"
+            />
+            {element}
+          </button>
+        ))}
+      </div>
+
+      {/* Row 2: Search + status + sort */}
+      <div className="flex items-center gap-1.5">
+        <div className="relative w-1/2 lg:w-1/3">
+          <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Search…"
+            value={filters.search}
+            onChange={(e) => onChange({ ...filters, search: e.target.value })}
+            className="h-8 pl-9 text-xs [&::-webkit-search-cancel-button]:grayscale"
+            aria-label="Search characters by name"
+          />
+        </div>
+
+        <div className="flex-1" />
+
+        <p className="text-sm text-muted-foreground">
+          {filteredCount === totalCount ? (
+            <>
+              {ownedCount} / {totalCount} owned
+            </>
+          ) : (
+            <>
+              {filteredOwnedCount} / {filteredCount} owned
+            </>
+          )}
+        </p>
+
+        <div className="flex shrink-0 items-center">
+          <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
+            {SORT_LABELS[filters.sortField]}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={toggleSortDirection}
+            aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+            className="-ml-px rounded-l-none px-1.5"
+          >
+            {filters.sortDirection === 'asc' ? (
+              <ArrowDown className="h-3.5 w-3.5" />
+            ) : (
+              <ArrowUp className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/CharacterFilters.tsx
+++ b/apps/web/src/components/CharacterFilters.tsx
@@ -196,7 +196,11 @@ export function CharacterFilters({
       {/* Row 2: Search + status + sort */}
       <div className="flex items-center gap-1.5">
         <div className="relative w-1/2 lg:w-1/3">
-          <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Search
+            className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+            focusable={false}
+          />
           <Input
             type="search"
             placeholder="Search…"
@@ -233,9 +237,9 @@ export function CharacterFilters({
             className="-ml-px rounded-l-none px-1.5"
           >
             {filters.sortDirection === 'asc' ? (
-              <ArrowUpNarrowWide className="h-3.5 w-3.5" />
+              <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
             ) : (
-              <ArrowDownWideNarrow className="h-3.5 w-3.5" />
+              <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
             )}
           </Button>
         </div>

--- a/apps/web/src/lib/elementStyles.ts
+++ b/apps/web/src/lib/elementStyles.ts
@@ -42,3 +42,13 @@ export const ELEMENT_FOCUS_RINGS: Record<Element, string> = {
   Geo: 'focus-visible:ring-geo',
   Dendro: 'focus-visible:ring-dendro',
 };
+
+export const ELEMENT_BG_COLORS: Record<Element, string> = {
+  Pyro: 'bg-pyro-dark text-white',
+  Hydro: 'bg-hydro-dark text-white',
+  Electro: 'bg-electro-dark text-white',
+  Cryo: 'bg-cryo-dark text-white',
+  Anemo: 'bg-anemo-dark text-white',
+  Geo: 'bg-geo-dark text-white',
+  Dendro: 'bg-dendro-dark text-white',
+};

--- a/apps/web/src/pages/CharactersPage.tsx
+++ b/apps/web/src/pages/CharactersPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Character } from '@genshin/game-data';
+import type { Character, Element, Rarity } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { useMemo, useState } from 'react';
 
@@ -13,8 +13,8 @@ import { useCollectionStore } from '@/features/collection/useCollectionStore';
 function initialFilterState(): CharacterFilterState {
   return {
     search: '',
-    elements: new Set(),
-    rarities: new Set(),
+    elements: new Set<Element>(),
+    rarities: new Set<Rarity>(),
     ownership: 'all',
     sortField: 'release',
     sortDirection: 'desc',

--- a/apps/web/src/pages/CharactersPage.tsx
+++ b/apps/web/src/pages/CharactersPage.tsx
@@ -3,9 +3,23 @@
 
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
+import { useMemo, useState } from 'react';
 
 import { CharacterCard } from '@/components/CharacterCard';
+import type { CharacterFilterState } from '@/components/CharacterFilters';
+import { CharacterFilters, filterCharacters } from '@/components/CharacterFilters';
 import { useCollectionStore } from '@/features/collection/useCollectionStore';
+
+function initialFilterState(): CharacterFilterState {
+  return {
+    search: '',
+    elements: new Set(),
+    rarities: new Set(),
+    ownership: 'all',
+    sortField: 'release',
+    sortDirection: 'asc',
+  };
+}
 
 export function CharactersPage() {
   const addCharacter = useCollectionStore((s) => s.addCharacter);
@@ -14,7 +28,15 @@ export function CharactersPage() {
   const isOwned = useCollectionStore((s) => s.isOwned);
   const characters = useCollectionStore((s) => s.characters);
 
+  const [filters, setFilters] = useState<CharacterFilterState>(initialFilterState);
+
   const ownedCount = Object.keys(characters).length;
+  const ownedIds = useMemo(() => new Set(Object.keys(characters)), [characters]);
+
+  const filteredCharacters = useMemo(
+    () => filterCharacters(CHARACTERS, filters, ownedIds),
+    [filters, ownedIds],
+  );
 
   function handleConstellationChange(characterId: Character['id'], level: number) {
     setConstellationLevel(characterId, level);
@@ -23,12 +45,18 @@ export function CharactersPage() {
   return (
     <div className="mx-auto max-w-7xl px-4 py-12">
       <h1 className="sr-only">Characters</h1>
-      <p className="text-sm text-muted-foreground">
-        {ownedCount} / {CHARACTERS.length} owned
-      </p>
+
+      <CharacterFilters
+        filters={filters}
+        onChange={setFilters}
+        filteredCount={filteredCharacters.length}
+        totalCount={CHARACTERS.length}
+        ownedCount={ownedCount}
+        filteredOwnedCount={filteredCharacters.filter((c) => ownedIds.has(c.id)).length}
+      />
 
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {CHARACTERS.map((character) => {
+        {filteredCharacters.map((character) => {
           const owned = isOwned(character.id);
           const entry = owned ? characters[character.id] : undefined;
 
@@ -46,6 +74,10 @@ export function CharactersPage() {
           );
         })}
       </div>
+
+      {filteredCharacters.length === 0 && (
+        <p className="py-12 text-center text-muted-foreground">No characters match your filters.</p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/CharactersPage.tsx
+++ b/apps/web/src/pages/CharactersPage.tsx
@@ -17,7 +17,7 @@ function initialFilterState(): CharacterFilterState {
     rarities: new Set(),
     ownership: 'all',
     sortField: 'release',
-    sortDirection: 'asc',
+    sortDirection: 'desc',
   };
 }
 

--- a/apps/web/src/pages/CharactersPage.tsx
+++ b/apps/web/src/pages/CharactersPage.tsx
@@ -33,10 +33,13 @@ export function CharactersPage() {
   const ownedCount = Object.keys(characters).length;
   const ownedIds = useMemo(() => new Set(Object.keys(characters)), [characters]);
 
-  const filteredCharacters = useMemo(
-    () => filterCharacters(CHARACTERS, filters, ownedIds),
-    [filters, ownedIds],
-  );
+  const { filteredCharacters, filteredOwnedCount } = useMemo(() => {
+    const filtered = filterCharacters(CHARACTERS, filters, ownedIds);
+    return {
+      filteredCharacters: filtered,
+      filteredOwnedCount: filtered.filter((c) => ownedIds.has(c.id)).length,
+    };
+  }, [filters, ownedIds]);
 
   function handleConstellationChange(characterId: Character['id'], level: number) {
     setConstellationLevel(characterId, level);
@@ -52,7 +55,7 @@ export function CharactersPage() {
         filteredCount={filteredCharacters.length}
         totalCount={CHARACTERS.length}
         ownedCount={ownedCount}
-        filteredOwnedCount={filteredCharacters.filter((c) => ownedIds.has(c.id)).length}
+        filteredOwnedCount={filteredOwnedCount}
       />
 
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,9 @@ flag_management:
     - name: collection-json
       paths:
         - packages/collection-json/src/**
+    - name: game-data
+      paths:
+        - packages/game-data/src/**
 
 component_management:
   individual_components:
@@ -58,6 +61,12 @@ component_management:
         - apps/api/src/lib/firebase/**
       flag_regexes:
         - api
+    - component_id: game-data-versions
+      name: 'Game Data: Versions'
+      paths:
+        - packages/game-data/src/versions.ts
+      flag_regexes:
+        - game-data
     - component_id: collection-json
       name: Collection JSON
       paths:

--- a/packages/game-data/package.json
+++ b/packages/game-data/package.json
@@ -15,13 +15,16 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "lint": "eslint ."
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/node": "25.5.0",
+    "@vitest/coverage-v8": "4.1.0",
     "eslint": "10.1.0",
     "typescript": "5.9.3",
-    "typescript-eslint": "8.57.1"
+    "typescript-eslint": "8.57.1",
+    "vitest": "4.1.0"
   }
 }

--- a/packages/game-data/src/index.ts
+++ b/packages/game-data/src/index.ts
@@ -10,10 +10,10 @@
 
 // Elements
 export {
-  ELEMENT_REACTION_TYPES,
   ELEMENTS,
-  getReactionsByVersion,
+  ELEMENT_REACTION_TYPES,
   REACTION_TYPES,
+  getReactionsByVersion,
   type Element,
   type ReactionType,
 } from './elements.js';
@@ -34,13 +34,13 @@ export {
 
 // Weapons
 export {
+  WEAPONS,
+  WEAPON_STAT_TYPES,
+  WEAPON_TYPES,
   getWeaponById,
   getWeaponsByRarity,
   getWeaponsByType,
   getWeaponsByVersion,
-  WEAPON_STAT_TYPES,
-  WEAPON_TYPES,
-  WEAPONS,
   type Weapon,
   type WeaponStatType,
   type WeaponType,
@@ -55,3 +55,6 @@ export {
   type ArtifactPiece,
   type ArtifactSet,
 } from './artifacts.js';
+
+// Versions
+export { compareVersions } from './versions.js';

--- a/packages/game-data/src/versions.test.ts
+++ b/packages/game-data/src/versions.test.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { compareVersions } from './versions.js';
+
+describe('compareVersions', () => {
+  describe('numeric versions', () => {
+    it('returns negative when a comes before b', () => {
+      expect(compareVersions('1.0', '2.0')).toBeLessThan(0);
+    });
+
+    it('returns positive when a comes after b', () => {
+      expect(compareVersions('3.0', '1.0')).toBeGreaterThan(0);
+    });
+
+    it('returns zero for equal versions', () => {
+      expect(compareVersions('3.2', '3.2')).toBe(0);
+    });
+
+    it('compares minor versions within the same major', () => {
+      expect(compareVersions('1.0', '1.1')).toBeLessThan(0);
+      expect(compareVersions('5.8', '5.3')).toBeGreaterThan(0);
+    });
+
+    it('treats a single-segment version as minor zero', () => {
+      expect(compareVersions('2', '2.0')).toBe(0);
+    });
+  });
+
+  describe('Luna versions', () => {
+    it('orders Luna versions sequentially', () => {
+      expect(compareVersions('Luna I', 'Luna II')).toBeLessThan(0);
+      expect(compareVersions('Luna II', 'Luna III')).toBeLessThan(0);
+      expect(compareVersions('Luna III', 'Luna IV')).toBeLessThan(0);
+    });
+
+    it('returns zero for equal Luna versions', () => {
+      expect(compareVersions('Luna I', 'Luna I')).toBe(0);
+    });
+
+    it('places Luna versions after numeric versions', () => {
+      expect(compareVersions('5.8', 'Luna I')).toBeLessThan(0);
+      expect(compareVersions('Luna I', '5.8')).toBeGreaterThan(0);
+    });
+  });
+
+  describe('invalid versions', () => {
+    it('throws for non-numeric strings', () => {
+      expect(() => compareVersions('abc', '1.0')).toThrow('Invalid version string: "abc"');
+    });
+
+    it('throws for empty strings', () => {
+      expect(() => compareVersions('', '1.0')).toThrow('Invalid version string: ""');
+    });
+  });
+});

--- a/packages/game-data/src/versions.test.ts
+++ b/packages/game-data/src/versions.test.ts
@@ -24,6 +24,10 @@ describe('compareVersions', () => {
       expect(compareVersions('5.8', '5.3')).toBeGreaterThan(0);
     });
 
+    it('handles multi-digit minor versions correctly', () => {
+      expect(compareVersions('5.9', '5.10')).toBeLessThan(0);
+    });
+
     it('treats a single-segment version as minor zero', () => {
       expect(compareVersions('2', '2.0')).toBe(0);
     });

--- a/packages/game-data/src/versions.test.ts
+++ b/packages/game-data/src/versions.test.ts
@@ -58,5 +58,13 @@ describe('compareVersions', () => {
     it('throws for empty strings', () => {
       expect(() => compareVersions('', '1.0')).toThrow('Invalid version string: ""');
     });
+
+    it('throws for trailing dot', () => {
+      expect(() => compareVersions('5.', '1.0')).toThrow('Invalid version string: "5."');
+    });
+
+    it('throws for extra segments', () => {
+      expect(() => compareVersions('1.2.3', '1.0')).toThrow('Invalid version string: "1.2.3"');
+    });
   });
 });

--- a/packages/game-data/src/versions.ts
+++ b/packages/game-data/src/versions.ts
@@ -12,11 +12,20 @@ const LUNA_VERSIONS: Record<string, readonly [number, number]> = {
 function versionTuple(version: string): readonly [number, number] {
   if (Object.hasOwn(LUNA_VERSIONS, version)) return LUNA_VERSIONS[version];
 
-  const [majorRaw, minorRaw] = version.split('.');
+  const parts = version.split('.');
+  if (parts.length > 2) {
+    throw new Error(`Invalid version string: "${version}"`);
+  }
+
+  const [majorRaw, minorRaw] = parts;
+  if (!majorRaw || (minorRaw !== undefined && minorRaw === '')) {
+    throw new Error(`Invalid version string: "${version}"`);
+  }
+
   const major = Number(majorRaw);
   const minor = minorRaw === undefined ? 0 : Number(minorRaw);
 
-  if (!majorRaw || Number.isNaN(major) || Number.isNaN(minor)) {
+  if (Number.isNaN(major) || Number.isNaN(minor)) {
     throw new Error(`Invalid version string: "${version}"`);
   }
 

--- a/packages/game-data/src/versions.ts
+++ b/packages/game-data/src/versions.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-// Luna versions map to [major, minor] tuples that sort after all numeric versions.
+// Luna versions map to [major, minor] tuples in the 6.x series (after 5.x, the last numeric era).
 const LUNA_VERSIONS: Record<string, readonly [number, number]> = {
   'Luna I': [6, 0],
   'Luna II': [6, 1],

--- a/packages/game-data/src/versions.ts
+++ b/packages/game-data/src/versions.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Luna versions map to [major, minor] tuples that sort after all numeric versions.
+const LUNA_VERSIONS: Record<string, readonly [number, number]> = {
+  'Luna I': [6, 0],
+  'Luna II': [6, 1],
+  'Luna III': [6, 2],
+  'Luna IV': [6, 3],
+};
+
+function versionTuple(version: string): readonly [number, number] {
+  if (version in LUNA_VERSIONS) return LUNA_VERSIONS[version];
+  const [major, minor] = version.split('.').map(Number);
+  return [major, minor ?? 0];
+}
+
+/**
+ * Compare two version strings for sorting.
+ * Returns negative if a comes before b, positive if after, zero if equal.
+ */
+export function compareVersions(a: string, b: string): number {
+  const [aMajor, aMinor] = versionTuple(a);
+  const [bMajor, bMinor] = versionTuple(b);
+  return aMajor - bMajor || aMinor - bMinor;
+}

--- a/packages/game-data/src/versions.ts
+++ b/packages/game-data/src/versions.ts
@@ -10,9 +10,17 @@ const LUNA_VERSIONS: Record<string, readonly [number, number]> = {
 };
 
 function versionTuple(version: string): readonly [number, number] {
-  if (version in LUNA_VERSIONS) return LUNA_VERSIONS[version];
-  const [major, minor] = version.split('.').map(Number);
-  return [major, minor ?? 0];
+  if (Object.hasOwn(LUNA_VERSIONS, version)) return LUNA_VERSIONS[version];
+
+  const [majorRaw, minorRaw] = version.split('.');
+  const major = Number(majorRaw);
+  const minor = minorRaw === undefined ? 0 : Number(minorRaw);
+
+  if (!majorRaw || Number.isNaN(major) || Number.isNaN(minor)) {
+    throw new Error(`Invalid version string: "${version}"`);
+  }
+
+  return [major, minor];
 }
 
 /**

--- a/packages/game-data/tsconfig.json
+++ b/packages/game-data/tsconfig.json
@@ -17,5 +17,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/packages/game-data/vitest.config.ts
+++ b/packages/game-data/vitest.config.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['dist/**', 'node_modules/**'],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       '@types/node':
         specifier: 25.5.0
         version: 25.5.0
+      '@vitest/coverage-v8':
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)))
       eslint:
         specifier: 10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -278,6 +281,9 @@ importers:
       typescript-eslint:
         specifier: 8.57.1
         version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
 
 packages:
 


### PR DESCRIPTION
## Summary

Add a **CharacterFilters** component with ownership, rarity, and element toggle filters, text search, and release/name sort with direction toggle.

## Changes

### New files
- `apps/web/src/components/CharacterFilters.tsx` — filter toolbar UI + `filterCharacters()` pure function
- `packages/game-data/src/versions.ts` — tuple-based `compareVersions()` for safe version ordering

### Modified files
- `apps/web/src/pages/CharactersPage.tsx` — wire up filters, delegate filtering to `filterCharacters()`
- `apps/web/src/components/CharacterCard.tsx` — use shared `getElementIconPath()`
- `apps/web/src/lib/elementStyles.ts` — add `ELEMENT_BG_COLORS` map
- `packages/game-data/src/index.ts` — export `compareVersions`

## Design decisions

- **Two-row toolbar**: Row 1 has filter toggles (ownership | rarity | elements), Row 2 has search + count + sort. Explicit rows instead of flex-wrap for predictable break points.
- **Owned count scopes to filtered results**: When filters are active, shows "3 / 15 owned" instead of global counts.
- **Sort options limited to release and name**: Element and rarity sorts were too coarse (7 and 2 groups respectively) — toggle filters serve that role better.
- **Version comparison uses integer tuples**: Avoids float precision issues with `parseFloat` for version strings like "5.10".
- **Shared element styles**: `ELEMENT_BG_COLORS` extracted to `lib/elementStyles.ts` alongside existing border/ring maps. Static class strings preserved for Tailwind's content scanner.

## Follow-up issues
- #534 — Add `releaseDate` field to game-data characters
- #535 — Structured `GameVersion` type instead of version strings

Part of #41