### PR TITLE
feat: add DevContainer setup verification and shared lifecycle helpers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -81,7 +81,7 @@
 
   "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   "updateContentCommand": "pnpm install",
-  "postAttachCommand": "echo '✅ Ready | Node $(node --version) | pnpm $(pnpm --version)'",
+  "postAttachCommand": "bash .devcontainer/postAttachCommand.sh",
 
   "containerEnv": {
     "NODE_ENV": "development"

--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -41,6 +41,8 @@ print_version() {
 # ---------------------------------------------------------------------------
 
 run_verification() {
+  local _xtrace
+  _xtrace="$(shopt -po xtrace 2>/dev/null)" || true
   { set +x; } 2>/dev/null
   step "Verifying installed tools"
 
@@ -51,8 +53,8 @@ run_verification() {
   verify "reuse"                reuse --version
   verify "firebase"             firebase --version
   verify "playwright-cli"       npx playwright --version
-  verify "playwright-chromium"  npx playwright install --list
-  set -x
+  verify "playwright-browsers"  npx playwright install --list
+  eval "${_xtrace}"
 }
 
 # ---------------------------------------------------------------------------
@@ -60,6 +62,8 @@ run_verification() {
 # ---------------------------------------------------------------------------
 
 run_version_summary() {
+  local _xtrace
+  _xtrace="$(shopt -po xtrace 2>/dev/null)" || true
   { set +x; } 2>/dev/null
   step "Environment versions"
 
@@ -70,7 +74,7 @@ run_version_summary() {
   print_version "reuse"      reuse --version
   print_version "firebase"   firebase --version
   print_version "playwright" npx playwright --version
-  set -x
+  eval "${_xtrace}"
 }
 
 # ---------------------------------------------------------------------------
@@ -78,6 +82,8 @@ run_version_summary() {
 # ---------------------------------------------------------------------------
 
 run_status() {
+  local _xtrace
+  _xtrace="$(shopt -po xtrace 2>/dev/null)" || true
   { set +x; } 2>/dev/null
   echo ""
   if [[ ${#FAILURES[@]} -gt 0 ]]; then
@@ -91,4 +97,5 @@ run_status() {
   fi
 
   echo "Setup complete — all tools verified."
+  eval "${_xtrace}"
 }

--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -52,8 +52,8 @@ run_verification() {
   verify "pre-commit"           pre-commit --version
   verify "reuse"                reuse --version
   verify "firebase"             firebase --version
-  verify "playwright-cli"       npx playwright --version
-  verify "playwright-browsers"  npx playwright install --list
+  verify "playwright-cli"       npx --yes playwright --version
+  verify "playwright-browsers"  npx --yes playwright install --list
   eval "${_xtrace}"
 }
 
@@ -73,7 +73,7 @@ run_version_summary() {
   print_version "pre-commit" pre-commit --version
   print_version "reuse"      reuse --version
   print_version "firebase"   firebase --version
-  print_version "playwright" npx playwright --version
+  print_version "playwright" npx --yes playwright --version
   eval "${_xtrace}"
 }
 

--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Shared helpers for DevContainer lifecycle scripts.
+# Source this file; do not execute it directly.
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAILURES=()
+
+step() {
+  echo ""
+  echo "===> $1"
+  echo ""
+}
+
+verify() {
+  local label="$1"
+  shift
+  if "$@" > /dev/null 2>&1; then
+    echo "  [ok] ${label}"
+  else
+    echo "  [FAIL] ${label}"
+    FAILURES+=("${label}")
+  fi
+}
+
+print_version() {
+  local label="$1"
+  shift
+  local version
+  version="$("$@" 2>&1 | head -1)" || true
+  echo "  ${label}: ${version}"
+}
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+run_verification() {
+  { set +x; } 2>/dev/null
+  step "Verifying installed tools"
+
+  verify "node"                 node --version
+  verify "pnpm"                 pnpm --version
+  verify "gcloud"               gcloud --version
+  verify "pre-commit"           pre-commit --version
+  verify "reuse"                reuse --version
+  verify "firebase"             firebase --version
+  verify "playwright-cli"       npx playwright --version
+  verify "playwright-chromium"  npx playwright install --list
+  set -x
+}
+
+# ---------------------------------------------------------------------------
+# Version summary
+# ---------------------------------------------------------------------------
+
+run_version_summary() {
+  { set +x; } 2>/dev/null
+  step "Environment versions"
+
+  print_version "node"       node --version
+  print_version "pnpm"       pnpm --version
+  print_version "gcloud"     gcloud --version
+  print_version "pre-commit" pre-commit --version
+  print_version "reuse"      reuse --version
+  print_version "firebase"   firebase --version
+  print_version "playwright" npx playwright --version
+  set -x
+}
+
+# ---------------------------------------------------------------------------
+# Final status
+# ---------------------------------------------------------------------------
+
+run_status() {
+  { set +x; } 2>/dev/null
+  echo ""
+  if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    echo "Setup completed with failures:"
+    for f in "${FAILURES[@]}"; do
+      echo "  - ${f}"
+    done
+    echo ""
+    echo "Fix the issues above and re-run this script, or check docs/how-tos/manual-setup.md."
+    exit 1
+  fi
+
+  echo "Setup complete — all tools verified."
+}

--- a/.devcontainer/postAttachCommand.sh
+++ b/.devcontainer/postAttachCommand.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+set -x
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+run_verification
+run_version_summary
+run_status

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -5,22 +5,59 @@
 set -euo pipefail
 set -x
 
-# Install pnpm globally
-npm install -g pnpm@9.15.4
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
 
-# Install gcloud CLI
+# ---------------------------------------------------------------------------
+# 1. Package manager
+# ---------------------------------------------------------------------------
+step "Installing pnpm via corepack"
+
+corepack enable
+corepack install
+
+# ---------------------------------------------------------------------------
+# 2. Google Cloud SDK
+# ---------------------------------------------------------------------------
+step "Installing Google Cloud SDK"
+
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
 sudo apt-get update && sudo apt-get install -y google-cloud-sdk
 
-# Install project dependencies
+# ---------------------------------------------------------------------------
+# 3. Project dependencies
+# ---------------------------------------------------------------------------
+step "Installing project dependencies"
+
 pnpm install
 
-# Install pre-commit hooks
+# ---------------------------------------------------------------------------
+# 4. Pre-commit hooks
+# ---------------------------------------------------------------------------
+step "Installing pre-commit hooks"
+
 pre-commit install
 
-# Install reuse-tool (SPDX license compliance checker)
+# ---------------------------------------------------------------------------
+# 5. SPDX license compliance checker
+# ---------------------------------------------------------------------------
+step "Installing reuse-tool"
+
 pipx install reuse==6.2.0
 
-# Install Playwright Chromium and system dependencies for the Playwright MCP server
+# ---------------------------------------------------------------------------
+# 6. Playwright browsers (for Playwright MCP server)
+# ---------------------------------------------------------------------------
+step "Installing Playwright Chromium and Chrome"
+
 npx --yes playwright install --with-deps chromium chrome
+
+# ---------------------------------------------------------------------------
+# Verify and report
+# ---------------------------------------------------------------------------
+
+run_verification
+run_version_summary
+run_status

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -28,6 +28,8 @@ Dockerfile
 
 # Code quality tools
 Codecov
+jq
+pipx
 ESLint
 Prettier
 Stylelint

--- a/docs/how-tos/manual-setup.md
+++ b/docs/how-tos/manual-setup.md
@@ -13,73 +13,31 @@ This guide covers setting up the project **without DevContainers**.
 
 ## Prerequisites
 
-Make sure you have these installed:
+The setup script installs most tooling automatically. You only need these
+on your host before running it:
 
-```bash
-node --version       # v20+ required
-pnpm --version       # v9+ required
-java -version        # Java 21+ required (Firebase emulators)
-firebase --version   # Firebase CLI
-gh --version         # GitHub CLI
-pre-commit --version # pre-commit hooks
-jq --version         # JSON processor
-```
+- **Node.js** v20+ (`node --version`)
+- **Java** 21+, required by Firebase emulators (`java -version`)
+- **GitHub CLI** (`gh --version`)
+- **jq** (`jq --version`)
+- **pipx** (`pipx --version`)
 
-### Install missing tools
+### Install missing prerequisites
 
 #### macOS
 
 ```bash
-# pnpm
-npm install -g pnpm
-
-# Java 21 (required by Firebase emulators)
-brew install openjdk@21
-
-# Firebase CLI
-npm install -g firebase-tools
-
-# GitHub CLI
-brew install gh
-
-# pre-commit
-brew install pre-commit
-
-# jq
-brew install jq
+brew install openjdk@21 gh jq pipx
 ```
 
 #### Linux / Windows Subsystem for Linux
 
 ```bash
-# pnpm
-npm install -g pnpm
-
-# Java 21 (required by Firebase emulators)
-# Debian/Ubuntu
-sudo apt-get install openjdk-21-jre-headless
-
-# Fedora
-sudo dnf install java-21-openjdk-headless
-
-# Firebase CLI
-npm install -g firebase-tools
-
-# GitHub CLI - See https://cli.github.com/manual/installation for distro-specific instructions
 # Debian/Ubuntu (including most WSL images)
-sudo apt-get install gh
+sudo apt-get install openjdk-21-jre-headless gh jq pipx
 
 # Fedora
-sudo dnf install gh
-
-# pre-commit
-pip install pre-commit
-
-# jq (Debian/Ubuntu)
-sudo apt-get install jq
-
-# jq (Fedora)
-sudo dnf install jq
+sudo dnf install java-21-openjdk-headless gh jq pipx
 ```
 
 ---
@@ -91,15 +49,15 @@ sudo dnf install jq
 git clone https://github.com/dungeon-studio/genshin.dungeon.studio.git
 cd genshin.dungeon.studio
 
-# Install dependencies
-pnpm install
-
-# Set up pre-commit hooks (runs linters, formatters, SPDX checks automatically)
-pre-commit install
+# Run the setup script (installs dependencies, hooks, and verifies tools)
+.devcontainer/postCreateCommand.sh
 
 # Configure the web app for local emulators
 cp apps/web/.env.example apps/web/.env.local
 ```
+
+The script prints a verification summary at the end. If any tools fail
+verification, fix them and re-run the script.
 
 Edit `apps/web/.env.local` and fill in the Firebase client config. For local
 emulator development, any non-empty placeholder values work because the emulator
@@ -118,10 +76,12 @@ all routes work immediately. To use real GCP Firestore instead, see
 
 ---
 
-## Verify your setup
+## Re-verify your environment
 
-Open your browser and visit <http://localhost:5173> to verify the frontend is running.
+Run the attach script any time to re-check all tools without reinstalling:
 
-Check API health at <http://localhost:8080/health> to verify the API is running.
+```bash
+.devcontainer/postAttachCommand.sh
+```
 
 For more detailed development instructions, see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/how-tos/manual-setup.md
+++ b/docs/how-tos/manual-setup.md
@@ -18,7 +18,9 @@ on your host before running it:
 
 - **Node.js** v20+ (`node --version`)
 - **Java** 21+, required by Firebase emulators (`java -version`)
+- **Firebase CLI** (`firebase --version`)
 - **GitHub CLI** (`gh --version`)
+- **pre-commit** (`pre-commit --version`)
 - **jq** (`jq --version`)
 - **pipx** (`pipx --version`)
 
@@ -27,7 +29,8 @@ on your host before running it:
 #### macOS
 
 ```bash
-brew install openjdk@21 gh jq pipx
+brew install openjdk@21 gh jq pipx pre-commit
+npm install -g firebase-tools
 ```
 
 #### Linux / Windows Subsystem for Linux
@@ -35,9 +38,13 @@ brew install openjdk@21 gh jq pipx
 ```bash
 # Debian/Ubuntu (including most WSL images)
 sudo apt-get install openjdk-21-jre-headless gh jq pipx
+pip install pre-commit
+npm install -g firebase-tools
 
 # Fedora
 sudo dnf install java-21-openjdk-headless gh jq pipx
+pip install pre-commit
+npm install -g firebase-tools
 ```
 
 ---
@@ -50,6 +57,8 @@ git clone https://github.com/dungeon-studio/genshin.dungeon.studio.git
 cd genshin.dungeon.studio
 
 # Run the setup script (installs dependencies, hooks, and verifies tools)
+# NOTE: The script assumes Debian/Ubuntu for the Google Cloud SDK install step.
+# On macOS or Fedora, install gcloud separately and run the remaining steps manually.
 .devcontainer/postCreateCommand.sh
 
 # Configure the web app for local emulators

--- a/docs/how-tos/manual-setup.md
+++ b/docs/how-tos/manual-setup.md
@@ -38,12 +38,12 @@ npm install -g firebase-tools
 ```bash
 # Debian/Ubuntu (including most WSL images)
 sudo apt-get install openjdk-21-jre-headless gh jq pipx
-pip install pre-commit
+pipx install pre-commit
 npm install -g firebase-tools
 
 # Fedora
 sudo dnf install java-21-openjdk-headless gh jq pipx
-pip install pre-commit
+pipx install pre-commit
 npm install -g firebase-tools
 ```
 


### PR DESCRIPTION
## Summary

Adds tool verification and reporting to the DevContainer lifecycle scripts, and extracts shared helpers so both create and attach get accurate reporting.

## Changes

- **`.devcontainer/lib.sh`** (new): shared helpers (`step`, `verify`, `print_version`) and composable functions (`run_verification`, `run_version_summary`, `run_status`). Suppresses `set -x` trace inside formatted output.
- **`.devcontainer/postCreateCommand.sh`**: sources `lib.sh`, uses `corepack enable && corepack install` instead of hard-coded pnpm version, runs verification/summary/status after all installs.
- **`.devcontainer/postAttachCommand.sh`** (new): sources `lib.sh` and runs verification only (no installs). Every attach session gets a tool health check.
- **`.devcontainer/devcontainer.json`**: `postAttachCommand` now runs `postAttachCommand.sh` instead of a one-liner echo.
- **`docs/how-tos/manual-setup.md`**: simplified prerequisites (only host-provided tools), delegates install/verify to the setup scripts, adds re-verify section pointing to `postAttachCommand.sh`.
- **`.styles/config/vocabularies/Project/accept.txt`**: added `jq` and `pipx`.

## How it works

| Lifecycle event | Script | Installs? | Verifies? |
|---|---|---|---|
| Container create | `postCreateCommand.sh` | Yes | Yes |
| Container attach | `postAttachCommand.sh` | No | Yes |
| Manual setup | `postCreateCommand.sh` | Yes | Yes |
| Re-verify anytime | `postAttachCommand.sh` | No | Yes |

## Verification approach

- Uses `npx playwright install --list` to confirm browsers are present (no manual path assumptions)
- `npx playwright --version` confirms the CLI
- Every other tool gets a `verify` check (`--version` exit code) and a `print_version` line
- Failures are collected and reported at the end with a non-zero exit

Closes #584