### PR TITLE
refactor(web): extract Header, Nav, Footer from Layout

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border bg-muted py-8">
+      <div className="mx-auto max-w-7xl px-4 text-center text-sm text-muted-foreground">
+        <p>Built with React 19 + TypeScript + Vite</p>
+        <p className="mt-2 text-xs text-muted-foreground/70">© 2026 Genshin Team Builder</p>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { Link } from 'react-router-dom';
+
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { LoginButton, LogoutButton, useAuth } from '@/features/auth';
+
+export function Header() {
+  const { user, loading } = useAuth();
+
+  return (
+    <header className="border-b border-border bg-background">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
+        <Link
+          to="/"
+          className="flex items-center gap-2 text-2xl font-bold text-foreground hover:text-foreground/80"
+        >
+          <img
+            src="/favicon-32x32.png"
+            alt=""
+            aria-hidden="true"
+            width={32}
+            height={32}
+            className="dark:hidden"
+          />
+          <img
+            src="/favicon-32x32-dark.png"
+            alt=""
+            aria-hidden="true"
+            width={32}
+            height={32}
+            className="hidden dark:block"
+          />
+          Genshin Team Builder
+        </Link>
+        <div className="flex items-center gap-3">
+          {!loading && (user ? <UserMenu user={user} /> : <LoginButton />)}
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function UserMenu({ user }: { user: { displayName: string | null; photoURL: string | null } }) {
+  return (
+    <div className="flex items-center gap-3">
+      {user.photoURL ? (
+        <img
+          src={user.photoURL}
+          alt=""
+          aria-hidden="true"
+          className="h-8 w-8 rounded-full"
+          referrerPolicy="no-referrer"
+        />
+      ) : null}
+      <span className="text-sm font-medium text-foreground">{user.displayName ?? 'User'}</span>
+      <LogoutButton />
+    </div>
+  );
+}

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { Link, NavLink, Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { LoginButton, LogoutButton, useAuth } from '@/features/auth';
+import { Footer } from '@/components/Footer';
+import { Header } from '@/components/Header';
+import { Nav } from '@/components/Nav';
 
 export function Layout() {
   return (
@@ -16,106 +17,5 @@ export function Layout() {
       </main>
       <Footer />
     </div>
-  );
-}
-
-function Header() {
-  const { user, loading } = useAuth();
-
-  return (
-    <header className="border-b border-border bg-background">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
-        <Link
-          to="/"
-          className="flex items-center gap-2 text-2xl font-bold text-foreground hover:text-foreground/80"
-        >
-          <img
-            src="/favicon-32x32.png"
-            alt=""
-            aria-hidden="true"
-            width={32}
-            height={32}
-            className="dark:hidden"
-          />
-          <img
-            src="/favicon-32x32-dark.png"
-            alt=""
-            aria-hidden="true"
-            width={32}
-            height={32}
-            className="hidden dark:block"
-          />
-          Genshin Team Builder
-        </Link>
-        <div className="flex items-center gap-3">
-          {!loading && (user ? <UserMenu user={user} /> : <LoginButton />)}
-          <ThemeToggle />
-        </div>
-      </div>
-    </header>
-  );
-}
-
-function UserMenu({ user }: { user: { displayName: string | null; photoURL: string | null } }) {
-  return (
-    <div className="flex items-center gap-3">
-      {user.photoURL ? (
-        <img
-          src={user.photoURL}
-          alt=""
-          aria-hidden="true"
-          className="h-8 w-8 rounded-full"
-          referrerPolicy="no-referrer"
-        />
-      ) : null}
-      <span className="text-sm font-medium text-foreground">{user.displayName ?? 'User'}</span>
-      <LogoutButton />
-    </div>
-  );
-}
-
-function Nav() {
-  const navLinks = [
-    { to: '/', label: 'Home' },
-    { to: '/characters', label: 'Characters' },
-    { to: '/weapons', label: 'Weapons' },
-    { to: '/teams', label: 'Teams' },
-    { to: '/chat', label: 'Chat' },
-  ];
-
-  return (
-    <nav className="border-b border-border bg-muted" aria-label="Main navigation">
-      <div className="mx-auto max-w-7xl px-4">
-        <div className="flex gap-8">
-          {navLinks.map((link) => (
-            <NavLink
-              key={link.to}
-              to={link.to}
-              end={link.to === '/'}
-              className={({ isActive }) =>
-                `inline-block border-b-2 px-1 py-4 text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'border-blue-500 text-foreground'
-                    : 'border-transparent text-muted-foreground hover:border-blue-500 hover:text-foreground'
-                }`
-              }
-            >
-              {link.label}
-            </NavLink>
-          ))}
-        </div>
-      </div>
-    </nav>
-  );
-}
-
-function Footer() {
-  return (
-    <footer className="border-t border-border bg-muted py-8">
-      <div className="mx-auto max-w-7xl px-4 text-center text-sm text-muted-foreground">
-        <p>Built with React 19 + TypeScript + Vite</p>
-        <p className="mt-2 text-xs text-muted-foreground/70">© 2026 Genshin Team Builder</p>
-      </div>
-    </footer>
   );
 }

--- a/apps/web/src/components/Nav.tsx
+++ b/apps/web/src/components/Nav.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { NavLink } from 'react-router-dom';
+
+export function Nav() {
+  const navLinks = [
+    { to: '/', label: 'Home' },
+    { to: '/characters', label: 'Characters' },
+    { to: '/weapons', label: 'Weapons' },
+    { to: '/teams', label: 'Teams' },
+    { to: '/chat', label: 'Chat' },
+  ];
+
+  return (
+    <nav className="border-b border-border bg-muted" aria-label="Main navigation">
+      <div className="mx-auto max-w-7xl px-4">
+        <div className="flex gap-8">
+          {navLinks.map((link) => (
+            <NavLink
+              key={link.to}
+              to={link.to}
+              end={link.to === '/'}
+              className={({ isActive }) =>
+                `inline-block border-b-2 px-1 py-4 text-sm font-medium transition-colors ${
+                  isActive
+                    ? 'border-blue-500 text-foreground'
+                    : 'border-transparent text-muted-foreground hover:border-blue-500 hover:text-foreground'
+                }`
+              }
+            >
+              {link.label}
+            </NavLink>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

Extracts `Header`, `Nav`, and `Footer` from `Layout.tsx` into their own component files so `Layout.tsx` is a thin composition wrapper.

## Changes

- **`Header.tsx`** — Header component with its private `UserMenu` helper, auth state logic, theme toggle
- **`Nav.tsx`** — Main navigation bar with route links
- **`Footer.tsx`** — Site footer
- **`Layout.tsx`** — Now only imports and composes `Header`, `Nav`, `Footer`, and `Outlet`

## Verification

- Typecheck passes (`pnpm turbo run typecheck --filter=@genshin/web`)
- No user-visible behaviour change

Closes #575