### PR TITLE
feat(web): handle mutation errors with rollback and toast notifications

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "7.13.2",
+    "sonner": "2.0.7",
     "tailwind-merge": "3.5.0",
     "zustand": "5.0.12"
   },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 
 import { Layout } from './components/Layout';
+import { Toaster } from './components/ui/sonner';
 import { AuthProvider } from './features/auth';
 import { CharactersPage } from './pages/CharactersPage';
 import { ChatPage } from './pages/ChatPage';
@@ -32,6 +33,7 @@ export function App() {
           </Routes>
         </Router>
       </AuthProvider>
+      <Toaster />
     </QueryClientProvider>
   );
 }

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { Toaster as Sonner } from 'sonner';
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+export function Toaster(props: ToasterProps) {
+  return (
+    <Sonner
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
+          actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+        },
+      }}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { ComponentProps } from 'react';
 import { Toaster as Sonner } from 'sonner';
 
-type ToasterProps = React.ComponentProps<typeof Sonner>;
+type ToasterProps = ComponentProps<typeof Sonner>;
 
 export function Toaster(props: ToasterProps) {
   return (

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -66,12 +66,15 @@ export function useCollection(): UseCollectionResult {
 
   const addCharacter = useCallback(
     (id: CharacterId) => {
+      const existed = id in characters;
       storeAddCharacter(id);
       if (isAuthenticated) {
         addCharacterApi(id, {
           onSuccess: applyMutationResult,
           onError: () => {
-            storeRemoveCharacter(id);
+            if (!existed) {
+              storeRemoveCharacter(id);
+            }
             toast.error('Failed to add character. Change has been reverted.');
           },
         });
@@ -79,6 +82,7 @@ export function useCollection(): UseCollectionResult {
     },
     [
       isAuthenticated,
+      characters,
       addCharacterApi,
       storeAddCharacter,
       storeRemoveCharacter,
@@ -93,7 +97,7 @@ export function useCollection(): UseCollectionResult {
       if (isAuthenticated) {
         removeCharacterApi(id, {
           onError: () => {
-            if (previous) {
+            if (previous && !(id in useCollectionStore.getState().characters)) {
               storeAddCharacter(id);
               storeSetConstellationLevel(id, previous.constellationLevel);
             }
@@ -122,7 +126,8 @@ export function useCollection(): UseCollectionResult {
           {
             onSuccess: applyMutationResult,
             onError: () => {
-              if (previousLevel !== undefined) {
+              const currentLevel = useCollectionStore.getState().characters[id]?.constellationLevel;
+              if (previousLevel !== undefined && currentLevel === level) {
                 storeSetConstellationLevel(id, previousLevel);
               }
               toast.error('Failed to update constellation level. Change has been reverted.');

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { useCallback, useEffect } from 'react';
+import { toast } from 'sonner';
 
 import { useAuth } from '@/features/auth/useAuth';
 
@@ -67,30 +68,76 @@ export function useCollection(): UseCollectionResult {
     (id: CharacterId) => {
       storeAddCharacter(id);
       if (isAuthenticated) {
-        addCharacterApi(id, { onSuccess: applyMutationResult });
+        addCharacterApi(id, {
+          onSuccess: applyMutationResult,
+          onError: () => {
+            storeRemoveCharacter(id);
+            toast.error('Failed to add character. Change has been reverted.');
+          },
+        });
       }
     },
-    [isAuthenticated, addCharacterApi, storeAddCharacter, applyMutationResult],
+    [
+      isAuthenticated,
+      addCharacterApi,
+      storeAddCharacter,
+      storeRemoveCharacter,
+      applyMutationResult,
+    ],
   );
 
   const removeCharacter = useCallback(
     (id: CharacterId) => {
+      const previous = characters[id];
       storeRemoveCharacter(id);
       if (isAuthenticated) {
-        removeCharacterApi(id);
+        removeCharacterApi(id, {
+          onError: () => {
+            if (previous) {
+              storeAddCharacter(id);
+              storeSetConstellationLevel(id, previous.constellationLevel);
+            }
+            toast.error('Failed to remove character. Change has been reverted.');
+          },
+        });
       }
     },
-    [isAuthenticated, removeCharacterApi, storeRemoveCharacter],
+    [
+      isAuthenticated,
+      characters,
+      removeCharacterApi,
+      storeRemoveCharacter,
+      storeAddCharacter,
+      storeSetConstellationLevel,
+    ],
   );
 
   const setConstellationLevel = useCallback(
     (id: CharacterId, level: number) => {
+      const previousLevel = characters[id]?.constellationLevel;
       storeSetConstellationLevel(id, level);
       if (isAuthenticated) {
-        setConstellationLevelApi({ characterId: id, level }, { onSuccess: applyMutationResult });
+        setConstellationLevelApi(
+          { characterId: id, level },
+          {
+            onSuccess: applyMutationResult,
+            onError: () => {
+              if (previousLevel !== undefined) {
+                storeSetConstellationLevel(id, previousLevel);
+              }
+              toast.error('Failed to update constellation level. Change has been reverted.');
+            },
+          },
+        );
       }
     },
-    [isAuthenticated, setConstellationLevelApi, storeSetConstellationLevel, applyMutationResult],
+    [
+      isAuthenticated,
+      characters,
+      setConstellationLevelApi,
+      storeSetConstellationLevel,
+      applyMutationResult,
+    ],
   );
 
   const isOwned = useCallback((id: CharacterId) => id in characters, [characters]);

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -134,6 +134,8 @@ export function useCollection(): UseCollectionResult {
   const setConstellationLevel = useCallback(
     (id: CharacterId, level: number) => {
       const previousLevel = useCollectionStore.getState().characters[id]?.constellationLevel;
+      if (previousLevel === undefined || previousLevel === level) return;
+
       storeSetConstellationLevel(id, level);
       if (isAuthenticated) {
         setConstellationLevelApi(

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -4,6 +4,8 @@
 import { useCallback, useEffect } from 'react';
 import { toast } from 'sonner';
 
+import { MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+
 import { useAuth } from '@/features/auth/useAuth';
 
 import type { MutationResult } from './useCollectionApi';
@@ -81,8 +83,8 @@ export function useCollection(): UseCollectionResult {
         addCharacterApi(id, {
           onSuccess: applyMutationResult,
           onError: () => {
-            const stillExists = id in useCollectionStore.getState().characters;
-            if (stillExists) {
+            const current = useCollectionStore.getState().characters[id];
+            if (current && current.constellationLevel === MIN_CONSTELLATION_LEVEL) {
               storeRemoveCharacter(id);
               toast.error('Failed to add character. Change has been reverted.');
             } else {

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -66,23 +66,27 @@ export function useCollection(): UseCollectionResult {
 
   const addCharacter = useCallback(
     (id: CharacterId) => {
-      const existed = id in characters;
+      const alreadyOwned = id in useCollectionStore.getState().characters;
+      if (alreadyOwned) return;
+
       storeAddCharacter(id);
       if (isAuthenticated) {
         addCharacterApi(id, {
           onSuccess: applyMutationResult,
           onError: () => {
-            if (!existed) {
+            const stillExists = id in useCollectionStore.getState().characters;
+            if (stillExists) {
               storeRemoveCharacter(id);
+              toast.error('Failed to add character. Change has been reverted.');
+            } else {
+              toast.error('Failed to add character.');
             }
-            toast.error('Failed to add character. Change has been reverted.');
           },
         });
       }
     },
     [
       isAuthenticated,
-      characters,
       addCharacterApi,
       storeAddCharacter,
       storeRemoveCharacter,
@@ -92,23 +96,27 @@ export function useCollection(): UseCollectionResult {
 
   const removeCharacter = useCallback(
     (id: CharacterId) => {
-      const previous = characters[id];
+      const current = useCollectionStore.getState().characters[id];
+      if (!current) return;
+
       storeRemoveCharacter(id);
       if (isAuthenticated) {
         removeCharacterApi(id, {
           onError: () => {
-            if (previous && !(id in useCollectionStore.getState().characters)) {
+            const stillAbsent = !(id in useCollectionStore.getState().characters);
+            if (stillAbsent) {
               storeAddCharacter(id);
-              storeSetConstellationLevel(id, previous.constellationLevel);
+              storeSetConstellationLevel(id, current.constellationLevel);
+              toast.error('Failed to remove character. Change has been reverted.');
+            } else {
+              toast.error('Failed to remove character.');
             }
-            toast.error('Failed to remove character. Change has been reverted.');
           },
         });
       }
     },
     [
       isAuthenticated,
-      characters,
       removeCharacterApi,
       storeRemoveCharacter,
       storeAddCharacter,
@@ -118,7 +126,7 @@ export function useCollection(): UseCollectionResult {
 
   const setConstellationLevel = useCallback(
     (id: CharacterId, level: number) => {
-      const previousLevel = characters[id]?.constellationLevel;
+      const previousLevel = useCollectionStore.getState().characters[id]?.constellationLevel;
       storeSetConstellationLevel(id, level);
       if (isAuthenticated) {
         setConstellationLevelApi(
@@ -129,20 +137,16 @@ export function useCollection(): UseCollectionResult {
               const currentLevel = useCollectionStore.getState().characters[id]?.constellationLevel;
               if (previousLevel !== undefined && currentLevel === level) {
                 storeSetConstellationLevel(id, previousLevel);
+                toast.error('Failed to update constellation level. Change has been reverted.');
+              } else {
+                toast.error('Failed to update constellation level.');
               }
-              toast.error('Failed to update constellation level. Change has been reverted.');
             },
           },
         );
       }
     },
-    [
-      isAuthenticated,
-      characters,
-      setConstellationLevelApi,
-      storeSetConstellationLevel,
-      applyMutationResult,
-    ],
+    [isAuthenticated, setConstellationLevelApi, storeSetConstellationLevel, applyMutationResult],
   );
 
   const isOwned = useCallback((id: CharacterId) => id in characters, [characters]);

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -64,6 +64,13 @@ export function useCollection(): UseCollectionResult {
     [storeSetConstellationLevel],
   );
 
+  // Mutation error strategy: optimistic rollback + toast notification.
+  // Each mutation writes to zustand first for instant UI feedback, then fires
+  // the API call. On failure the onError callback rolls back the zustand change
+  // only if the store still reflects this mutation's optimistic value (guards
+  // against races from rapid user interactions). Errors are surfaced via toast
+  // side-effects — no retry is attempted.
+
   const addCharacter = useCallback(
     (id: CharacterId) => {
       const alreadyOwned = id in useCollectionStore.getState().characters;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       react-router-dom:
         specifier: 7.13.2
         version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sonner:
+        specifier: 2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: 3.5.0
         version: 3.5.0
@@ -1270,42 +1273,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -1381,28 +1378,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2525,28 +2518,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3066,6 +3055,12 @@ packages:
   slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6284,6 +6279,11 @@ snapshots:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Handle mutation errors in the collection API sync layer by rolling back optimistic zustand updates and notifying the user with toast messages.

## Changes

- **Optimistic rollback**: Each mutation captures the previous zustand state before firing. On API failure, `onError` restores the previous state so the UI stays consistent.
  - `addCharacter` → removes the optimistically-added character
  - `removeCharacter` → re-adds the character with its previous constellation level
  - `setConstellationLevel` → restores the previous constellation level
- **Toast notifications**: Uses [sonner](https://sonner.emilkowal.dev/) (via `shadcn/ui`) to fire `toast.error()` on each mutation failure. Toasts queue naturally, so multiple concurrent failures each get their own notification.
- **Sonner integration**: Added `sonner` via `shadcn/ui`, wired `<Toaster />` in `App.tsx`. Removed unused `next-themes` dependency that the scaffold brought in.

## Design decisions

- **Toast over banner**: Toasts support queuing multiple errors and auto-dismiss, which is better UX for transient sync failures than a persistent error banner.
- **No retry**: Keeps the scope minimal — rollback + notify. Retry can be added later if needed.
- **No `syncError` field**: Errors are handled entirely via toast side-effects in the hook, so consumers don't need to destructure or render error state.

Closes #548