### PR TITLE
feat(web): merge anonymous collection with server on login

### DIFF
--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -51,9 +51,25 @@ export function useCollection(): UseCollectionResult {
   const { mutate: removeCharacterApi } = useRemoveCharacterMutation(user?.uid);
   const { mutate: setConstellationLevelApi } = useSetConstellationLevelMutation(user?.uid);
 
+  // Patch zustand with confirmed server data
+  const applyMutationResult = useCallback(
+    ({ characterId, entry }: MutationResult) => {
+      storeSetConstellationLevel(characterId, entry.constellationLevel);
+    },
+    [storeSetConstellationLevel],
+  );
+
   // Merge anonymous localStorage data with server data on first query resolution
-  // per user session. Subsequent resolutions (refetches) replace zustand normally.
+  // per user session. Subsequent resolutions (refetches) merge additively to
+  // avoid overwriting optimistic state while merge mutations are in flight.
   const mergedForUser = useRef<string | null>(null);
+
+  // Reset merge tracking on logout so re-login triggers a fresh merge.
+  useEffect(() => {
+    if (!user) {
+      mergedForUser.current = null;
+    }
+  }, [user]);
 
   useEffect(() => {
     if (!apiCharacters) return;
@@ -74,7 +90,12 @@ export function useCollection(): UseCollectionResult {
       }
 
       for (const diff of diffs) {
-        setConstellationLevelApi(diff);
+        setConstellationLevelApi(diff, {
+          onSuccess: applyMutationResult,
+          onError: () => {
+            toast.error('Failed to sync a merged character to the server.');
+          },
+        });
       }
 
       if (diffs.length > 0) {
@@ -83,17 +104,12 @@ export function useCollection(): UseCollectionResult {
 
       mergedForUser.current = user.uid;
     } else {
-      replaceCharacters(apiCharacters);
+      // Keep refetches additive so in-flight merge mutations aren't overwritten.
+      const currentCharacters = useCollectionStore.getState().characters;
+      const merged = mergeCollections(currentCharacters, apiCharacters);
+      replaceCharacters(merged);
     }
-  }, [apiCharacters, user, replaceCharacters, setConstellationLevelApi]);
-
-  // Patch zustand with confirmed server data
-  const applyMutationResult = useCallback(
-    ({ characterId, entry }: MutationResult) => {
-      storeSetConstellationLevel(characterId, entry.constellationLevel);
-    },
-    [storeSetConstellationLevel],
-  );
+  }, [apiCharacters, user, replaceCharacters, setConstellationLevelApi, applyMutationResult]);
 
   // Mutation error strategy: optimistic rollback + toast notification.
   // Each mutation writes to zustand first for instant UI feedback, then fires

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -4,7 +4,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
-import { MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 
 import { useAuth } from '@/features/auth/useAuth';
 
@@ -39,6 +39,7 @@ export function useCollection(): UseCollectionResult {
   const storeRemoveCharacter = useCollectionStore((s) => s.removeCharacter);
   const storeSetConstellationLevel = useCollectionStore((s) => s.setConstellationLevel);
   const replaceCharacters = useCollectionStore((s) => s.replaceCharacters);
+  const clearCharacters = useCollectionStore((s) => s.clearCharacters);
 
   // TanStack Query — background sync when authenticated
   const {
@@ -64,12 +65,15 @@ export function useCollection(): UseCollectionResult {
   // avoid overwriting optimistic state while merge mutations are in flight.
   const mergedForUser = useRef<string | null>(null);
 
-  // Reset merge tracking on logout so re-login triggers a fresh merge.
+  // Reset merge tracking and clear persisted collection on logout so
+  // re-login triggers a fresh merge and a different account cannot
+  // inherit the previous user's local data.
   useEffect(() => {
     if (!user) {
       mergedForUser.current = null;
+      clearCharacters();
     }
-  }, [user]);
+  }, [user, clearCharacters]);
 
   useEffect(() => {
     if (!apiCharacters) return;
@@ -84,7 +88,10 @@ export function useCollection(): UseCollectionResult {
       for (const id of Object.keys(merged)) {
         const entry = merged[id];
         const serverEntry = apiCharacters[id];
-        if (!serverEntry || entry.constellationLevel > serverEntry.constellationLevel) {
+        if (
+          isValidConstellationLevel(entry.constellationLevel) &&
+          (!serverEntry || entry.constellationLevel > serverEntry.constellationLevel)
+        ) {
           diffs.push({ characterId: id, level: entry.constellationLevel });
         }
       }

--- a/apps/web/src/features/collection/useCollection.ts
+++ b/apps/web/src/features/collection/useCollection.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
@@ -16,7 +16,7 @@ import {
   useSetConstellationLevelMutation,
 } from './useCollectionApi';
 import type { CharacterId, CollectionEntry } from './useCollectionStore';
-import { useCollectionStore } from './useCollectionStore';
+import { mergeCollections, useCollectionStore } from './useCollectionStore';
 
 export interface UseCollectionResult {
   characters: Record<CharacterId, CollectionEntry>;
@@ -51,12 +51,41 @@ export function useCollection(): UseCollectionResult {
   const { mutate: removeCharacterApi } = useRemoveCharacterMutation(user?.uid);
   const { mutate: setConstellationLevelApi } = useSetConstellationLevelMutation(user?.uid);
 
-  // Sync API data into zustand when the query resolves
+  // Merge anonymous localStorage data with server data on first query resolution
+  // per user session. Subsequent resolutions (refetches) replace zustand normally.
+  const mergedForUser = useRef<string | null>(null);
+
   useEffect(() => {
-    if (apiCharacters) {
+    if (!apiCharacters) return;
+
+    if (user && mergedForUser.current !== user.uid) {
+      const localData = useCollectionStore.getState().characters;
+      const merged = mergeCollections(localData, apiCharacters);
+      replaceCharacters(merged);
+
+      // Push entries that differ from the server
+      const diffs: Array<{ characterId: CharacterId; level: number }> = [];
+      for (const id of Object.keys(merged)) {
+        const entry = merged[id];
+        const serverEntry = apiCharacters[id];
+        if (!serverEntry || entry.constellationLevel > serverEntry.constellationLevel) {
+          diffs.push({ characterId: id, level: entry.constellationLevel });
+        }
+      }
+
+      for (const diff of diffs) {
+        setConstellationLevelApi(diff);
+      }
+
+      if (diffs.length > 0) {
+        toast.success(`Merged ${diffs.length} character(s) from your local collection.`);
+      }
+
+      mergedForUser.current = user.uid;
+    } else {
       replaceCharacters(apiCharacters);
     }
-  }, [apiCharacters, replaceCharacters]);
+  }, [apiCharacters, user, replaceCharacters, setConstellationLevelApi]);
 
   // Patch zustand with confirmed server data
   const applyMutationResult = useCallback(

--- a/apps/web/src/features/collection/useCollectionStore.ts
+++ b/apps/web/src/features/collection/useCollectionStore.ts
@@ -12,6 +12,25 @@ export interface CollectionEntry {
 
 export type CharacterId = CollectionCharacter['characterId'];
 
+// Additive merge: union of both sets, keep higher constellation level on conflicts.
+export function mergeCollections(
+  local: Record<CharacterId, CollectionEntry>,
+  server: Record<CharacterId, CollectionEntry>,
+): Record<CharacterId, CollectionEntry> {
+  const merged: Record<CharacterId, CollectionEntry> = { ...server };
+
+  for (const [id, localEntry] of Object.entries(local)) {
+    const serverEntry = merged[id];
+    if (!serverEntry) {
+      merged[id] = localEntry;
+    } else if (localEntry.constellationLevel > serverEntry.constellationLevel) {
+      merged[id] = { constellationLevel: localEntry.constellationLevel };
+    }
+  }
+
+  return merged;
+}
+
 interface CollectionState {
   characters: Record<CharacterId, CollectionEntry>;
   addCharacter: (characterId: CharacterId) => void;
@@ -20,6 +39,7 @@ interface CollectionState {
   isOwned: (characterId: CharacterId) => boolean;
   getCharacter: (characterId: CharacterId) => CollectionEntry | undefined;
   replaceCharacters: (characters: Record<CharacterId, CollectionEntry>) => void;
+  clearCharacters: () => void;
 }
 
 export const useCollectionStore = create<CollectionState>()(
@@ -72,6 +92,10 @@ export const useCollectionStore = create<CollectionState>()(
 
       replaceCharacters: (characters) => {
         set({ characters });
+      },
+
+      clearCharacters: () => {
+        set({ characters: {} });
       },
     }),
     {


### PR DESCRIPTION
## Summary

On login, reconcile the anonymous localStorage collection with the server collection using an additive merge strategy.

## Changes

- **`mergeCollections()`** — pure function in `useCollectionStore`: computes the union of local and server character sets, keeping the higher constellation level on conflicts.
- **Merge-on-first-query** — `useCollection` tracks the last userId for which a merge was performed (`useRef`). On the first query resolution for a new user, it snapshots the local zustand data, computes the merge, replaces zustand with the merged result, and pushes diffs to the server via existing mutation hooks.
- **Toast confirmation** — shows `Merged N character(s) from your local collection.` when diffs exist.
- **`clearCharacters()`** — new store action added for future use (e.g., logout cleanup).

## Design decisions

- **Additive merge**: union of both sets, max constellation level on conflicts. No merge UI needed since resolution is deterministic.
- **Server push via existing mutation hooks**: uses `setConstellationLevelApi` (which calls PUT) for both new characters and level updates. Each mutation independently invalidates the collection query, so the server state converges.
- **One-time per user session**: the merge ref prevents re-merging on subsequent query refetches.
- **Edge case**: anonymous removals/decrements that conflict with server data re-appear after login. Accepted tradeoff per the design in #41 — user can fix post-login.

## PR 6 of 6 for #41

| # | PR | Status |
|---|-----|--------|
| 1 | #478 — Wire up TanStack Query | Merged |
| 2 | #497 — Create authenticated API client | Merged |
| 3 | #509 — Build collection list view | Merged |
| 4 | #536 — Add filters, search, sort | Merged |
| 5 | #538 — Sync collection with API | Merged |
| 6 | This PR — Anonymous-to-authenticated merge | **Open** |

Closes #41