### PR TITLE
fix: include query string in filtered collection.href

### DIFF
--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -97,6 +97,10 @@ describe('Weapon routes', () => {
       );
     });
 
+    it('sets collection.href without query string', () => {
+      expect(body.collection.href).toBe('http://localhost/api/weapons');
+    });
+
     it('returns empty items when no weapons exist', async () => {
       vi.mocked(listWeapons).mockResolvedValue([]);
 
@@ -149,6 +153,12 @@ describe('Weapon routes', () => {
           expect.objectContaining({ name: 'weaponId', value: 'mistsplitter-reforged' }),
           expect.objectContaining({ name: 'refinementLevel', value: 1 }),
         ]),
+      );
+    });
+
+    it('sets collection.href with query string', () => {
+      expect(body.collection.href).toBe(
+        'http://localhost/api/weapons?weaponId=mistsplitter-reforged',
       );
     });
 

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -67,7 +67,7 @@ weapons.get('/', async (c) => {
       JSON.stringify(
         serialiseCollection(
           weaponRepresentation,
-          `${baseUrl}/api/weapons`,
+          `${baseUrl}/api/weapons?weaponId=${encodeURIComponent(weaponId)}`,
           instances.map((w) => serialiseWeapon(w, baseUrl)),
         ),
       ),


### PR DESCRIPTION
## Summary

When `GET /api/weapons` is filtered by `weaponId`, `collection.href` now includes the query parameter so clients can treat it as a stable self-link.

## Changes

- **`apps/api/src/routes/weapons.ts`**: Use `${baseUrl}/api/weapons?weaponId=${encodeURIComponent(weaponId)}` for `collection.href` in the filtered branch.
- **`apps/api/src/routes/weapons.test.ts`**: Add tests asserting `collection.href` for both filtered and unfiltered responses.

Closes #500