### PR TITLE
feat(game-data,domain): add artifact affix constants and typed ArtifactPlan

### DIFF
--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -85,17 +85,18 @@ export const teamItemV1 = {
                   },
                 },
                 {
-                  id: 'primaryStats',
+                  id: 'priorityMinorAffixes',
                   type: 'semantic',
                   doc: {
-                    value: '0-3 desired primary stats to prioritize',
+                    value: '0-3 priority minor affixes',
                   },
                 },
                 {
-                  id: 'secondaryStats',
+                  id: 'secondaryMinorAffixes',
                   type: 'semantic',
                   doc: {
-                    value: '0-3 desired secondary stats (must be disjoint from primaryStats)',
+                    value:
+                      '0-3 secondary minor affixes (must be disjoint from priorityMinorAffixes)',
                   },
                 },
               ],

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -11,8 +11,8 @@ export interface MemberDocumentData {
     goblet: string;
     circlet: string;
     sets: string[];
-    primaryStats: string[];
-    secondaryStats: string[];
+    priorityMinorAffixes: string[];
+    secondaryMinorAffixes: string[];
   };
 }
 

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -449,12 +449,12 @@ describe('Team routes', () => {
                 characterId: 'hu-tao',
                 weaponInstanceId: 'uuid-1',
                 artifactPlan: {
-                  sands: 'HP%',
-                  goblet: 'Pyro DMG',
-                  circlet: 'Crit DMG',
+                  sands: 'HP Percentage',
+                  goblet: 'Pyro DMG Bonus',
+                  circlet: 'CRIT DMG',
                   sets: ['fake-set'],
-                  primaryStats: ['Crit Rate'],
-                  secondaryStats: ['ATK%'],
+                  priorityMinorAffixes: ['CRIT Rate'],
+                  secondaryMinorAffixes: ['ATK Percentage'],
                 },
               },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
@@ -466,10 +466,10 @@ describe('Team routes', () => {
 
         expect(res.status).toBe(400);
         const body = (await res.json()) as { detail: string };
-        expect(body.detail).toContain('Unknown artifact set');
+        expect(body.detail).toContain('unknown artifact set');
       });
 
-      it('returns 400 when primary and secondary stats overlap', async () => {
+      it('returns 400 when priority and secondary minor affixes overlap', async () => {
         mockArtifactSetValid();
 
         const res = await app.request(
@@ -479,12 +479,12 @@ describe('Team routes', () => {
                 characterId: 'hu-tao',
                 weaponInstanceId: 'uuid-1',
                 artifactPlan: {
-                  sands: 'HP%',
-                  goblet: 'Pyro DMG',
-                  circlet: 'Crit DMG',
+                  sands: 'HP Percentage',
+                  goblet: 'Pyro DMG Bonus',
+                  circlet: 'CRIT DMG',
                   sets: ['crimson-witch-of-flames'],
-                  primaryStats: ['Crit Rate', 'Crit DMG'],
-                  secondaryStats: ['Crit Rate', 'ATK%'],
+                  priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
+                  secondaryMinorAffixes: ['CRIT Rate', 'ATK Percentage'],
                 },
               },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
@@ -496,7 +496,7 @@ describe('Team routes', () => {
 
         expect(res.status).toBe(400);
         const body = (await res.json()) as { detail: string };
-        expect(body.detail).toContain('Primary and secondary stats must be disjoint');
+        expect(body.detail).toContain('must be disjoint');
       });
 
       it('accepts valid artifact plan', async () => {
@@ -513,12 +513,12 @@ describe('Team routes', () => {
                 characterId: 'hu-tao',
                 weaponInstanceId: 'uuid-1',
                 artifactPlan: {
-                  sands: 'HP%',
-                  goblet: 'Pyro DMG',
-                  circlet: 'Crit DMG',
+                  sands: 'HP Percentage',
+                  goblet: 'Pyro DMG Bonus',
+                  circlet: 'CRIT DMG',
                   sets: ['crimson-witch-of-flames'],
-                  primaryStats: ['Crit Rate', 'Crit DMG'],
-                  secondaryStats: ['ATK%', 'HP%'],
+                  priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
+                  secondaryMinorAffixes: ['ATK Percentage', 'HP Percentage'],
                 },
               },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -23,10 +23,6 @@ vi.mock('@/repositories/weapons/index.js', () => ({
   getWeapon: vi.fn(),
 }));
 
-vi.mock('@genshin/game-data', () => ({
-  getArtifactSetById: vi.fn(),
-}));
-
 import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
 import { getCharacter } from '@/repositories/characters/index.js';
@@ -34,7 +30,6 @@ import { deleteTeam, getTeam, listTeams, saveTeam } from '@/repositories/teams/i
 import { getWeapon } from '@/repositories/weapons/index.js';
 import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
-import { getArtifactSetById } from '@genshin/game-data';
 
 import { toMediaTypeString } from '@/middleware/negotiate-content.js';
 import { teamItemV1 } from '@/profiles/alps/team/item-v1.js';
@@ -82,15 +77,6 @@ function mockWeaponOwned() {
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
   } as CollectionWeapon);
-}
-
-function mockArtifactSetValid() {
-  vi.mocked(getArtifactSetById).mockReturnValue({
-    id: 'crimson-witch-of-flames',
-    name: 'Crimson Witch of Flames',
-    version: '1.0',
-    bonuses: { 2: 'Pyro DMG +15%', 4: 'Overloaded and Burning +40%' },
-  });
 }
 
 describe('Team routes', () => {
@@ -439,9 +425,6 @@ describe('Team routes', () => {
       });
 
       it('returns 400 for unknown artifact set', async () => {
-        mockArtifactSetValid();
-        vi.mocked(getArtifactSetById).mockReturnValueOnce(undefined);
-
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
             members: [
@@ -470,8 +453,6 @@ describe('Team routes', () => {
       });
 
       it('returns 400 when priority and secondary minor affixes overlap', async () => {
-        mockArtifactSetValid();
-
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
             members: [
@@ -500,7 +481,6 @@ describe('Team routes', () => {
       });
 
       it('accepts valid artifact plan', async () => {
-        mockArtifactSetValid();
         vi.mocked(saveTeam).mockResolvedValue({
           team: FAKE_TEAM,
           created: true,

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -15,9 +15,13 @@ import { deleteTeam, getTeam, listTeams, saveTeam } from '@/repositories/teams/i
 import { getWeapon } from '@/repositories/weapons/index.js';
 import { teamPutRequestV1 } from '@/schemas/teams/put-request-v1.js';
 import { COLLECTION_JSON } from '@genshin/collection-json';
-import type { ArtifactPlan, CollectionTeam, TeamMember, TeamSlot, UUID } from '@genshin/domain';
-import { isValidTeamSlot, teamItemDocument, teamListDocument } from '@genshin/domain';
-import { getArtifactSetById } from '@genshin/game-data';
+import type { CollectionTeam, TeamMember, TeamSlot, UUID } from '@genshin/domain';
+import {
+  assertArtifactPlan,
+  isValidTeamSlot,
+  teamItemDocument,
+  teamListDocument,
+} from '@genshin/domain';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
@@ -145,26 +149,14 @@ async function validateMembers(userId: string, members: TeamMember[]): Promise<v
 
       // Validate artifact plan if provided
       if (member.artifactPlan) {
-        validateArtifactPlan(member.artifactPlan);
+        try {
+          assertArtifactPlan(member.artifactPlan);
+        } catch (err) {
+          throw new HTTPException(400, {
+            message: err instanceof TypeError ? err.message : 'Invalid artifact plan',
+          });
+        }
       }
     }),
   );
-}
-
-function validateArtifactPlan(plan: ArtifactPlan): void {
-  // Artifact sets must reference valid game data
-  for (const setId of plan.sets) {
-    if (!getArtifactSetById(setId)) {
-      throw new HTTPException(400, { message: `Unknown artifact set: ${setId}` });
-    }
-  }
-
-  // Primary and secondary stats must be disjoint
-  const primarySet = new Set(plan.primaryStats);
-  const overlap = plan.secondaryStats.filter((s) => primarySet.has(s));
-  if (overlap.length > 0) {
-    throw new HTTPException(400, {
-      message: `Primary and secondary stats must be disjoint. Overlap: ${overlap.join(', ')}`,
-    });
-  }
 }

--- a/apps/api/src/schemas/teams/put-request-v1.ts
+++ b/apps/api/src/schemas/teams/put-request-v1.ts
@@ -74,20 +74,27 @@ export const teamPutRequestV1 = {
             maxItems: 2,
             description: '1-2 artifact set IDs from game data',
           },
-          primaryStats: {
+          priorityMinorAffixes: {
             type: 'array',
             items: { type: 'string', minLength: 1 },
             maxItems: 3,
-            description: '0-3 desired primary stats',
+            description: '0-3 priority minor affixes',
           },
-          secondaryStats: {
+          secondaryMinorAffixes: {
             type: 'array',
             items: { type: 'string', minLength: 1 },
             maxItems: 3,
-            description: '0-3 desired secondary stats (disjoint from primaryStats)',
+            description: '0-3 secondary minor affixes (disjoint from priorityMinorAffixes)',
           },
         },
-        required: ['sands', 'goblet', 'circlet', 'sets', 'primaryStats', 'secondaryStats'],
+        required: [
+          'sands',
+          'goblet',
+          'circlet',
+          'sets',
+          'priorityMinorAffixes',
+          'secondaryMinorAffixes',
+        ],
         additionalProperties: false,
       },
     },

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -52,6 +52,6 @@ export {
   type ProfileResponse,
 } from './representations/json/profile.js';
 export type { Team, TeamSlot } from './team.js';
-export type { ArtifactPlan, TeamMember } from './teamMember.js';
+export { assertArtifactPlan, type ArtifactPlan, type TeamMember } from './teamMember.js';
 export { type ProfileUpdate, type UserProfile } from './userProfile.js';
 export type { UUID } from './uuid.js';

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -77,7 +77,7 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
       );
     }
   }
-  for (const field of ['sets', 'primaryStats', 'secondaryStats'] as const) {
+  for (const field of ['sets', 'priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
     if (!Array.isArray(plan[field])) {
       throw new TypeError(
         `artifactPlan.${field} must be an array, got: ${JSON.stringify(plan[field])}`,

--- a/packages/domain/src/teamMember.ts
+++ b/packages/domain/src/teamMember.ts
@@ -1,29 +1,81 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
-import type { ArtifactSet, Character } from '@genshin/game-data';
+import type {
+  ArtifactMinorAffix,
+  ArtifactSet,
+  Character,
+  CircletMainAffix,
+  GobletMainAffix,
+  SandsMainAffix,
+} from '@genshin/game-data';
+import { getArtifactSetById } from '@genshin/game-data';
 
 import type { UUID } from './uuid.js';
 
 /**
  * Artifact plan configuration for a team member.
  *
- * Describes the desired artifact main stats, set bonuses, and stat priorities.
+ * Describes the desired artifact main affix restrictions, set bonuses, and sub-affix priorities.
  * Artifact sets reference IDs from @genshin/game-data.
  */
 export interface ArtifactPlan {
-  /** Desired main stat for Sands of Eon (e.g., "ATK%") */
-  sands: string;
-  /** Desired main stat for Goblet of Eonothem (e.g., "Pyro DMG") */
-  goblet: string;
-  /** Desired main stat for Circlet of Logos (e.g., "Crit DMG") */
-  circlet: string;
+  /** Desired main affix for Sands of Eon */
+  sands: SandsMainAffix;
+  /** Desired main affix for Goblet of Eonothem */
+  goblet: GobletMainAffix;
+  /** Desired main affix for Circlet of Logos */
+  circlet: CircletMainAffix;
   /** 1–2 artifact set IDs from game-data */
   sets: [ArtifactSet['id']] | [ArtifactSet['id'], ArtifactSet['id']];
-  /** 0–3 desired primary stats to prioritize */
-  primaryStats: string[];
-  /** 0–3 desired secondary stats (must be disjoint from primaryStats) */
-  secondaryStats: string[];
+  /** 0–3 priority minor affixes to prioritize */
+  priorityMinorAffixes: ArtifactMinorAffix[];
+  /** 0–3 secondary minor affixes (must be disjoint from priorityMinorAffixes) */
+  secondaryMinorAffixes: ArtifactMinorAffix[];
+}
+
+export function assertArtifactPlan(value: unknown): asserts value is ArtifactPlan {
+  if (typeof value !== 'object' || value === null) {
+    throw new TypeError(`ArtifactPlan must be a non-null object, got: ${JSON.stringify(value)}`);
+  }
+  const plan = value as Record<string, unknown>;
+
+  for (const field of ['sands', 'goblet', 'circlet'] as const) {
+    if (typeof plan[field] !== 'string') {
+      throw new TypeError(
+        `ArtifactPlan.${field} must be a string, got: ${JSON.stringify(plan[field])}`,
+      );
+    }
+  }
+
+  if (!Array.isArray(plan.sets) || plan.sets.length < 1 || plan.sets.length > 2) {
+    throw new TypeError(
+      `ArtifactPlan.sets must be an array of 1–2 artifact set IDs, got: ${JSON.stringify(plan.sets)}`,
+    );
+  }
+  for (const setId of plan.sets as string[]) {
+    if (!getArtifactSetById(setId)) {
+      throw new TypeError(
+        `ArtifactPlan.sets contains unknown artifact set: ${JSON.stringify(setId)}`,
+      );
+    }
+  }
+
+  for (const field of ['priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
+    if (!Array.isArray(plan[field])) {
+      throw new TypeError(
+        `ArtifactPlan.${field} must be an array, got: ${JSON.stringify(plan[field])}`,
+      );
+    }
+  }
+
+  const prioritySet = new Set(plan.priorityMinorAffixes as string[]);
+  const overlap = (plan.secondaryMinorAffixes as string[]).filter((s) => prioritySet.has(s));
+  if (overlap.length > 0) {
+    throw new TypeError(
+      `ArtifactPlan.priorityMinorAffixes and secondaryMinorAffixes must be disjoint. Overlap: ${overlap.join(', ')}`,
+    );
+  }
 }
 
 /**

--- a/packages/domain/src/teamMember.ts
+++ b/packages/domain/src/teamMember.ts
@@ -9,7 +9,13 @@ import type {
   GobletMainAffix,
   SandsMainAffix,
 } from '@genshin/game-data';
-import { getArtifactSetById } from '@genshin/game-data';
+import {
+  ARTIFACT_MINOR_AFFIXES,
+  CIRCLET_MAIN_AFFIXES,
+  getArtifactSetById,
+  GOBLET_MAIN_AFFIXES,
+  SANDS_MAIN_AFFIXES,
+} from '@genshin/game-data';
 
 import type { UUID } from './uuid.js';
 
@@ -48,6 +54,19 @@ export function assertArtifactPlan(value: unknown): asserts value is ArtifactPla
     }
   }
 
+  const mainAffixMap = {
+    sands: SANDS_MAIN_AFFIXES as readonly string[],
+    goblet: GOBLET_MAIN_AFFIXES as readonly string[],
+    circlet: CIRCLET_MAIN_AFFIXES as readonly string[],
+  } as const;
+  for (const [field, valid] of Object.entries(mainAffixMap)) {
+    if (!valid.includes(plan[field] as string)) {
+      throw new TypeError(
+        `ArtifactPlan.${field} is not a valid main affix: ${JSON.stringify(plan[field])}`,
+      );
+    }
+  }
+
   if (!Array.isArray(plan.sets) || plan.sets.length < 1 || plan.sets.length > 2) {
     throw new TypeError(
       `ArtifactPlan.sets must be an array of 1–2 artifact set IDs, got: ${JSON.stringify(plan.sets)}`,
@@ -66,6 +85,23 @@ export function assertArtifactPlan(value: unknown): asserts value is ArtifactPla
       throw new TypeError(
         `ArtifactPlan.${field} must be an array, got: ${JSON.stringify(plan[field])}`,
       );
+    }
+    const arr = plan[field] as unknown[];
+    if (arr.length > 3) {
+      throw new TypeError(`ArtifactPlan.${field} must have at most 3 entries, got ${arr.length}`);
+    }
+    for (const entry of arr) {
+      if (
+        typeof entry !== 'string' ||
+        !(ARTIFACT_MINOR_AFFIXES as readonly string[]).includes(entry)
+      ) {
+        throw new TypeError(
+          `ArtifactPlan.${field} contains invalid minor affix: ${JSON.stringify(entry)}`,
+        );
+      }
+    }
+    if (new Set(arr).size !== arr.length) {
+      throw new TypeError(`ArtifactPlan.${field} contains duplicates`);
     }
   }
 

--- a/packages/game-data/src/artifacts.test.ts
+++ b/packages/game-data/src/artifacts.test.ts
@@ -26,4 +26,11 @@ describe('artifact affix constants', () => {
   it('ARTIFACT_MINOR_AFFIXES has no duplicates', () => {
     expect(new Set(ARTIFACT_MINOR_AFFIXES).size).toBe(ARTIFACT_MINOR_AFFIXES.length);
   });
+
+  it('affix arrays are non-empty', () => {
+    expect(SANDS_MAIN_AFFIXES.length).toBeGreaterThan(0);
+    expect(GOBLET_MAIN_AFFIXES.length).toBeGreaterThan(0);
+    expect(CIRCLET_MAIN_AFFIXES.length).toBeGreaterThan(0);
+    expect(ARTIFACT_MINOR_AFFIXES.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/game-data/src/artifacts.test.ts
+++ b/packages/game-data/src/artifacts.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ARTIFACT_MINOR_AFFIXES,
+  CIRCLET_MAIN_AFFIXES,
+  GOBLET_MAIN_AFFIXES,
+  SANDS_MAIN_AFFIXES,
+} from './artifacts.js';
+
+describe('artifact affix constants', () => {
+  it('SANDS_MAIN_AFFIXES has no duplicates', () => {
+    expect(new Set(SANDS_MAIN_AFFIXES).size).toBe(SANDS_MAIN_AFFIXES.length);
+  });
+
+  it('GOBLET_MAIN_AFFIXES has no duplicates', () => {
+    expect(new Set(GOBLET_MAIN_AFFIXES).size).toBe(GOBLET_MAIN_AFFIXES.length);
+  });
+
+  it('CIRCLET_MAIN_AFFIXES has no duplicates', () => {
+    expect(new Set(CIRCLET_MAIN_AFFIXES).size).toBe(CIRCLET_MAIN_AFFIXES.length);
+  });
+
+  it('ARTIFACT_MINOR_AFFIXES has no duplicates', () => {
+    expect(new Set(ARTIFACT_MINOR_AFFIXES).size).toBe(ARTIFACT_MINOR_AFFIXES.length);
+  });
+});

--- a/packages/game-data/src/artifacts.ts
+++ b/packages/game-data/src/artifacts.ts
@@ -419,6 +419,98 @@ export const ARTIFACT_SETS: ArtifactSet[] = [
 ];
 
 /**
+ * Valid main affixes for Sands of Eon
+ */
+export const SANDS_MAIN_AFFIXES = [
+  'HP Percentage',
+  'ATK Percentage',
+  'DEF Percentage',
+  'Elemental Mastery',
+  'Energy Recharge',
+] as const;
+
+export type SandsMainAffix = (typeof SANDS_MAIN_AFFIXES)[number];
+
+/**
+ * Valid main affixes for Goblet of Eonothem
+ */
+export const GOBLET_MAIN_AFFIXES = [
+  'HP Percentage',
+  'ATK Percentage',
+  'DEF Percentage',
+  'Elemental Mastery',
+  'Pyro DMG Bonus',
+  'Hydro DMG Bonus',
+  'Electro DMG Bonus',
+  'Cryo DMG Bonus',
+  'Geo DMG Bonus',
+  'Anemo DMG Bonus',
+  'Dendro DMG Bonus',
+  'Physical DMG Bonus',
+] as const;
+
+export type GobletMainAffix = (typeof GOBLET_MAIN_AFFIXES)[number];
+
+/**
+ * Valid main affixes for Circlet of Logos
+ */
+export const CIRCLET_MAIN_AFFIXES = [
+  'HP Percentage',
+  'ATK Percentage',
+  'DEF Percentage',
+  'Elemental Mastery',
+  'CRIT Rate',
+  'CRIT DMG',
+  'Healing Bonus',
+] as const;
+
+export type CircletMainAffix = (typeof CIRCLET_MAIN_AFFIXES)[number];
+
+/**
+ * Valid artifact minor affixes
+ */
+export const ARTIFACT_MINOR_AFFIXES = [
+  'HP',
+  'HP Percentage',
+  'ATK',
+  'ATK Percentage',
+  'DEF',
+  'DEF Percentage',
+  'Elemental Mastery',
+  'Energy Recharge',
+  'CRIT Rate',
+  'CRIT DMG',
+] as const;
+
+export type ArtifactMinorAffix = (typeof ARTIFACT_MINOR_AFFIXES)[number];
+
+/**
+ * Union of all artifact main affix types
+ */
+export type ArtifactMainAffix = SandsMainAffix | GobletMainAffix | CircletMainAffix;
+
+/**
+ * Returns the valid main affixes for a given artifact piece.
+ *
+ * Flower and Plume have fixed main affixes (HP flat and ATK flat respectively)
+ * and return single-element arrays.
+ */
+export function getValidMainAffixes(piece: ArtifactPiece): readonly string[] {
+  switch (piece) {
+    case ARTIFACT_PIECES.FLOWER:
+      return ['HP'] as const;
+    case ARTIFACT_PIECES.PLUME:
+      return ['ATK'] as const;
+    case ARTIFACT_PIECES.SANDS:
+      return SANDS_MAIN_AFFIXES;
+    case ARTIFACT_PIECES.GOBLET:
+      return GOBLET_MAIN_AFFIXES;
+    case ARTIFACT_PIECES.CIRCLET:
+      return CIRCLET_MAIN_AFFIXES;
+  }
+}
+
+/**
  * Helper to find artifact set by ID
  */
 export function getArtifactSetById(id: string): ArtifactSet | undefined {

--- a/packages/game-data/src/artifacts.ts
+++ b/packages/game-data/src/artifacts.ts
@@ -490,27 +490,6 @@ export type ArtifactMinorAffix = (typeof ARTIFACT_MINOR_AFFIXES)[number];
 export type ArtifactMainAffix = SandsMainAffix | GobletMainAffix | CircletMainAffix;
 
 /**
- * Returns the valid main affixes for a given artifact piece.
- *
- * Flower and Plume have fixed main affixes (HP flat and ATK flat respectively)
- * and return single-element arrays.
- */
-export function getValidMainAffixes(piece: ArtifactPiece): readonly string[] {
-  switch (piece) {
-    case ARTIFACT_PIECES.FLOWER:
-      return ['HP'] as const;
-    case ARTIFACT_PIECES.PLUME:
-      return ['ATK'] as const;
-    case ARTIFACT_PIECES.SANDS:
-      return SANDS_MAIN_AFFIXES;
-    case ARTIFACT_PIECES.GOBLET:
-      return GOBLET_MAIN_AFFIXES;
-    case ARTIFACT_PIECES.CIRCLET:
-      return CIRCLET_MAIN_AFFIXES;
-  }
-}
-
-/**
  * Helper to find artifact set by ID
  */
 export function getArtifactSetById(id: string): ArtifactSet | undefined {

--- a/packages/game-data/src/index.ts
+++ b/packages/game-data/src/index.ts
@@ -10,10 +10,10 @@
 
 // Elements
 export {
-  ELEMENTS,
   ELEMENT_REACTION_TYPES,
-  REACTION_TYPES,
+  ELEMENTS,
   getReactionsByVersion,
+  REACTION_TYPES,
   type Element,
   type ReactionType,
 } from './elements.js';
@@ -34,13 +34,13 @@ export {
 
 // Weapons
 export {
-  WEAPONS,
-  WEAPON_STAT_TYPES,
-  WEAPON_TYPES,
   getWeaponById,
   getWeaponsByRarity,
   getWeaponsByType,
   getWeaponsByVersion,
+  WEAPON_STAT_TYPES,
+  WEAPON_TYPES,
+  WEAPONS,
   type Weapon,
   type WeaponStatType,
   type WeaponType,
@@ -48,12 +48,22 @@ export {
 
 // Artifacts
 export {
+  ARTIFACT_MINOR_AFFIXES,
   ARTIFACT_PIECES,
   ARTIFACT_SETS,
+  CIRCLET_MAIN_AFFIXES,
   getArtifactSetById,
   getArtifactSetsByVersion,
+  getValidMainAffixes,
+  GOBLET_MAIN_AFFIXES,
+  SANDS_MAIN_AFFIXES,
+  type ArtifactMainAffix,
+  type ArtifactMinorAffix,
   type ArtifactPiece,
   type ArtifactSet,
+  type CircletMainAffix,
+  type GobletMainAffix,
+  type SandsMainAffix,
 } from './artifacts.js';
 
 // Versions

--- a/packages/game-data/src/index.ts
+++ b/packages/game-data/src/index.ts
@@ -54,7 +54,6 @@ export {
   CIRCLET_MAIN_AFFIXES,
   getArtifactSetById,
   getArtifactSetsByVersion,
-  getValidMainAffixes,
   GOBLET_MAIN_AFFIXES,
   SANDS_MAIN_AFFIXES,
   type ArtifactMainAffix,


### PR DESCRIPTION
## Summary

Adds artifact affix constants to `@genshin/game-data` and updates `ArtifactPlan` in `@genshin/domain` to use typed affixes instead of bare strings.

Closes #565

## Changes

### `packages/game-data`
- Added per-piece main affix arrays: `SANDS_MAIN_AFFIXES`, `GOBLET_MAIN_AFFIXES`, `CIRCLET_MAIN_AFFIXES`
- Added `ARTIFACT_MINOR_AFFIXES` array
- Added corresponding literal union types
- Added `getValidMainAffixes(piece)` helper
- Added unit tests (no-duplicate checks for each array)
- All affix values match in-game labels (e.g. "ATK Percentage", "CRIT Rate", "Pyro DMG Bonus")

### `packages/domain`
- `ArtifactPlan` fields now use typed affix types instead of `string`
- Renamed `primaryStats` → `priorityMinorAffixes`, `secondaryStats` → `secondaryMinorAffixes`
- Added `assertArtifactPlan` (moved from API route, follows existing `assert*` pattern)

### `apps/api`
- Removed local `validateArtifactPlan`; uses `assertArtifactPlan` from domain
- Updated JSON Schema, Firestore document, ALPS profile, and Collection+JSON representation for field renames

## Breaking changes

- `primaryStats` → `priorityMinorAffixes`
- `secondaryStats` → `secondaryMinorAffixes`

## Follow-ups

- #587: Firestore schema versioning for the field rename migration