### PR TITLE
feat(web): assign owned characters to team slots by clicking

### DIFF
--- a/apps/web/src/components/TeamCharacterPlanner.tsx
+++ b/apps/web/src/components/TeamCharacterPlanner.tsx
@@ -39,9 +39,9 @@ export function TeamCharacterPlanner({
   return (
     <Card className={cn('border-l-4 transition-colors', borderClass)}>
       {/* Row 1: Character */}
-      <CardHeader className="pb-3">
+      <CardHeader className="p-3 pb-1.5">
         {character ? (
-          <div className="flex items-center gap-3 rounded-md bg-muted/50 px-2 py-1.5">
+          <div className="flex items-center gap-2">
             <CharacterSummary character={character} />
 
             {collectionCharacter && (
@@ -54,16 +54,16 @@ export function TeamCharacterPlanner({
             )}
           </div>
         ) : (
-          <div className="flex items-center gap-3 rounded-md border border-dashed border-border px-2 py-1.5">
+          <div className="flex items-center gap-2">
             <CharacterSummary />
           </div>
         )}
       </CardHeader>
 
-      <CardContent className="space-y-4 pt-0">
+      <CardContent className="space-y-1.5 p-3 pt-0">
         {/* Row 2: Weapon instance */}
         {weapon && collectionWeapon ? (
-          <div className="flex items-center gap-3 rounded-md bg-muted/50 px-2 py-1.5">
+          <div className="flex items-center gap-2">
             <WeaponSummary weapon={weapon} />
             <span
               className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-muted-foreground"
@@ -73,7 +73,7 @@ export function TeamCharacterPlanner({
             </span>
           </div>
         ) : (
-          <div className="flex items-center gap-3 rounded-md border border-dashed border-border px-2 py-1.5">
+          <div className="flex items-center gap-2">
             <WeaponSummary />
           </div>
         )}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -57,10 +57,10 @@ interface SheetContentProps
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
-  SheetContentProps
->(({ side = 'right', className, children, ...props }, ref) => (
+  SheetContentProps & { overlayOpacity?: number }
+>(({ side = 'right', className, children, overlayOpacity = 80, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay />
+    <SheetOverlay style={{ backgroundColor: `rgb(0 0 0 / ${overlayOpacity}%)` }} />
     <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" aria-hidden="true" focusable={false} />

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -57,10 +57,10 @@ interface SheetContentProps
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
-  SheetContentProps & { overlayOpacity?: number }
->(({ side = 'right', className, children, overlayOpacity = 80, ...props }, ref) => (
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay style={{ backgroundColor: `rgb(0 0 0 / ${overlayOpacity}%)` }} />
+    <SheetOverlay />
     <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" aria-hidden="true" focusable={false} />

--- a/apps/web/src/features/collection/characters/CharacterFilters.tsx
+++ b/apps/web/src/features/collection/characters/CharacterFilters.tsx
@@ -31,6 +31,7 @@ interface CharacterFiltersProps {
   totalCount: number;
   ownedCount: number;
   filteredOwnedCount: number;
+  showOwnership?: boolean;
 }
 
 const ELEMENT_VALUES = Object.values(ELEMENTS);
@@ -40,6 +41,17 @@ const SORT_LABELS: Record<SortField, string> = {
   release: 'Release',
   name: 'Name',
 };
+
+export function initialFilterState(): CharacterFilterState {
+  return {
+    search: '',
+    elements: new Set<Element>(),
+    rarities: new Set<Rarity>(),
+    ownership: 'all',
+    sortField: 'release',
+    sortDirection: 'desc',
+  };
+}
 
 export function filterCharacters(
   characters: readonly Character[],
@@ -83,6 +95,7 @@ export function CharacterFilters({
   totalCount,
   ownedCount,
   filteredOwnedCount,
+  showOwnership = true,
 }: CharacterFiltersProps) {
   function toggleElement(element: Element) {
     const next = new Set(filters.elements);
@@ -123,26 +136,29 @@ export function CharacterFilters({
       {/* Row 1: Filters */}
       <div className="flex flex-wrap items-center gap-1.5">
         {/* Ownership filters */}
-        {(['all', 'owned', 'unowned'] as const).map((value) => (
-          <button
-            key={value}
-            type="button"
-            onClick={() => onChange({ ...filters, ownership: value })}
-            className={cn(
-              'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
-              filters.ownership === value
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:bg-muted/80',
-            )}
-            aria-pressed={filters.ownership === value}
-          >
-            {value}
-          </button>
-        ))}
+        {showOwnership &&
+          (['all', 'owned', 'unowned'] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onChange({ ...filters, ownership: value })}
+              className={cn(
+                'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
+                filters.ownership === value
+                  ? 'bg-foreground text-background'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
+              )}
+              aria-pressed={filters.ownership === value}
+            >
+              {value}
+            </button>
+          ))}
 
-        <span className="self-center text-border" aria-hidden="true">
-          |
-        </span>
+        {showOwnership && (
+          <span className="self-center text-border" aria-hidden="true">
+            |
+          </span>
+        )}
 
         {/* Rarity filters */}
         {RARITY_VALUES.map((rarity) => (
@@ -214,7 +230,9 @@ export function CharacterFilters({
         <div className="flex-1" />
 
         <p className="text-sm text-muted-foreground">
-          {filteredCount === totalCount ? (
+          {!showOwnership ? (
+            <>{filteredCount} characters</>
+          ) : filteredCount === totalCount ? (
             <>
               {ownedCount} / {totalCount} owned
             </>

--- a/apps/web/src/features/collection/characters/useCharacterCollection.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollection.ts
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
+import type { CollectionCharacter } from '@genshin/domain';
 import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 
 import { useAuth } from '@/features/auth/useAuth';
@@ -15,16 +16,16 @@ import {
   useRemoveCharacterMutation,
   useSetConstellationLevelMutation,
 } from './useCharacterCollectionApi';
-import type { CharacterId, CollectionEntry } from './useCharacterCollectionStore';
+import type { CharacterId } from './useCharacterCollectionStore';
 import { mergeCollections, useCollectionStore } from './useCharacterCollectionStore';
 
 export interface UseCollectionResult {
-  characters: Record<CharacterId, CollectionEntry>;
+  characters: Record<CharacterId, CollectionCharacter>;
   addCharacter: (characterId: CharacterId) => void;
   removeCharacter: (characterId: CharacterId) => void;
   setConstellationLevel: (characterId: CharacterId, level: number) => void;
   isOwned: (characterId: CharacterId) => boolean;
-  getCharacter: (characterId: CharacterId) => CollectionEntry | undefined;
+  getCharacter: (characterId: CharacterId) => CollectionCharacter | undefined;
   isLoading: boolean;
   error: Error | null;
 }

--- a/apps/web/src/features/collection/characters/useCharacterCollectionApi.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollectionApi.ts
@@ -2,18 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 import { assertCollectionDocument } from '@genshin/collection-json';
+import type { CollectionCharacter } from '@genshin/domain';
 import { deserialiseCharacter, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiDelete, apiGet, apiPut } from '@/lib/api';
 
-import type { CharacterId, CollectionEntry } from './useCharacterCollectionStore';
+import type { CharacterId } from './useCharacterCollectionStore';
 
-type CharacterRecord = Record<CharacterId, CollectionEntry>;
+type CharacterRecord = Record<CharacterId, CollectionCharacter>;
 
 export interface MutationResult {
   characterId: CharacterId;
-  entry: CollectionEntry;
+  entry: CollectionCharacter;
 }
 
 export function collectionKey(userId: string): readonly [string, string] {
@@ -26,7 +27,7 @@ export function parseCollectionResponse(response: unknown): CharacterRecord {
 
   for (const item of response.collection.items) {
     const character = deserialiseCharacter(item);
-    record[character.characterId] = { constellationLevel: character.constellationLevel };
+    record[character.characterId] = character;
   }
 
   return record;
@@ -42,7 +43,7 @@ function parseSingleCharacterResponse(response: unknown): MutationResult {
   const character = deserialiseCharacter(response.collection.items[0]);
   return {
     characterId: character.characterId,
-    entry: { constellationLevel: character.constellationLevel },
+    entry: character,
   };
 }
 

--- a/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
@@ -108,27 +108,6 @@ export const useCollectionStore = create<CollectionState>()(
     }),
     {
       name: 'genshin-collection',
-      version: 1,
-      migrate: (persisted, version) => {
-        if (version === 0) {
-          const state = persisted as { characters: Record<string, Record<string, unknown>> };
-          const now = nowTimestamp();
-          const migrated: Record<CharacterId, CollectionCharacter> = {};
-
-          for (const [id, entry] of Object.entries(state.characters)) {
-            migrated[id] = {
-              characterId: (entry.characterId as string) ?? id,
-              constellationLevel: (entry.constellationLevel as number) ?? MIN_CONSTELLATION_LEVEL,
-              createdAt: (entry.createdAt as ISOTimestamp) ?? now,
-              updatedAt: (entry.updatedAt as ISOTimestamp) ?? now,
-            };
-          }
-
-          return { ...state, characters: migrated };
-        }
-
-        return persisted as CollectionState;
-      },
     },
   ),
 );

--- a/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
@@ -85,7 +85,7 @@ export const useCollectionStore = create<CollectionState>()(
         set((state) => ({
           characters: {
             ...state.characters,
-            [characterId]: { ...entry, constellationLevel: level },
+            [characterId]: { ...entry, constellationLevel: level, updatedAt: nowTimestamp() },
           },
         }));
       },
@@ -108,6 +108,27 @@ export const useCollectionStore = create<CollectionState>()(
     }),
     {
       name: 'genshin-collection',
+      version: 1,
+      migrate: (persisted, version) => {
+        if (version === 0) {
+          const state = persisted as { characters: Record<string, Record<string, unknown>> };
+          const now = nowTimestamp();
+          const migrated: Record<CharacterId, CollectionCharacter> = {};
+
+          for (const [id, entry] of Object.entries(state.characters)) {
+            migrated[id] = {
+              characterId: (entry.characterId as string) ?? id,
+              constellationLevel: (entry.constellationLevel as number) ?? MIN_CONSTELLATION_LEVEL,
+              createdAt: (entry.createdAt as ISOTimestamp) ?? now,
+              updatedAt: (entry.updatedAt as ISOTimestamp) ?? now,
+            };
+          }
+
+          return { ...state, characters: migrated };
+        }
+
+        return persisted as CollectionState;
+      },
     },
   ),
 );

--- a/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
@@ -1,30 +1,34 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionCharacter } from '@genshin/domain';
+import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
 import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export interface CollectionEntry {
-  constellationLevel: number;
-}
-
 export type CharacterId = CollectionCharacter['characterId'];
+
+function nowTimestamp(): ISOTimestamp {
+  return new Date().toISOString() as ISOTimestamp;
+}
 
 // Additive merge: union of both sets, keep higher constellation level on conflicts.
 export function mergeCollections(
-  local: Record<CharacterId, CollectionEntry>,
-  server: Record<CharacterId, CollectionEntry>,
-): Record<CharacterId, CollectionEntry> {
-  const merged: Record<CharacterId, CollectionEntry> = { ...server };
+  local: Record<CharacterId, CollectionCharacter>,
+  server: Record<CharacterId, CollectionCharacter>,
+): Record<CharacterId, CollectionCharacter> {
+  const merged: Record<CharacterId, CollectionCharacter> = { ...server };
 
   for (const [id, localEntry] of Object.entries(local)) {
     const serverEntry = merged[id];
     if (!serverEntry) {
       merged[id] = localEntry;
     } else if (localEntry.constellationLevel > serverEntry.constellationLevel) {
-      merged[id] = { constellationLevel: localEntry.constellationLevel };
+      merged[id] = {
+        ...serverEntry,
+        constellationLevel: localEntry.constellationLevel,
+        updatedAt: nowTimestamp(),
+      };
     }
   }
 
@@ -32,13 +36,13 @@ export function mergeCollections(
 }
 
 interface CollectionState {
-  characters: Record<CharacterId, CollectionEntry>;
+  characters: Record<CharacterId, CollectionCharacter>;
   addCharacter: (characterId: CharacterId) => void;
   removeCharacter: (characterId: CharacterId) => void;
   setConstellationLevel: (characterId: CharacterId, level: number) => void;
   isOwned: (characterId: CharacterId) => boolean;
-  getCharacter: (characterId: CharacterId) => CollectionEntry | undefined;
-  replaceCharacters: (characters: Record<CharacterId, CollectionEntry>) => void;
+  getCharacter: (characterId: CharacterId) => CollectionCharacter | undefined;
+  replaceCharacters: (characters: Record<CharacterId, CollectionCharacter>) => void;
   clearCharacters: () => void;
 }
 
@@ -50,11 +54,15 @@ export const useCollectionStore = create<CollectionState>()(
       addCharacter: (characterId) => {
         if (get().characters[characterId]) return;
 
+        const now = nowTimestamp();
         set((state) => ({
           characters: {
             ...state.characters,
             [characterId]: {
+              characterId,
               constellationLevel: MIN_CONSTELLATION_LEVEL,
+              createdAt: now,
+              updatedAt: now,
             },
           },
         }));

--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { CollectionCharacter } from '@genshin/domain';
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { useMemo, useState } from 'react';
@@ -12,10 +13,7 @@ import {
   filterCharacters,
   initialFilterState,
 } from '@/features/collection/characters/CharacterFilters';
-import type {
-  CharacterId,
-  CollectionEntry,
-} from '@/features/collection/characters/useCharacterCollectionStore';
+import type { CharacterId } from '@/features/collection/characters/useCharacterCollectionStore';
 import { ELEMENT_BORDER_COLORS, ELEMENT_BORDER_COLORS_DIM } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
 
@@ -24,7 +22,7 @@ function poolFilterState(): CharacterFilterState {
 }
 
 interface CharacterPoolProps {
-  characters: Record<CharacterId, CollectionEntry>;
+  characters: Record<CharacterId, CollectionCharacter>;
   assignedIds: Set<string>;
   teamFull: boolean;
   onAssign: (characterId: string) => void;

--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Character } from '@genshin/game-data';
+import { CHARACTERS } from '@genshin/game-data';
+import { useMemo, useState } from 'react';
+
+import { CharacterSummary } from '@/components/CharacterSummary';
+import type { CharacterFilterState } from '@/features/collection/characters/CharacterFilters';
+import {
+  CharacterFilters,
+  filterCharacters,
+  initialFilterState,
+} from '@/features/collection/characters/CharacterFilters';
+import type {
+  CharacterId,
+  CollectionEntry,
+} from '@/features/collection/characters/useCharacterCollectionStore';
+import { ELEMENT_BORDER_COLORS, ELEMENT_BORDER_COLORS_DIM } from '@/lib/elementStyles';
+import { cn } from '@/lib/utils';
+
+function poolFilterState(): CharacterFilterState {
+  return { ...initialFilterState(), ownership: 'owned' };
+}
+
+interface CharacterPoolProps {
+  characters: Record<CharacterId, CollectionEntry>;
+  assignedIds: Set<string>;
+  teamFull: boolean;
+  onAssign: (characterId: string) => void;
+}
+
+export function CharacterPool({ characters, assignedIds, teamFull, onAssign }: CharacterPoolProps) {
+  const [filters, setFilters] = useState<CharacterFilterState>(poolFilterState);
+
+  function handleFilterChange(next: CharacterFilterState) {
+    setFilters({ ...next, ownership: 'owned' });
+  }
+
+  const ownedIds = useMemo(() => new Set(Object.keys(characters)), [characters]);
+  const ownedCount = ownedIds.size;
+
+  const { filteredCharacters, filteredOwnedCount } = useMemo(() => {
+    const filtered = filterCharacters(CHARACTERS, filters, ownedIds);
+    return {
+      filteredCharacters: filtered,
+      filteredOwnedCount: filtered.filter((c) => ownedIds.has(c.id)).length,
+    };
+  }, [filters, ownedIds]);
+
+  return (
+    <div className="space-y-3">
+      <CharacterFilters
+        filters={filters}
+        onChange={handleFilterChange}
+        filteredCount={filteredCharacters.length}
+        totalCount={CHARACTERS.length}
+        ownedCount={ownedCount}
+        filteredOwnedCount={filteredOwnedCount}
+        showOwnership={false}
+      />
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {filteredCharacters.map((character) => {
+          const owned = ownedIds.has(character.id);
+          const assigned = assignedIds.has(character.id);
+          const clickable = owned && (assigned || !teamFull);
+
+          const entry = characters[character.id];
+
+          return (
+            <PoolCharacterCard
+              key={character.id}
+              character={character}
+              constellationLevel={entry?.constellationLevel ?? 0}
+              assigned={assigned}
+              disabled={!clickable}
+              onClick={() => onAssign(character.id)}
+            />
+          );
+        })}
+      </div>
+
+      {filteredCharacters.length === 0 && (
+        <p className="py-8 text-center text-muted-foreground">No characters match your filters.</p>
+      )}
+    </div>
+  );
+}
+
+interface PoolCharacterCardProps {
+  character: Character;
+  constellationLevel: number;
+  assigned: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+function PoolCharacterCard({
+  character,
+  constellationLevel,
+  assigned,
+  disabled,
+  onClick,
+}: PoolCharacterCardProps) {
+  const borderColors = assigned ? ELEMENT_BORDER_COLORS : ELEMENT_BORDER_COLORS_DIM;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
+        borderColors[character.element],
+        disabled && 'cursor-not-allowed opacity-40',
+        !disabled && 'cursor-pointer hover:bg-accent/50',
+      )}
+      aria-label={assigned ? `Remove ${character.name} from team` : `Add ${character.name} to team`}
+      aria-pressed={assigned}
+    >
+      <CharacterSummary character={character} dimmed={!assigned} />
+      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground">
+        C{constellationLevel}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -1,22 +1,83 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { TeamMember } from '@genshin/domain';
+import type { TeamMember, TeamSlot } from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+import { Pencil } from 'lucide-react';
+import { useRef, useState } from 'react';
 
 import { TeamCharacterPlanner } from '@/components/TeamCharacterPlanner';
+import { Input } from '@/components/ui/input';
 
 interface TeamPlannerProps {
+  slot: TeamSlot;
   name: string;
   members: TeamMember[];
+  onSelect: () => void;
+  onNameChange: (name: string) => void;
 }
 
-export function TeamPlanner({ name, members }: TeamPlannerProps) {
+export function TeamPlanner({ slot, name, members, onSelect, onNameChange }: TeamPlannerProps) {
   const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function startEditing() {
+    setEditValue(name);
+    setEditing(true);
+    requestAnimationFrame(() => inputRef.current?.select());
+  }
+
+  function commitEdit() {
+    const trimmed = editValue.trim();
+    if (trimmed) {
+      onNameChange(trimmed);
+    }
+    setEditing(false);
+  }
 
   return (
-    <section>
-      <h2 className="mb-3 text-xl font-semibold text-foreground">{name}</h2>
+    <section aria-label={name} className="rounded-xl border-2 border-transparent p-4">
+      <div className="mb-3 flex items-center gap-2">
+        {editing ? (
+          <Input
+            ref={inputRef}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={commitEdit}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitEdit();
+              if (e.key === 'Escape') setEditing(false);
+            }}
+            className="h-8 w-48 text-xl font-semibold"
+            aria-label={`Rename team ${slot}`}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={startEditing}
+            className="group flex items-center gap-1.5 text-xl font-semibold text-foreground hover:text-primary"
+            aria-label={`Edit name of ${name}`}
+          >
+            {name}
+            <Pencil
+              className="h-3.5 w-3.5 opacity-0 transition-opacity group-hover:opacity-100"
+              aria-hidden="true"
+              focusable={false}
+            />
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={onSelect}
+          className="ml-auto rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
+        >
+          Edit
+        </button>
+      </div>
+
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         {slots.map((member, i) => (
           <TeamCharacterPlanner key={i} member={member} />

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { CollectionCharacter } from '@genshin/domain';
 import type { TeamMember, TeamSlot } from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { Pencil } from 'lucide-react';
@@ -8,19 +9,25 @@ import { useRef, useState } from 'react';
 
 import { TeamCharacterPlanner } from '@/components/TeamCharacterPlanner';
 import { Input } from '@/components/ui/input';
-import { useCollection } from '@/features/collection/characters/useCharacterCollection';
 
 interface TeamPlannerProps {
   slot: TeamSlot;
   name: string;
   members: TeamMember[];
+  getCharacter: (characterId: string) => CollectionCharacter | undefined;
   onNameChange: (name: string) => void;
   onEdit?: () => void;
 }
 
-export function TeamPlanner({ slot, name, members, onNameChange, onEdit }: TeamPlannerProps) {
+export function TeamPlanner({
+  slot,
+  name,
+  members,
+  getCharacter,
+  onNameChange,
+  onEdit,
+}: TeamPlannerProps) {
   const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
-  const { getCharacter } = useCollection();
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(name);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -28,7 +28,10 @@ export function TeamPlanner({ slot, name, members, onNameChange, onEdit }: TeamP
   function startEditing() {
     setEditValue(name);
     setEditing(true);
-    requestAnimationFrame(() => inputRef.current?.select());
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
   }
 
   function commitEdit() {

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -8,17 +8,19 @@ import { useRef, useState } from 'react';
 
 import { TeamCharacterPlanner } from '@/components/TeamCharacterPlanner';
 import { Input } from '@/components/ui/input';
+import { useCollection } from '@/features/collection/characters/useCharacterCollection';
 
 interface TeamPlannerProps {
   slot: TeamSlot;
   name: string;
   members: TeamMember[];
-  onSelect: () => void;
   onNameChange: (name: string) => void;
+  onEdit?: () => void;
 }
 
-export function TeamPlanner({ slot, name, members, onSelect, onNameChange }: TeamPlannerProps) {
+export function TeamPlanner({ slot, name, members, onNameChange, onEdit }: TeamPlannerProps) {
   const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
+  const { getCharacter } = useCollection();
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(name);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -38,51 +40,59 @@ export function TeamPlanner({ slot, name, members, onSelect, onNameChange }: Tea
   }
 
   return (
-    <section aria-label={name} className="rounded-xl border-2 border-transparent p-4">
+    <div>
       <div className="mb-3 flex items-center gap-2">
-        {editing ? (
-          <Input
-            ref={inputRef}
-            value={editValue}
-            onChange={(e) => setEditValue(e.target.value)}
-            onBlur={commitEdit}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') commitEdit();
-              if (e.key === 'Escape') setEditing(false);
-            }}
-            className="h-8 w-48 text-xl font-semibold"
-            aria-label={`Rename team ${slot}`}
-          />
-        ) : (
+        <h2 className="text-xl font-semibold text-foreground">
+          {editing ? (
+            <Input
+              ref={inputRef}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitEdit();
+                if (e.key === 'Escape') setEditing(false);
+              }}
+              className="h-8 w-48 text-xl font-semibold"
+              aria-label={`Rename team ${slot}`}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={startEditing}
+              className="group flex items-center gap-1.5 hover:text-primary"
+              aria-label={`Edit name of ${name}`}
+            >
+              {name}
+              <Pencil
+                className="h-3.5 w-3.5 opacity-0 transition-opacity group-hover:opacity-100"
+                aria-hidden="true"
+                focusable={false}
+              />
+            </button>
+          )}
+        </h2>
+
+        {onEdit && (
           <button
             type="button"
-            onClick={startEditing}
-            className="group flex items-center gap-1.5 text-xl font-semibold text-foreground hover:text-primary"
-            aria-label={`Edit name of ${name}`}
+            onClick={onEdit}
+            className="ml-auto rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
           >
-            {name}
-            <Pencil
-              className="h-3.5 w-3.5 opacity-0 transition-opacity group-hover:opacity-100"
-              aria-hidden="true"
-              focusable={false}
-            />
+            Edit
           </button>
         )}
-
-        <button
-          type="button"
-          onClick={onSelect}
-          className="ml-auto rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
-        >
-          Edit
-        </button>
       </div>
 
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         {slots.map((member, i) => (
-          <TeamCharacterPlanner key={i} member={member} />
+          <TeamCharacterPlanner
+            key={i}
+            member={member}
+            collectionCharacter={member ? getCharacter(member.characterId) : undefined}
+          />
         ))}
       </div>
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -78,6 +78,7 @@ export function TeamPlanner({ slot, name, members, onNameChange, onEdit }: TeamP
             type="button"
             onClick={onEdit}
             className="ml-auto rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
+            aria-label={`Edit ${name}`}
           >
             Edit
           </button>

--- a/apps/web/src/features/teams/useTeamStore.ts
+++ b/apps/web/src/features/teams/useTeamStore.ts
@@ -15,12 +15,12 @@ function createEmptyTeam(slot: TeamSlot): TeamState {
 }
 
 function initialTeams(): Record<TeamSlot, TeamState> {
-  return {
-    1: createEmptyTeam(1),
-    2: createEmptyTeam(2),
-    3: createEmptyTeam(3),
-    4: createEmptyTeam(4),
-  };
+  return Object.fromEntries(
+    Array.from({ length: MAX_TEAM_SLOT - MIN_TEAM_SLOT + 1 }, (_, i) => {
+      const slot = (MIN_TEAM_SLOT + i) as TeamSlot;
+      return [slot, createEmptyTeam(slot)];
+    }),
+  ) as Record<TeamSlot, TeamState>;
 }
 
 interface TeamStoreState {

--- a/apps/web/src/features/teams/useTeamStore.ts
+++ b/apps/web/src/features/teams/useTeamStore.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { TeamMember, TeamSlot } from '@genshin/domain';
+import { MAX_TEAM_MEMBERS, MAX_TEAM_SLOT, MIN_TEAM_SLOT } from '@genshin/domain';
+import { create } from 'zustand';
+
+interface TeamState {
+  name: string;
+  members: TeamMember[];
+}
+
+function createEmptyTeam(slot: TeamSlot): TeamState {
+  return { name: `Team ${slot}`, members: [] };
+}
+
+function initialTeams(): Record<TeamSlot, TeamState> {
+  return {
+    1: createEmptyTeam(1),
+    2: createEmptyTeam(2),
+    3: createEmptyTeam(3),
+    4: createEmptyTeam(4),
+  };
+}
+
+interface TeamStoreState {
+  teams: Record<TeamSlot, TeamState>;
+  selectedSlot: TeamSlot | null;
+
+  selectSlot: (slot: TeamSlot) => void;
+  deselectSlot: () => void;
+  assignCharacter: (slot: TeamSlot, characterId: string) => void;
+  removeCharacter: (slot: TeamSlot, memberIndex: number) => void;
+  clearTeam: (slot: TeamSlot) => void;
+  setTeamName: (slot: TeamSlot, name: string) => void;
+
+  getTeam: (slot: TeamSlot) => TeamState;
+  isCharacterInTeam: (slot: TeamSlot, characterId: string) => boolean;
+}
+
+export const useTeamStore = create<TeamStoreState>()((set, get) => ({
+  teams: initialTeams(),
+  selectedSlot: null,
+
+  selectSlot: (slot) => {
+    set({ selectedSlot: slot });
+  },
+
+  deselectSlot: () => {
+    set({ selectedSlot: null });
+  },
+
+  assignCharacter: (slot, characterId) => {
+    const team = get().teams[slot];
+    if (team.members.length >= MAX_TEAM_MEMBERS) return;
+    if (team.members.some((m) => m.characterId === characterId)) return;
+
+    set((state) => ({
+      teams: {
+        ...state.teams,
+        [slot]: {
+          ...state.teams[slot],
+          members: [...state.teams[slot].members, { characterId }],
+        },
+      },
+    }));
+  },
+
+  removeCharacter: (slot, memberIndex) => {
+    const team = get().teams[slot];
+    if (memberIndex < 0 || memberIndex >= team.members.length) return;
+
+    set((state) => ({
+      teams: {
+        ...state.teams,
+        [slot]: {
+          ...state.teams[slot],
+          members: state.teams[slot].members.filter((_, i) => i !== memberIndex),
+        },
+      },
+    }));
+  },
+
+  clearTeam: (slot) => {
+    set((state) => ({
+      teams: {
+        ...state.teams,
+        [slot]: { ...state.teams[slot], members: [] },
+      },
+    }));
+  },
+
+  setTeamName: (slot, name) => {
+    set((state) => ({
+      teams: {
+        ...state.teams,
+        [slot]: { ...state.teams[slot], name },
+      },
+    }));
+  },
+
+  getTeam: (slot) => get().teams[slot],
+
+  isCharacterInTeam: (slot, characterId) => {
+    return get().teams[slot].members.some((m) => m.characterId === characterId);
+  },
+}));
+
+export const TEAM_SLOTS: TeamSlot[] = Array.from(
+  { length: MAX_TEAM_SLOT - MIN_TEAM_SLOT + 1 },
+  (_, i) => (MIN_TEAM_SLOT + i) as TeamSlot,
+);

--- a/apps/web/src/pages/CharactersPage.tsx
+++ b/apps/web/src/pages/CharactersPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Character, Element, Rarity } from '@genshin/game-data';
+import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -11,19 +11,9 @@ import type { CharacterFilterState } from '@/features/collection/characters/Char
 import {
   CharacterFilters,
   filterCharacters,
+  initialFilterState,
 } from '@/features/collection/characters/CharacterFilters';
 import { useCollection } from '@/features/collection/characters/useCharacterCollection';
-
-function initialFilterState(): CharacterFilterState {
-  return {
-    search: '',
-    elements: new Set<Element>(),
-    rarities: new Set<Rarity>(),
-    ownership: 'all',
-    sortField: 'release',
-    sortDirection: 'desc',
-  };
-}
 
 export function CharactersPage() {
   const {

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -11,7 +11,7 @@ import { TeamPlanner } from '@/features/teams/TeamPlanner';
 import { TEAM_SLOTS, useTeamStore } from '@/features/teams/useTeamStore';
 
 export function TeamsPage() {
-  const { characters } = useCollection();
+  const { characters, getCharacter } = useCollection();
 
   const teams = useTeamStore((s) => s.teams);
   const selectedSlot = useTeamStore((s) => s.selectedSlot);
@@ -54,6 +54,7 @@ export function TeamsPage() {
               slot={slot}
               name={teams[slot].name}
               members={teams[slot].members}
+              getCharacter={getCharacter}
               onNameChange={(name) => setTeamName(slot, name)}
               onEdit={() => selectSlot(slot)}
             />
@@ -77,6 +78,7 @@ export function TeamsPage() {
                 slot={selectedSlot}
                 name={selectedTeam.name}
                 members={selectedTeam.members}
+                getCharacter={getCharacter}
                 onNameChange={(name) => setTeamName(selectedSlot, name)}
               />
 

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -2,20 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
+import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { useCollection } from '@/features/collection/characters/useCharacterCollection';
 import { CharacterPool } from '@/features/teams/CharacterPool';
 import { TeamPlanner } from '@/features/teams/TeamPlanner';
 import { TEAM_SLOTS, useTeamStore } from '@/features/teams/useTeamStore';
-import { cn } from '@/lib/utils';
 
 export function TeamsPage() {
   const { characters } = useCollection();
@@ -50,39 +43,21 @@ export function TeamsPage() {
     [selectedSlot, assignedIds, selectedTeam?.members, assignCharacter, removeCharacter],
   );
 
-  const teamRefs = useRef<Record<number, HTMLElement | null>>({});
-
-  useEffect(() => {
-    if (selectedSlot !== null) {
-      teamRefs.current[selectedSlot]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }, [selectedSlot]);
-
   return (
-    <div
-      className={cn(
-        'max-w-7xl px-4 py-12 transition-all duration-500',
-        selectedSlot !== null ? 'mr-auto sm:max-w-[50vw]' : 'mx-auto',
-      )}
-    >
+    <div className="mx-auto max-w-7xl px-4 py-12">
       <h1 className="sr-only">Teams</h1>
 
       <div className="space-y-4">
         {TEAM_SLOTS.map((slot) => (
-          <div
-            key={slot}
-            ref={(el) => {
-              teamRefs.current[slot] = el;
-            }}
-          >
+          <section key={slot} aria-label={teams[slot].name} className="p-4">
             <TeamPlanner
               slot={slot}
               name={teams[slot].name}
               members={teams[slot].members}
-              onSelect={() => selectSlot(slot)}
               onNameChange={(name) => setTeamName(slot, name)}
+              onEdit={() => selectSlot(slot)}
             />
-          </div>
+          </section>
         ))}
       </div>
 
@@ -93,16 +68,17 @@ export function TeamsPage() {
         }}
       >
         <SheetContent
-          side="right"
-          overlayOpacity={10}
-          className="flex w-full flex-col overflow-y-auto sm:w-1/2 sm:max-w-none"
+          side="bottom"
+          className="mx-auto flex w-full max-w-7xl flex-col overflow-y-auto rounded-t-xl top-[124px]"
         >
           {selectedSlot !== null && selectedTeam && (
             <>
-              <SheetHeader>
-                <SheetTitle>{selectedTeam.name}</SheetTitle>
-                <SheetDescription>Click a character to assign or remove them.</SheetDescription>
-              </SheetHeader>
+              <TeamPlanner
+                slot={selectedSlot}
+                name={selectedTeam.name}
+                members={selectedTeam.members}
+                onNameChange={(name) => setTeamName(selectedSlot, name)}
+              />
 
               <nav className="mt-4 flex gap-4 border-b border-border">
                 <button

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -1,19 +1,131 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { TeamPlanner } from '@/features/teams/TeamPlanner';
+import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-const TEAM_NAMES = ['Team 1', 'Team 2', 'Team 3', 'Team 4'];
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { useCollection } from '@/features/collection/characters/useCharacterCollection';
+import { CharacterPool } from '@/features/teams/CharacterPool';
+import { TeamPlanner } from '@/features/teams/TeamPlanner';
+import { TEAM_SLOTS, useTeamStore } from '@/features/teams/useTeamStore';
+import { cn } from '@/lib/utils';
 
 export function TeamsPage() {
+  const { characters } = useCollection();
+
+  const teams = useTeamStore((s) => s.teams);
+  const selectedSlot = useTeamStore((s) => s.selectedSlot);
+  const selectSlot = useTeamStore((s) => s.selectSlot);
+  const deselectSlot = useTeamStore((s) => s.deselectSlot);
+  const assignCharacter = useTeamStore((s) => s.assignCharacter);
+  const removeCharacter = useTeamStore((s) => s.removeCharacter);
+  const setTeamName = useTeamStore((s) => s.setTeamName);
+
+  const selectedTeam = selectedSlot !== null ? teams[selectedSlot] : null;
+
+  const assignedIds = useMemo(
+    () => new Set(selectedTeam?.members.map((m) => m.characterId) ?? []),
+    [selectedTeam?.members],
+  );
+
+  const teamFull = (selectedTeam?.members.length ?? 0) >= MAX_TEAM_MEMBERS;
+
+  const handleToggleCharacter = useCallback(
+    (characterId: string) => {
+      if (selectedSlot === null) return;
+      if (assignedIds.has(characterId)) {
+        const index = selectedTeam?.members.findIndex((m) => m.characterId === characterId) ?? -1;
+        if (index >= 0) removeCharacter(selectedSlot, index);
+      } else {
+        assignCharacter(selectedSlot, characterId);
+      }
+    },
+    [selectedSlot, assignedIds, selectedTeam?.members, assignCharacter, removeCharacter],
+  );
+
+  const teamRefs = useRef<Record<number, HTMLElement | null>>({});
+
+  useEffect(() => {
+    if (selectedSlot !== null) {
+      teamRefs.current[selectedSlot]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [selectedSlot]);
+
   return (
-    <div className="mx-auto max-w-7xl px-4 py-12">
+    <div
+      className={cn(
+        'max-w-7xl px-4 py-12 transition-all duration-500',
+        selectedSlot !== null ? 'mr-auto sm:max-w-[50vw]' : 'mx-auto',
+      )}
+    >
       <h1 className="sr-only">Teams</h1>
-      <div className="space-y-8">
-        {TEAM_NAMES.map((name) => (
-          <TeamPlanner key={name} name={name} members={[]} />
+
+      <div className="space-y-4">
+        {TEAM_SLOTS.map((slot) => (
+          <div
+            key={slot}
+            ref={(el) => {
+              teamRefs.current[slot] = el;
+            }}
+          >
+            <TeamPlanner
+              slot={slot}
+              name={teams[slot].name}
+              members={teams[slot].members}
+              onSelect={() => selectSlot(slot)}
+              onNameChange={(name) => setTeamName(slot, name)}
+            />
+          </div>
         ))}
       </div>
+
+      <Sheet
+        open={selectedSlot !== null}
+        onOpenChange={(open) => {
+          if (!open) deselectSlot();
+        }}
+      >
+        <SheetContent
+          side="right"
+          overlayOpacity={10}
+          className="flex w-full flex-col overflow-y-auto sm:w-1/2 sm:max-w-none"
+        >
+          {selectedSlot !== null && selectedTeam && (
+            <>
+              <SheetHeader>
+                <SheetTitle>{selectedTeam.name}</SheetTitle>
+                <SheetDescription>Click a character to assign or remove them.</SheetDescription>
+              </SheetHeader>
+
+              <nav className="mt-4 flex gap-4 border-b border-border">
+                <button
+                  type="button"
+                  className="border-b-2 border-primary px-1 pb-2 text-sm font-semibold text-foreground"
+                  aria-current="page"
+                >
+                  Characters
+                </button>
+              </nav>
+
+              <div className="mt-3 flex-1">
+                <CharacterPool
+                  characters={characters}
+                  assignedIds={assignedIds}
+                  teamFull={teamFull}
+                  onAssign={handleToggleCharacter}
+                />
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implement issue #604: owned characters can be assigned to and removed from team slots by clicking.

### Changes

- **useTeamStore** (zustand): manages 4 teams with 4 slots each, with select/deselect, assign/remove, clear, and rename. Initial teams generated from domain constants.
- **CharacterPool**: filterable character grid inside a bottom Sheet for team assignment
- **TeamsPage**: selecting a team opens a bottom Sheet; clicking a character toggles assignment
- **TeamPlanner**: reuses `TeamCharacterPlanner` for slot cards; inline-editable team name wrapped in `h2` for heading hierarchy; `aria-label` on Edit button
- **CharacterFilters**: extracted shared `initialFilterState()`; renamed `hideOwnershipFilter` → `showOwnership`
- **CollectionEntry → CollectionCharacter**: replaced the web-only `CollectionEntry` type with `CollectionCharacter` from `@genshin/domain` throughout the store, API layer, and consumers. Added persist migration (v0 → v1) for existing localStorage data.
- **TeamCharacterPlanner**: tightened card spacing, removed inner `bg-muted/50` backgrounds, constellation badge shown when collection data is available
- Removed orphaned `useMediaQuery` hook

Closes #604