### PR TITLE
feat: team builder page with 4 team rows of empty character slots

### DIFF
--- a/apps/web/src/components/TeamCharacterPlanner.tsx
+++ b/apps/web/src/components/TeamCharacterPlanner.tsx
@@ -17,7 +17,7 @@ import { ELEMENT_BORDER_COLORS } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
 
 interface TeamCharacterPlannerProps {
-  member: TeamMember;
+  member?: TeamMember;
   collectionCharacter?: CollectionCharacter;
   collectionWeapon?: CollectionWeapon;
   onArtifactPlanChange?: (plan: ArtifactPlan | undefined) => void;
@@ -29,7 +29,7 @@ export function TeamCharacterPlanner({
   collectionWeapon,
   onArtifactPlanChange,
 }: TeamCharacterPlannerProps) {
-  const character = getCharacterById(member.characterId);
+  const character = member ? getCharacterById(member.characterId) : undefined;
   const weapon = collectionWeapon ? getWeaponById(collectionWeapon.weaponId) : undefined;
 
   const borderClass = character
@@ -40,18 +40,24 @@ export function TeamCharacterPlanner({
     <Card className={cn('border-l-4 transition-colors', borderClass)}>
       {/* Row 1: Character */}
       <CardHeader className="pb-3">
-        <div className="flex items-center gap-3">
-          <CharacterSummary character={character} />
+        {character ? (
+          <div className="flex items-center gap-3 rounded-md bg-muted/50 px-2 py-1.5">
+            <CharacterSummary character={character} />
 
-          {character && collectionCharacter && (
-            <span
-              className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground"
-              aria-label={`Constellation level ${collectionCharacter.constellationLevel}`}
-            >
-              C{collectionCharacter.constellationLevel}
-            </span>
-          )}
-        </div>
+            {collectionCharacter && (
+              <span
+                className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground"
+                aria-label={`Constellation level ${collectionCharacter.constellationLevel}`}
+              >
+                C{collectionCharacter.constellationLevel}
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 rounded-md border border-dashed border-border px-2 py-1.5">
+            <CharacterSummary />
+          </div>
+        )}
       </CardHeader>
 
       <CardContent className="space-y-4 pt-0">
@@ -73,7 +79,7 @@ export function TeamCharacterPlanner({
         )}
 
         {/* Row 3: Artifact plan (only when character is assigned) */}
-        {character && (
+        {character && member && (
           <ArtifactPlanner plan={member.artifactPlan} onChange={onArtifactPlanChange} />
         )}
       </CardContent>

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { TeamMember } from '@genshin/domain';
+import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+
+import { TeamCharacterPlanner } from '@/components/TeamCharacterPlanner';
+
+interface TeamPlannerProps {
+  name: string;
+  members: TeamMember[];
+}
+
+export function TeamPlanner({ name, members }: TeamPlannerProps) {
+  const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
+
+  return (
+    <section>
+      <h2 className="mb-3 text-xl font-semibold text-foreground">{name}</h2>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {slots.map((member, i) => (
+          <TeamCharacterPlanner key={i} member={member} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -1,13 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { TeamPlanner } from '@/features/teams/TeamPlanner';
+
+const TEAM_NAMES = ['Team 1', 'Team 2', 'Team 3', 'Team 4'];
+
 export function TeamsPage() {
   return (
     <div className="mx-auto max-w-7xl px-4 py-12">
-      <h1 className="text-3xl font-bold text-foreground">Team Builder</h1>
-      <p className="mt-4 text-muted-foreground">Create and save your team compositions.</p>
-      <div className="mt-8 rounded-lg border border-border bg-muted p-8 text-center">
-        <p className="text-muted-foreground">Coming soon...</p>
+      <h1 className="sr-only">Teams</h1>
+      <div className="space-y-8">
+        {TEAM_NAMES.map((name) => (
+          <TeamPlanner key={name} name={name} members={[]} />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
### Summary

Replaces the team builder placeholder page with a static 4×4 grid layout showing 4 team rows of 4 character slots each.

### Changes

- **`apps/web/src/features/teams/TeamPlanner.tsx`** — New component rendering a labeled team row with 4 `TeamCharacterPlanner` slots, padded to `MAX_TEAM_MEMBERS` from `@genshin/domain`
- **`apps/web/src/components/TeamCharacterPlanner.tsx`** — Made `member` prop optional so the component renders its empty state natively; added consistent border styling for the character row matching the weapon row pattern
- **`apps/web/src/pages/TeamsPage.tsx`** — Replaced "Coming soon" placeholder with 4 `TeamPlanner` rows; switched to `sr-only` heading to match Characters and Weapons pages

### Acceptance criteria from #603

- [x] Navigating to `/teams` renders 4 labeled team rows, each with 4 empty slot placeholders
- [x] Filled slots render `TeamCharacterPlanner` when passed a `TeamMember` prop
- [x] Layout is responsive (2×2 slot grid on narrow viewports)
- [x] Typecheck and lint pass

### Follow-up issues filed

- #616 — Allow users to edit team names
- #617 — Reduce auth race condition on dev startup
- #618 — Improve visual distinction between owned and unowned weapons
- #619 — Simplify page title and header branding
- #620 — Replace home page with teams page as default route
- #621 — Replace footer tech stack text with user-facing links
- #622 — Remove chat page and nav link
- #623 — Clean up navigation after home page removal

Closes #603