### PR TITLE
feat: add team composition validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,23 @@ jobs:
           flag: collection-json
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Build
+        run: pnpm turbo run build --filter=@genshin/validation
+
+      - name: Typecheck
+        run: pnpm turbo run typecheck --filter=@genshin/validation
+
 # ---------------------------------------------------------------------------
 # Maintenance notes
 # - Add a new job when new apps or packages are added.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,6 +26,7 @@ COPY apps/api/package.json ./apps/api/
 COPY packages/collection-json/package.json ./packages/collection-json/
 COPY packages/domain/package.json ./packages/domain/
 COPY packages/game-data/package.json ./packages/game-data/
+COPY packages/validation/package.json ./packages/validation/
 
 RUN pnpm install --frozen-lockfile
 
@@ -51,6 +52,7 @@ COPY --from=builder /app/apps/api/dist ./apps/api/dist
 COPY --from=builder /app/packages/collection-json ./packages/collection-json
 COPY --from=builder /app/packages/domain ./packages/domain
 COPY --from=builder /app/packages/game-data ./packages/game-data
+COPY --from=builder /app/packages/validation ./packages/validation
 
 EXPOSE 8080
 

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -449,7 +449,7 @@ describe('Team routes', () => {
 
         expect(res.status).toBe(400);
         const body = (await res.json()) as { detail: string };
-        expect(body.detail).toContain('unknown artifact set');
+        expect(body.detail).toContain('Unknown artifact set');
       });
 
       it('returns 400 when priority and secondary minor affixes overlap', async () => {

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -17,10 +17,10 @@ import { teamPutRequestV1 } from '@/schemas/teams/put-request-v1.js';
 import { COLLECTION_JSON } from '@genshin/collection-json';
 import type { CollectionTeam, TeamMember, TeamSlot, UUID } from '@genshin/domain';
 import {
-  assertArtifactPlan,
   isValidTeamSlot,
   teamItemDocument,
   teamListDocument,
+  validateArtifactPlan,
 } from '@genshin/domain';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -149,12 +149,9 @@ async function validateMembers(userId: string, members: TeamMember[]): Promise<v
 
       // Validate artifact plan if provided
       if (member.artifactPlan) {
-        try {
-          assertArtifactPlan(member.artifactPlan);
-        } catch (err) {
-          throw new HTTPException(400, {
-            message: err instanceof TypeError ? err.message : 'Invalid artifact plan',
-          });
+        const issues = validateArtifactPlan(member.artifactPlan);
+        if (issues.length > 0) {
+          throw new HTTPException(400, { message: issues[0].message });
         }
       }
     }),

--- a/packages/domain/src/artifactPlanValidation.ts
+++ b/packages/domain/src/artifactPlanValidation.ts
@@ -19,6 +19,11 @@ import {
 import type { ValidationIssue } from '@genshin/validation';
 import { issue } from '@genshin/validation';
 
+// Intentionally uses loose string types instead of ArtifactPlan's branded types
+// (SandsMainAffix, etc.). The validator's job is to check raw input *before* it
+// becomes a domain object. Accepting ArtifactPlan would make the call circular.
+// Once #590 lands, JSON Schema enum constraints handle this at the boundary and
+// this function shrinks to just the disjointness check.
 export function validateArtifactPlan(plan: {
   sands: string;
   goblet: string;
@@ -79,6 +84,7 @@ export function validateArtifactPlan(plan: {
     issues.push(
       issue(
         `Priority and secondary minor affixes must be disjoint. Overlap: ${overlap.join(', ')}`,
+        'secondaryMinorAffixes',
       ),
     );
   }

--- a/packages/domain/src/artifactPlanValidation.ts
+++ b/packages/domain/src/artifactPlanValidation.ts
@@ -1,0 +1,87 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+/**
+ * Artifact plan validators.
+ *
+ * Returns {@link ValidationIssue}[] instead of throwing, so callers
+ * can display all issues at once (inline messages).
+ */
+
+import {
+  ARTIFACT_MINOR_AFFIXES,
+  CIRCLET_MAIN_AFFIXES,
+  getArtifactSetById,
+  GOBLET_MAIN_AFFIXES,
+  SANDS_MAIN_AFFIXES,
+} from '@genshin/game-data';
+
+import type { ValidationIssue } from '@genshin/validation';
+import { issue } from '@genshin/validation';
+
+export function validateArtifactPlan(plan: {
+  sands: string;
+  goblet: string;
+  circlet: string;
+  sets: string[];
+  priorityMinorAffixes: string[];
+  secondaryMinorAffixes: string[];
+}): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  // Main affixes -------------------------------------------------------
+  if (!(SANDS_MAIN_AFFIXES as readonly string[]).includes(plan.sands)) {
+    issues.push(issue(`Invalid sands main affix: ${plan.sands}`, 'sands'));
+  }
+
+  if (!(GOBLET_MAIN_AFFIXES as readonly string[]).includes(plan.goblet)) {
+    issues.push(issue(`Invalid goblet main affix: ${plan.goblet}`, 'goblet'));
+  }
+
+  if (!(CIRCLET_MAIN_AFFIXES as readonly string[]).includes(plan.circlet)) {
+    issues.push(issue(`Invalid circlet main affix: ${plan.circlet}`, 'circlet'));
+  }
+
+  // Sets ---------------------------------------------------------------
+  if (plan.sets.length < 1 || plan.sets.length > 2) {
+    issues.push(issue('Artifact plan must have 1-2 sets', 'sets'));
+  } else {
+    for (const [i, setId] of plan.sets.entries()) {
+      if (!getArtifactSetById(setId)) {
+        issues.push(issue(`Unknown artifact set: ${setId}`, `sets[${i}]`));
+      }
+    }
+  }
+
+  // Minor affixes ------------------------------------------------------
+  for (const field of ['priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
+    const arr = plan[field];
+
+    if (arr.length > 3) {
+      issues.push(issue(`${field} must have at most 3 entries`, field));
+    }
+
+    for (const [i, affix] of arr.entries()) {
+      if (!(ARTIFACT_MINOR_AFFIXES as readonly string[]).includes(affix)) {
+        issues.push(issue(`Invalid minor affix: ${affix}`, `${field}[${i}]`));
+      }
+    }
+
+    if (new Set(arr).size !== arr.length) {
+      issues.push(issue(`${field} contains duplicates`, field));
+    }
+  }
+
+  // Disjointness -------------------------------------------------------
+  const prioritySet = new Set(plan.priorityMinorAffixes);
+  const overlap = plan.secondaryMinorAffixes.filter((s) => prioritySet.has(s));
+  if (overlap.length > 0) {
+    issues.push(
+      issue(
+        `Priority and secondary minor affixes must be disjoint. Overlap: ${overlap.join(', ')}`,
+      ),
+    );
+  }
+
+  return issues;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+export { issue, isValid, prefixPaths, type ValidationIssue } from '@genshin/validation';
+export { validateArtifactPlan } from './artifactPlanValidation.js';
 export type { AuthIdentity } from './authIdentity.js';
 export {
   assertCollectionCharacter,
@@ -52,6 +54,7 @@ export {
   type ProfileResponse,
 } from './representations/json/profile.js';
 export type { Team, TeamSlot } from './team.js';
-export { assertArtifactPlan, type ArtifactPlan, type TeamMember } from './teamMember.js';
+export { type ArtifactPlan, type TeamMember } from './teamMember.js';
+export { validateTeam, validateTeamSlot, type TeamValidationContext } from './teamValidation.js';
 export { type ProfileUpdate, type UserProfile } from './userProfile.js';
 export type { UUID } from './uuid.js';

--- a/packages/domain/src/teamMember.ts
+++ b/packages/domain/src/teamMember.ts
@@ -9,13 +9,6 @@ import type {
   GobletMainAffix,
   SandsMainAffix,
 } from '@genshin/game-data';
-import {
-  ARTIFACT_MINOR_AFFIXES,
-  CIRCLET_MAIN_AFFIXES,
-  getArtifactSetById,
-  GOBLET_MAIN_AFFIXES,
-  SANDS_MAIN_AFFIXES,
-} from '@genshin/game-data';
 
 import type { UUID } from './uuid.js';
 
@@ -38,80 +31,6 @@ export interface ArtifactPlan {
   priorityMinorAffixes: ArtifactMinorAffix[];
   /** 0–3 secondary minor affixes (must be disjoint from priorityMinorAffixes) */
   secondaryMinorAffixes: ArtifactMinorAffix[];
-}
-
-export function assertArtifactPlan(value: unknown): asserts value is ArtifactPlan {
-  if (typeof value !== 'object' || value === null) {
-    throw new TypeError(`ArtifactPlan must be a non-null object, got: ${JSON.stringify(value)}`);
-  }
-  const plan = value as Record<string, unknown>;
-
-  for (const field of ['sands', 'goblet', 'circlet'] as const) {
-    if (typeof plan[field] !== 'string') {
-      throw new TypeError(
-        `ArtifactPlan.${field} must be a string, got: ${JSON.stringify(plan[field])}`,
-      );
-    }
-  }
-
-  const mainAffixMap = {
-    sands: SANDS_MAIN_AFFIXES as readonly string[],
-    goblet: GOBLET_MAIN_AFFIXES as readonly string[],
-    circlet: CIRCLET_MAIN_AFFIXES as readonly string[],
-  } as const;
-  for (const [field, valid] of Object.entries(mainAffixMap)) {
-    if (!valid.includes(plan[field] as string)) {
-      throw new TypeError(
-        `ArtifactPlan.${field} is not a valid main affix: ${JSON.stringify(plan[field])}`,
-      );
-    }
-  }
-
-  if (!Array.isArray(plan.sets) || plan.sets.length < 1 || plan.sets.length > 2) {
-    throw new TypeError(
-      `ArtifactPlan.sets must be an array of 1–2 artifact set IDs, got: ${JSON.stringify(plan.sets)}`,
-    );
-  }
-  for (const setId of plan.sets as string[]) {
-    if (!getArtifactSetById(setId)) {
-      throw new TypeError(
-        `ArtifactPlan.sets contains unknown artifact set: ${JSON.stringify(setId)}`,
-      );
-    }
-  }
-
-  for (const field of ['priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
-    if (!Array.isArray(plan[field])) {
-      throw new TypeError(
-        `ArtifactPlan.${field} must be an array, got: ${JSON.stringify(plan[field])}`,
-      );
-    }
-    const arr = plan[field] as unknown[];
-    if (arr.length > 3) {
-      throw new TypeError(`ArtifactPlan.${field} must have at most 3 entries, got ${arr.length}`);
-    }
-    for (const entry of arr) {
-      if (
-        typeof entry !== 'string' ||
-        !(ARTIFACT_MINOR_AFFIXES as readonly string[]).includes(entry)
-      ) {
-        throw new TypeError(
-          `ArtifactPlan.${field} contains invalid minor affix: ${JSON.stringify(entry)}`,
-        );
-      }
-    }
-    if (new Set(arr).size !== arr.length) {
-      throw new TypeError(`ArtifactPlan.${field} contains duplicates`);
-    }
-  }
-
-  const prioritySet = new Set(plan.priorityMinorAffixes as string[]);
-  const overlap = (plan.secondaryMinorAffixes as string[]).filter((s) => prioritySet.has(s));
-  if (overlap.length > 0) {
-    throw new TypeError(
-      `ArtifactPlan.priorityMinorAffixes and secondaryMinorAffixes must be disjoint. Overlap: ${overlap.join(', ')}`,
-    );
-  }
 }
 
 /**

--- a/packages/domain/src/teamValidation.ts
+++ b/packages/domain/src/teamValidation.ts
@@ -1,0 +1,106 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+/**
+ * Team composition validators for issue #52.
+ *
+ * These return {@link ValidationIssue}[] instead of throwing, so callers
+ * can display all issues at once (inline messages).
+ *
+ * Pure functions — no I/O. Ownership checks require a
+ * {@link TeamValidationContext} built by the caller from either the
+ * local zustand store (web) or Firestore queries (API).
+ */
+
+import type { ValidationIssue } from '@genshin/validation';
+import { issue, prefixPaths } from '@genshin/validation';
+import { validateArtifactPlan } from './artifactPlanValidation.js';
+import type { TeamMember } from './teamMember.js';
+
+/**
+ * Caller-supplied ownership data for collection-aware validation.
+ *
+ * On the web, populate from zustand / TanStack Query state.
+ * On the API, populate from Firestore lookups before calling validators.
+ */
+export interface TeamValidationContext {
+  /** Character IDs the user owns. */
+  ownedCharacterIds: ReadonlySet<string>;
+  /** Weapon instance IDs the user owns. */
+  ownedWeaponInstanceIds: ReadonlySet<string>;
+}
+
+// ---------------------------------------------------------------------------
+// validateTeamSlot
+// ---------------------------------------------------------------------------
+
+export function validateTeamSlot(slot: unknown): ValidationIssue[] {
+  if (typeof slot !== 'number' || !Number.isInteger(slot) || slot < 1 || slot > 4) {
+    return [issue('Team slot must be an integer between 1 and 4', 'slot')];
+  }
+
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// validateTeam
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a team composition against game rules and optional ownership data.
+ *
+ * When `context` is omitted, ownership checks are skipped (useful for
+ * offline / anonymous validation on the web).
+ */
+export function validateTeam(
+  team: { name: string; members: TeamMember[]; description?: string },
+  context?: TeamValidationContext,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  // Member count: 0-4 allowed (incomplete teams filled in later) -------
+  if (team.members.length > 4) {
+    issues.push(issue(`Team must have at most 4 members, got ${team.members.length}`, 'members'));
+  }
+
+  // Per-team uniqueness: no duplicate character IDs --------------------
+  const seen = new Set<string>();
+  for (const [i, member] of team.members.entries()) {
+    if (seen.has(member.characterId)) {
+      issues.push(
+        issue(`Duplicate character ID: ${member.characterId}`, `members[${i}].characterId`),
+      );
+    }
+    seen.add(member.characterId);
+  }
+
+  // Ownership checks (when collection context is available) ------------
+  if (context) {
+    for (const [i, member] of team.members.entries()) {
+      if (!context.ownedCharacterIds.has(member.characterId)) {
+        issues.push(
+          issue(`Character not in collection: ${member.characterId}`, `members[${i}].characterId`),
+        );
+      }
+      if (member.weaponInstanceId && !context.ownedWeaponInstanceIds.has(member.weaponInstanceId)) {
+        issues.push(
+          issue(
+            `Weapon instance not in collection: ${member.weaponInstanceId}`,
+            `members[${i}].weaponInstanceId`,
+          ),
+        );
+      }
+    }
+  }
+
+  // Per-member artifact plan validation --------------------------------
+  for (const [i, member] of team.members.entries()) {
+    if (member.artifactPlan) {
+      issues.push(
+        ...prefixPaths(validateArtifactPlan(member.artifactPlan), `members[${i}].artifactPlan`),
+      );
+    }
+  }
+
+  return issues;
+}

--- a/packages/validation/eslint.config.js
+++ b/packages/validation/eslint.config.js
@@ -1,0 +1,11 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { ignores: ['dist', 'node_modules'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+];

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@genshin/domain",
+  "name": "@genshin/validation",
   "version": "0.0.0",
-  "description": "Shared domain model for Genshin Dungeon Studio",
+  "description": "Reusable validation algebra — accumulating issues with a Valid/Invalid sum type",
   "private": true,
   "type": "module",
   "exports": {
@@ -19,11 +19,6 @@
     "typecheck": "tsc --noEmit",
     "build": "tsc",
     "lint": "eslint ."
-  },
-  "dependencies": {
-    "@genshin/collection-json": "workspace:*",
-    "@genshin/game-data": "workspace:*",
-    "@genshin/validation": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@genshin/validation",
   "version": "0.0.0",
-  "description": "Reusable validation algebra — accumulating issues with a Valid/Invalid sum type",
+  "description": "Reusable validation helpers for accumulating ValidationIssue[] results",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -1,0 +1,24 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+export interface ValidationIssue {
+  message: string;
+  /** Dot-path to the offending field, e.g. `members[0].characterId`. */
+  path?: string;
+}
+
+export function issue(message: string, path?: string): ValidationIssue {
+  return { message, path };
+}
+
+export function isValid(issues: readonly ValidationIssue[]): boolean {
+  return issues.length === 0;
+}
+
+/** Prefix all issue paths with a dot-separated prefix. */
+export function prefixPaths(issues: readonly ValidationIssue[], prefix: string): ValidationIssue[] {
+  return issues.map((i) => ({
+    ...i,
+    path: i.path ? `${prefix}.${i.path}` : prefix,
+  }));
+}

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -17,6 +17,8 @@ export function isValid(issues: readonly ValidationIssue[]): boolean {
 
 /** Prefix all issue paths with a dot-separated prefix. */
 export function prefixPaths(issues: readonly ValidationIssue[], prefix: string): ValidationIssue[] {
+  if (prefix === '') return issues.map((i) => ({ ...i }));
+
   return issues.map((i) => ({
     ...i,
     path: i.path ? `${prefix}.${i.path}` : prefix,

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       '@genshin/game-data':
         specifier: workspace:*
         version: link:../game-data
+      '@genshin/validation':
+        specifier: workspace:*
+        version: link:../validation
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -290,6 +293,21 @@ importers:
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+
+  packages/validation:
+    devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.1.0(jiti@2.6.1))
+      eslint:
+        specifier: 10.1.0
+        version: 10.1.0(jiti@2.6.1)
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
+      typescript-eslint:
+        specifier: 8.58.0
+        version: 8.58.0(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
 
 packages:
 


### PR DESCRIPTION
## Summary

Adds team composition validation for issue #52.

### New package: `@genshin/validation`

Minimal utility package (`ValidationIssue`, `issue()`, `isValid()`, `prefixPaths()`) operating on plain arrays. No test infrastructure yet — matches the `@genshin/domain` pattern (build + typecheck + lint only).

### Domain validators

- **`validateTeam()`** — 0–4 members, no duplicate characters, optional ownership checks, delegates artifact plan validation with path prefixing.
- **`validateArtifactPlan()`** — main affixes, sets, minor affixes, uniqueness, disjointness. Single source of truth — `assertArtifactPlan()` removed.
- **`validateTeamSlot()`** — integer 1–4.

All return `ValidationIssue[]` for inline form error display on the web (future) and direct use in API routes (now).

### API changes

- Route handler calls `validateArtifactPlan()` directly instead of `assertArtifactPlan()` wrapped in try/catch.
- Test assertion updated for consistent message casing.

### CI

- Added `validation` job (build + typecheck) to `ci.yml`.

Closes #52