### PR TITLE
Unify profile and schema URL paths under /profiles/{format}/

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@
 
 - Define each JSON Schema as a typed TypeScript module in `apps/api/src/schemas/{module}/`, not a `.json` file.
 - Export a single `const` using `as const satisfies JsonSchemaProfile` from `@/schemas/json-schema-profile.js`.
-- Name files `{method}-{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). `{method}` is the lowercase HTTP method and `{direction}` is `request` or `response`. The serving path mirrors the filename: `/schemas/{module}/{method}-{direction}-v{n}.json`. See [DSGEP-005](../docs/explanation/dsgep-005-schema-direction-segment.md).
+- Name files `{method}-{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). `{method}` is the lowercase HTTP method and `{direction}` is `request` or `response`. The serving path mirrors the filename: `/profiles/json-schema/{module}/{method}-{direction}-v{n}.json`. See [DSGEP-005](../docs/explanation/dsgep-005-schema-direction-segment.md).
 - Register every schema module in `apps/api/src/schemas/registry.ts`. The registry completeness test discovers files on disk and asserts the registry contains each one.
 - The schema route stamps `$id` from the request origin at serve time. Don't declare `$id` in schema modules.
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -94,8 +94,8 @@ app.get('/health', (c) =>
 );
 
 // Routes
-app.route('/schemas', schemas);
-app.route('/profiles', profiles);
+app.route('/profiles/json-schema', schemas);
+app.route('/profiles/alps', profiles);
 app.route('/api/characters', characters);
 app.route('/api/profile', userProfile);
 app.route('/api/teams', teams);

