### PR TITLE
fix(deploy): pass VITE_API_BASE_URL to web build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Build
         run: pnpm turbo run build --filter=@genshin/web
         env:
+          VITE_VERIFY_ENV: 'true'
           VITE_API_BASE_URL: https://api.develop.genshin.dungeon.studio
           VITE_FIREBASE_API_KEY: ${{ steps.firebase-config.outputs.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ steps.firebase-config.outputs.VITE_FIREBASE_AUTH_DOMAIN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build
         run: pnpm turbo run build --filter=@genshin/web
         env:
-          VITE_VERIFY_ENV: 'true'
+          VERIFY_ENV: 'true'
           VITE_API_BASE_URL: https://api.develop.genshin.dungeon.studio
           VITE_FIREBASE_API_KEY: ${{ steps.firebase-config.outputs.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ steps.firebase-config.outputs.VITE_FIREBASE_AUTH_DOMAIN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Build
         run: pnpm turbo run build --filter=@genshin/web
         env:
+          VITE_API_BASE_URL: https://api.develop.genshin.dungeon.studio
           VITE_FIREBASE_API_KEY: ${{ steps.firebase-config.outputs.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ steps.firebase-config.outputs.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ steps.firebase-config.outputs.VITE_FIREBASE_PROJECT_ID }}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     {
       name: 'validate-env',
       configResolved(config) {
-        if (config.command !== 'build' || !process.env.VITE_VERIFY_ENV) return;
+        if (config.command !== 'build' || process.env.VITE_VERIFY_ENV !== 'true') return;
 
         const missing = requiredEnvVars.filter((key) => !config.env[key]);
         if (missing.length > 0) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,10 +7,31 @@ import fs from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 
+const requiredEnvVars: readonly string[] = [
+  'VITE_FIREBASE_API_KEY',
+  'VITE_FIREBASE_AUTH_DOMAIN',
+  'VITE_FIREBASE_PROJECT_ID',
+  'VITE_FIREBASE_STORAGE_BUCKET',
+  'VITE_FIREBASE_MESSAGING_SENDER_ID',
+  'VITE_FIREBASE_APP_ID',
+  'VITE_API_BASE_URL',
+];
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
+    {
+      name: 'validate-env',
+      configResolved(config) {
+        if (config.command !== 'build') return;
+
+        const missing = requiredEnvVars.filter((key) => !config.env[key]);
+        if (missing.length > 0) {
+          throw new Error(`Missing required environment variables:\n  ${missing.join('\n  ')}`);
+        }
+      },
+    },
     {
       name: 'generate-version',
       closeBundle() {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     {
       name: 'validate-env',
       configResolved(config) {
-        if (config.command !== 'build' || process.env.VITE_VERIFY_ENV !== 'true') return;
+        if (config.command !== 'build' || process.env.VERIFY_ENV !== 'true') return;
 
         const missing = requiredEnvVars.filter((key) => !config.env[key]);
         if (missing.length > 0) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     {
       name: 'validate-env',
       configResolved(config) {
-        if (config.command !== 'build') return;
+        if (config.command !== 'build' || !process.env.VITE_VERIFY_ENV) return;
 
         const missing = requiredEnvVars.filter((key) => !config.env[key]);
         if (missing.length > 0) {


### PR DESCRIPTION
## Problem

`develop.genshin.dungeon.studio` throws a runtime error and renders nothing:

```
Uncaught Error: Missing required environment variable: VITE_API_BASE_URL
```

The deploy workflow passes all `VITE_FIREBASE_*` env vars to the web build step but omits `VITE_API_BASE_URL`, which `apps/web/src/lib/api.ts` requires at startup.

## Fix

Add `VITE_API_BASE_URL: https://api.develop.genshin.dungeon.studio` to the Build step's `env` block. This domain is already configured in Terraform with a Cloud Run domain mapping and DNS CNAME.