--- a/apps/api/src/middleware/negotiate-content.test.ts
+++ b/apps/api/src/middleware/negotiate-content.test.ts
@@ -11,7 +11,7 @@ const ORIGIN = 'http://localhost';
 
 const jsonWithProfileLink: SupportedRepresentation = {
   mediaType: 'application/json',
-  profile: { path: '/schemas/profile/get/1.0.0.json' },
+  profile: { path: '/profiles/json-schema/profile/get/1.0.0.json' },
 };
 
 const plainJson: SupportedRepresentation = {
@@ -25,20 +25,20 @@ describe('toMediaTypeString', () => {
 
   it('appends profile parameter with absolute URI', () => {
     expect(toMediaTypeString(jsonWithProfileLink, ORIGIN)).toBe(
-      'application/json; profile="http://localhost/schemas/profile/get/1.0.0.json"',
+      'application/json; profile="http://localhost/profiles/json-schema/profile/get/1.0.0.json"',
     );
   });
 
   it('uses the provided origin in the profile URI', () => {
     expect(toMediaTypeString(jsonWithProfileLink, 'https://api.example.com')).toBe(
-      'application/json; profile="https://api.example.com/schemas/profile/get/1.0.0.json"',
+      'application/json; profile="https://api.example.com/profiles/json-schema/profile/get/1.0.0.json"',
     );
   });
 });
 
 describe('negotiateContent middleware', () => {
   const supported: SupportedRepresentation[] = [
-    { mediaType: 'application/json', profile: { path: '/schemas/test/1.0.0.json' } },
+    { mediaType: 'application/json', profile: { path: '/profiles/json-schema/test/1.0.0.json' } },
   ];
 
   function createApp() {
@@ -55,7 +55,7 @@ describe('negotiateContent middleware', () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toBe(
-      'application/json; profile="http://localhost/schemas/test/1.0.0.json"',
+      'application/json; profile="http://localhost/profiles/json-schema/test/1.0.0.json"',
     );
   });
 
@@ -64,7 +64,7 @@ describe('negotiateContent middleware', () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toBe(
-      'application/json; profile="http://localhost/schemas/test/1.0.0.json"',
+      'application/json; profile="http://localhost/profiles/json-schema/test/1.0.0.json"',
     );
   });
 

--- a/apps/api/src/middleware/negotiate-request-schema.test.ts
+++ b/apps/api/src/middleware/negotiate-request-schema.test.ts
@@ -8,8 +8,8 @@ import { describe, expect, it } from 'vitest';
 import type { NegotiatedRequestSchemaVariables } from './negotiate-request-schema.js';
 import { negotiateRequestSchema } from './negotiate-request-schema.js';
 
-const profileV1: ProfileLink = { path: '/schemas/test/put-request-v1.json' };
-const profileV2: ProfileLink = { path: '/schemas/test/put-request-v2.json' };
+const profileV1: ProfileLink = { path: '/profiles/json-schema/test/put-request-v1.json' };
+const profileV2: ProfileLink = { path: '/profiles/json-schema/test/put-request-v2.json' };
 
 describe('negotiateRequestSchema middleware', () => {
   function createApp(profiles: ProfileLink[] = [profileV1]) {
@@ -39,7 +39,7 @@ describe('negotiateRequestSchema middleware', () => {
 
   it('selects v1 when v1 profile URL is specified', async () => {
     const app = createApp([profileV2, profileV1]);
-    const profileUrl = 'http://localhost/schemas/test/put-request-v1.json';
+    const profileUrl = 'http://localhost/profiles/json-schema/test/put-request-v1.json';
     const res = await app.request(putRequest(`application/json; profile="${profileUrl}"`));
 
     expect(res.status).toBe(200);
@@ -50,7 +50,7 @@ describe('negotiateRequestSchema middleware', () => {
   it('selects v1 when profile is an absolute path', async () => {
     const app = createApp([profileV1]);
     const res = await app.request(
-      putRequest('application/json; profile="/schemas/test/put-request-v1.json"'),
+      putRequest('application/json; profile="/profiles/json-schema/test/put-request-v1.json"'),
     );
 
     expect(res.status).toBe(200);
@@ -60,7 +60,7 @@ describe('negotiateRequestSchema middleware', () => {
 
   it('selects v2 when v2 profile URL is specified', async () => {
     const app = createApp([profileV2, profileV1]);
-    const profileUrl = 'http://localhost/schemas/test/put-request-v2.json';
+    const profileUrl = 'http://localhost/profiles/json-schema/test/put-request-v2.json';
     const res = await app.request(putRequest(`application/json; profile="${profileUrl}"`));
 
     expect(res.status).toBe(200);
@@ -70,7 +70,7 @@ describe('negotiateRequestSchema middleware', () => {
 
   it('returns 415 for unrecognised profile', async () => {
     const app = createApp([profileV1]);
-    const profileUrl = 'http://localhost/schemas/test/put-request-v99.json';
+    const profileUrl = 'http://localhost/profiles/json-schema/test/put-request-v99.json';
     const res = await app.request(putRequest(`application/json; profile="${profileUrl}"`));
 
     expect(res.status).toBe(415);
@@ -78,7 +78,7 @@ describe('negotiateRequestSchema middleware', () => {
 
   it('returns 415 when client requests v1 but server only supports v2', async () => {
     const app = createApp([profileV2]);
-    const profileUrl = 'http://localhost/schemas/test/put-request-v1.json';
+    const profileUrl = 'http://localhost/profiles/json-schema/test/put-request-v1.json';
     const res = await app.request(putRequest(`application/json; profile="${profileUrl}"`));
 
     expect(res.status).toBe(415);

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -10,7 +10,7 @@ import type { ValidatedRequestBodyVariables } from './validate-request-body.js';
 import { validateRequestBody } from './validate-request-body.js';
 
 const schemaV1: JsonSchemaProfile = {
-  path: '/schemas/test/put-request-v1.json',
+  path: '/profiles/json-schema/test/put-request-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     type: 'object',
@@ -21,7 +21,7 @@ const schemaV1: JsonSchemaProfile = {
 };
 
 const schemaV2: JsonSchemaProfile = {
-  path: '/schemas/test/put-request-v2.json',
+  path: '/profiles/json-schema/test/put-request-v2.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     type: 'object',

--- a/apps/api/src/profiles/alps/character/item-v1.ts
+++ b/apps/api/src/profiles/alps/character/item-v1.ts
@@ -4,7 +4,7 @@
 import type { AlpsProfile } from '@/profiles/alps/profile.js';
 
 export const characterItemV1 = {
-  path: '/profiles/character/item-v1.json',
+  path: '/profiles/alps/character/item-v1.json',
   profile: {
     alps: {
       version: '1.0',

--- a/apps/api/src/profiles/alps/profile.ts
+++ b/apps/api/src/profiles/alps/profile.ts
@@ -15,7 +15,7 @@
  * `SupportedRepresentation`.
  */
 export interface AlpsProfile {
-  /** Absolute URL path where the profile is served (e.g. `/profiles/character/item-v1.json`). */
+  /** Absolute URL path where the profile is served (e.g. `/profiles/alps/character/item-v1.json`). */
   readonly path: string;
   /** The ALPS profile document. */
   readonly profile: Record<string, unknown>;

--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -4,7 +4,7 @@
 import type { AlpsProfile } from '@/profiles/alps/profile.js';
 
 export const teamItemV1 = {
-  path: '/profiles/team/item-v1.json',
+  path: '/profiles/alps/team/item-v1.json',
   profile: {
     alps: {
       version: '1.0',

--- a/apps/api/src/profiles/alps/weapon/item-v1.ts
+++ b/apps/api/src/profiles/alps/weapon/item-v1.ts
@@ -4,7 +4,7 @@
 import type { AlpsProfile } from '@/profiles/alps/profile.js';
 
 export const weaponItemV1 = {
-  path: '/profiles/weapon/item-v1.json',
+  path: '/profiles/alps/weapon/item-v1.json',
   profile: {
     alps: {
       version: '1.0',

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -10,7 +10,7 @@ describe('Profile serving routes', () => {
     let res: Response;
 
     beforeEach(async () => {
-      res = await app.request('http://localhost/profiles/character/item-v1.json');
+      res = await app.request('http://localhost/profiles/alps/character/item-v1.json');
     });
 
     it('returns 200', () => {
@@ -38,7 +38,7 @@ describe('Profile serving routes', () => {
   });
 
   it('returns 404 for unknown profile', async () => {
-    const res = await app.request('/profiles/unknown/item-v1.json');
+    const res = await app.request('/profiles/alps/unknown/item-v1.json');
     expect(res.status).toBe(404);
   });
 });

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -7,9 +7,9 @@ import { Hono } from 'hono';
 export const profiles = new Hono();
 
 for (const entry of alpsRegistry) {
-  // entry.path is e.g. '/profiles/character/item-v1.json'
-  // The router is mounted at '/profiles', so strip the prefix for the route pattern.
-  const routePath = entry.path.replace(/^\/profiles/, '');
+  // entry.path is e.g. '/profiles/alps/character/item-v1.json'
+  // The router is mounted at '/profiles/alps', so strip the prefix for the route pattern.
+  const routePath = entry.path.replace(/^\/profiles\/alps/, '');
 
   profiles.get(routePath, (c) => {
     return c.json(entry.profile, 200, {

--- a/apps/api/src/routes/root.test.ts
+++ b/apps/api/src/routes/root.test.ts
@@ -10,7 +10,7 @@ const ajv = new Ajv2020();
 const validateGetSchema = ajv.compile(rootGetResponseV1.schema);
 
 const EXPECTED_CONTENT_TYPE =
-  'application/json; profile="http://localhost/schemas/root/get-response-v1.json"';
+  'application/json; profile="http://localhost/profiles/json-schema/root/get-response-v1.json"';
 
 describe('GET /', () => {
   let res: Response;

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -13,8 +13,9 @@ import { findTargetHandler, isMiddleware } from 'hono/utils/handler';
  * Returns GET-accessible paths that have a discrete handler (e.g.
  * `/api/characters`, `/health`).
  *
- * Excludes the root path itself, wildcard catch-all routes (like `/profiles/*`),
- * and sub-resource paths that contain route parameters.
+ * Excludes the root path itself, wildcard catch-all routes (like
+ * `/profiles/json-schema/*` and `/profiles/alps/*`), and sub-resource
+ * paths that contain route parameters.
  */
 function discoverLinks<E extends Env>(app: HonoApp<E>): Record<string, { href: string }> {
   const seen = new Set<string>();

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -13,8 +13,8 @@ import { findTargetHandler, isMiddleware } from 'hono/utils/handler';
  * Returns GET-accessible paths that have a discrete handler (e.g.
  * `/api/characters`, `/health`).
  *
- * Excludes the root path itself, wildcard catch-all routes (like `/schemas/*`
- * and `/profiles/*`), and sub-resource paths that contain route parameters.
+ * Excludes the root path itself, wildcard catch-all routes (like `/profiles/*`),
+ * and sub-resource paths that contain route parameters.
  */
 function discoverLinks<E extends Env>(app: HonoApp<E>): Record<string, { href: string }> {
   const seen = new Set<string>();

--- a/apps/api/src/routes/schemas.test.ts
+++ b/apps/api/src/routes/schemas.test.ts
@@ -10,7 +10,7 @@ describe('Schema serving routes', () => {
     let res: Response;
 
     beforeEach(async () => {
-      res = await app.request('http://localhost/schemas/root/get-response-v1.json');
+      res = await app.request('http://localhost/profiles/json-schema/root/get-response-v1.json');
     });
 
     it('returns 200', () => {
@@ -23,7 +23,7 @@ describe('Schema serving routes', () => {
 
     it('rewrites $id to match request origin', async () => {
       const body = (await res.json()) as Record<string, unknown>;
-      expect(body.$id).toBe('http://localhost/schemas/root/get-response-v1.json');
+      expect(body.$id).toBe('http://localhost/profiles/json-schema/root/get-response-v1.json');
     });
 
     it('preserves schema fields', async () => {
@@ -44,7 +44,7 @@ describe('Schema serving routes', () => {
   });
 
   it('returns 404 for unknown schema', async () => {
-    const res = await app.request('/schemas/unknown/get-response-v1.json');
+    const res = await app.request('/profiles/json-schema/unknown/get-response-v1.json');
     expect(res.status).toBe(404);
   });
 });

--- a/apps/api/src/routes/schemas.ts
+++ b/apps/api/src/routes/schemas.ts
@@ -7,9 +7,9 @@ import { Hono } from 'hono';
 export const schemas = new Hono();
 
 for (const entry of schemaRegistry) {
-  // entry.path is e.g. '/schemas/profile/get-response-v1.json'
-  // The router is mounted at '/schemas', so strip the prefix for the route pattern.
-  const routePath = entry.path.replace(/^\/schemas/, '');
+  // entry.path is e.g. '/profiles/json-schema/profile/get-response-v1.json'
+  // The router is mounted at '/profiles/json-schema', so strip the prefix for the route pattern.
+  const routePath = entry.path.replace(/^\/profiles\/json-schema/, '');
 
   schemas.get(routePath, (c) => {
     const origin = new URL(c.req.url).origin;

--- a/apps/api/src/routes/userProfile.test.ts
+++ b/apps/api/src/routes/userProfile.test.ts
@@ -24,7 +24,7 @@ const ajv = new Ajv2020();
 const validateGetSchema = ajv.compile(profileGetResponseV1.schema);
 
 const EXPECTED_CONTENT_TYPE =
-  'application/json; profile="http://localhost/schemas/profile/get-response-v1.json"';
+  'application/json; profile="http://localhost/profiles/json-schema/profile/get-response-v1.json"';
 
 const FAKE_PROFILE_TOKEN = {
   uid: FAKE_UID,

--- a/apps/api/src/schemas/characters/put-request-v1.ts
+++ b/apps/api/src/schemas/characters/put-request-v1.ts
@@ -4,7 +4,7 @@
 import type { JsonSchemaProfile } from '@/schemas/json-schema-profile.js';
 
 export const characterPutRequestV1 = {
-  path: '/schemas/characters/put-request-v1.json',
+  path: '/profiles/json-schema/characters/put-request-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Save Character Request',

--- a/apps/api/src/schemas/json-schema-profile.ts
+++ b/apps/api/src/schemas/json-schema-profile.ts
@@ -15,7 +15,7 @@
  * `SupportedRepresentation`.
  */
 export interface JsonSchemaProfile {
-  /** Absolute URL path where the schema is served (e.g. `/schemas/profile/get-response-v1.json`). */
+  /** Absolute URL path where the schema is served (e.g. `/profiles/json-schema/profile/get-response-v1.json`). */
   readonly path: string;
   // Intentionally `Record<string, unknown>` rather than AJV's `SchemaObject`
   // to keep this interface free of validation-library coupling. The

--- a/apps/api/src/schemas/profile/get-response-v1.ts
+++ b/apps/api/src/schemas/profile/get-response-v1.ts
@@ -4,7 +4,7 @@
 import type { JsonSchemaProfile } from '@/schemas/json-schema-profile.js';
 
 export const profileGetResponseV1 = {
-  path: '/schemas/profile/get-response-v1.json',
+  path: '/profiles/json-schema/profile/get-response-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Profile',

--- a/apps/api/src/schemas/profile/patch-request-v1.ts
+++ b/apps/api/src/schemas/profile/patch-request-v1.ts
@@ -4,7 +4,7 @@
 import type { JsonSchemaProfile } from '@/schemas/json-schema-profile.js';
 
 export const profilePatchRequestV1 = {
-  path: '/schemas/profile/patch-request-v1.json',
+  path: '/profiles/json-schema/profile/patch-request-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Patch Profile',

--- a/apps/api/src/schemas/root/get-response-v1.ts
+++ b/apps/api/src/schemas/root/get-response-v1.ts
@@ -4,7 +4,7 @@
 import type { JsonSchemaProfile } from '@/schemas/json-schema-profile.js';
 
 export const rootGetResponseV1 = {
-  path: '/schemas/root/get-response-v1.json',
+  path: '/profiles/json-schema/root/get-response-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'API Root',

--- a/apps/api/src/schemas/teams/put-request-v1.ts
+++ b/apps/api/src/schemas/teams/put-request-v1.ts
@@ -4,7 +4,7 @@
 import type { JsonSchemaProfile } from '@/schemas/json-schema-profile.js';
 
 export const teamPutRequestV1 = {
-  path: '/schemas/teams/put-request-v1.json',
+  path: '/profiles/json-schema/teams/put-request-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Update Team Request',

--- a/apps/api/src/schemas/weapons/patch-request-v1.ts
+++ b/apps/api/src/schemas/weapons/patch-request-v1.ts
@@ -4,7 +4,7 @@
 import type { JsonSchemaProfile } from '@/schemas/json-schema-profile.js';
 
 export const weaponPatchRequestV1 = {
-  path: '/schemas/weapons/patch-request-v1.json',
+  path: '/profiles/json-schema/weapons/patch-request-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Update Weapon Instance Request',

--- a/apps/api/src/schemas/weapons/post-request-v1.ts
+++ b/apps/api/src/schemas/weapons/post-request-v1.ts
@@ -4,7 +4,7 @@
 import type { JsonSchemaProfile } from '@/schemas/json-schema-profile.js';
 
 export const weaponPostRequestV1 = {
-  path: '/schemas/weapons/post-request-v1.json',
+  path: '/profiles/json-schema/weapons/post-request-v1.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Create Weapon Instance Request',

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -45,14 +45,14 @@ Clients request a specific representation version using the `profile` parameter 
 
 ```http
 GET /api/profile HTTP/1.1
-Accept: application/json; profile="https://api.genshin.dungeon.studio/schemas/profile/get/1.0.0.json"
+Accept: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/profile/get-response-v1.json"
 ```
 
 The API confirms the schema used in the response `Content-Type`:
 
 ```http
 HTTP/1.1 200 OK
-Content-Type: application/json; profile="https://api.genshin.dungeon.studio/schemas/profile/get/1.0.0.json"
+Content-Type: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/profile/get-response-v1.json"
 ```
 
 Negotiation rules:


### PR DESCRIPTION
### Summary

Consolidates the `/schemas/` and `/profiles/` URL prefixes into a single format-namespaced hierarchy under `/profiles/{format}/`, preventing future collisions as more profile formats are added.

### Changes

- **JSON Schema paths**: `/schemas/{module}/...` → `/profiles/json-schema/{module}/...`
- **ALPS profile paths**: `/profiles/{resource}/...` → `/profiles/alps/{resource}/...`
- **Route mounting**: two separate mounts (`/schemas`, `/profiles`) → two format-scoped mounts under `/profiles/json-schema` and `/profiles/alps`
- **Living docs updated**: `copilot-instructions.md` and `rest-api-conventions.md`
- **Immutable DSGEPs untouched**: DSGEP-003 and DSGEP-005 left as-is (accepted proposals)
- Source directory layout (`src/schemas/`, `src/profiles/alps/`) unchanged — the URL hierarchy is orthogonal to source organization

### Testing

- All 161 tests pass
- Typecheck clean

Closes #491