### PR TITLE
feat: team weapon assignment and artifact plan configuration

### DIFF
--- a/apps/web/src/features/auth/AuthProvider.tsx
+++ b/apps/web/src/features/auth/AuthProvider.tsx
@@ -20,7 +20,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     });
 
     return unsubscribe;
-  }, []);
+  }, [auth]);
 
   return <AuthContext value={{ user, loading }}>{children}</AuthContext>;
 }

--- a/apps/web/src/features/auth/AuthProvider.tsx
+++ b/apps/web/src/features/auth/AuthProvider.tsx
@@ -20,7 +20,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     });
 
     return unsubscribe;
-  }, [auth]);
+  }, []);
 
   return <AuthContext value={{ user, loading }}>{children}</AuthContext>;
 }

--- a/apps/web/src/features/collection/characters/CharacterFilters.tsx
+++ b/apps/web/src/features/collection/characters/CharacterFilters.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Character, Element, Rarity } from '@genshin/game-data';
-import { compareVersions, ELEMENTS } from '@genshin/game-data';
+import type { Element, Rarity } from '@genshin/game-data';
+import { ELEMENTS } from '@genshin/game-data';
 import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -11,18 +11,7 @@ import { ELEMENT_BG_COLORS } from '@/lib/elementStyles';
 import { getElementIconPath } from '@/lib/elements';
 import { cn } from '@/lib/utils';
 
-export type OwnershipFilter = 'all' | 'owned' | 'unowned';
-export type SortField = 'release' | 'name';
-export type SortDirection = 'asc' | 'desc';
-
-export interface CharacterFilterState {
-  search: string;
-  elements: Set<Element>;
-  rarities: Set<Rarity>;
-  ownership: OwnershipFilter;
-  sortField: SortField;
-  sortDirection: SortDirection;
-}
+import type { CharacterFilterState, SortField } from './filtering';
 
 interface CharacterFiltersProps {
   filters: CharacterFilterState;
@@ -41,52 +30,6 @@ const SORT_LABELS: Record<SortField, string> = {
   release: 'Release',
   name: 'Name',
 };
-
-export function initialFilterState(): CharacterFilterState {
-  return {
-    search: '',
-    elements: new Set<Element>(),
-    rarities: new Set<Rarity>(),
-    ownership: 'all',
-    sortField: 'release',
-    sortDirection: 'desc',
-  };
-}
-
-export function filterCharacters(
-  characters: readonly Character[],
-  filters: CharacterFilterState,
-  ownedIds: Set<Character['id']>,
-): Character[] {
-  const searchLower = filters.search.toLowerCase();
-
-  const result = characters.filter((c) => {
-    if (searchLower && !c.name.toLowerCase().includes(searchLower)) return false;
-    if (filters.elements.size > 0 && !filters.elements.has(c.element)) return false;
-    if (filters.rarities.size > 0 && !filters.rarities.has(c.rarity)) return false;
-    if (filters.ownership === 'owned' && !ownedIds.has(c.id)) return false;
-    if (filters.ownership === 'unowned' && ownedIds.has(c.id)) return false;
-    return true;
-  });
-
-  result.sort((a, b) => {
-    let cmp = 0;
-    switch (filters.sortField) {
-      case 'release':
-        cmp = compareVersions(a.version, b.version);
-        if (cmp === 0) {
-          cmp = a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
-        }
-        break;
-      case 'name':
-        cmp = a.name.localeCompare(b.name);
-        break;
-    }
-    return filters.sortDirection === 'desc' ? -cmp : cmp;
-  });
-
-  return result;
-}
 
 export function CharacterFilters({
   filters,

--- a/apps/web/src/features/collection/characters/filtering.ts
+++ b/apps/web/src/features/collection/characters/filtering.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Character, Element, Rarity } from '@genshin/game-data';
+import { compareVersions } from '@genshin/game-data';
+
+export type OwnershipFilter = 'all' | 'owned' | 'unowned';
+export type SortField = 'release' | 'name';
+export type SortDirection = 'asc' | 'desc';
+
+export interface CharacterFilterState {
+  search: string;
+  elements: Set<Element>;
+  rarities: Set<Rarity>;
+  ownership: OwnershipFilter;
+  sortField: SortField;
+  sortDirection: SortDirection;
+}
+
+export function initialFilterState(): CharacterFilterState {
+  return {
+    search: '',
+    elements: new Set<Element>(),
+    rarities: new Set<Rarity>(),
+    ownership: 'all',
+    sortField: 'release',
+    sortDirection: 'desc',
+  };
+}
+
+export function filterCharacters(
+  characters: readonly Character[],
+  filters: CharacterFilterState,
+  ownedIds: Set<Character['id']>,
+): Character[] {
+  const searchLower = filters.search.toLowerCase();
+
+  const result = characters.filter((c) => {
+    if (searchLower && !c.name.toLowerCase().includes(searchLower)) return false;
+    if (filters.elements.size > 0 && !filters.elements.has(c.element)) return false;
+    if (filters.rarities.size > 0 && !filters.rarities.has(c.rarity)) return false;
+    if (filters.ownership === 'owned' && !ownedIds.has(c.id)) return false;
+    if (filters.ownership === 'unowned' && ownedIds.has(c.id)) return false;
+    return true;
+  });
+
+  result.sort((a, b) => {
+    let cmp = 0;
+    switch (filters.sortField) {
+      case 'release':
+        cmp = compareVersions(a.version, b.version);
+        if (cmp === 0) {
+          cmp = a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+        }
+        break;
+      case 'name':
+        cmp = a.name.localeCompare(b.name);
+        break;
+    }
+    return filters.sortDirection === 'desc' ? -cmp : cmp;
+  });
+
+  return result;
+}

--- a/apps/web/src/features/collection/characters/useCharacterCollection.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollection.ts
@@ -4,7 +4,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
-import type { CollectionCharacter } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter } from '@genshin/domain';
 import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 
 import { useAuth } from '@/features/auth/useAuth';
@@ -16,7 +16,6 @@ import {
   useRemoveCharacterMutation,
   useSetConstellationLevelMutation,
 } from './useCharacterCollectionApi';
-import type { CharacterId } from './useCharacterCollectionStore';
 import { mergeCollections, useCollectionStore } from './useCharacterCollectionStore';
 
 export interface UseCollectionResult {

--- a/apps/web/src/features/collection/characters/useCharacterCollectionApi.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollectionApi.ts
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { assertCollectionDocument } from '@genshin/collection-json';
-import type { CollectionCharacter } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter } from '@genshin/domain';
 import { deserialiseCharacter, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiDelete, apiGet, apiPut } from '@/lib/api';
-
-import type { CharacterId } from './useCharacterCollectionStore';
 
 type CharacterRecord = Record<CharacterId, CollectionCharacter>;
 

--- a/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollectionStore.ts
@@ -1,16 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
-import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter } from '@genshin/domain';
+import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL, nowTimestamp } from '@genshin/domain';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-
-export type CharacterId = CollectionCharacter['characterId'];
-
-function nowTimestamp(): ISOTimestamp {
-  return new Date().toISOString() as ISOTimestamp;
-}
 
 // Additive merge: union of both sets, keep higher constellation level on conflicts.
 export function mergeCollections(

--- a/apps/web/src/features/collection/weapons/WeaponFilters.tsx
+++ b/apps/web/src/features/collection/weapons/WeaponFilters.tsx
@@ -1,26 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Rarity, Weapon, WeaponType } from '@genshin/game-data';
-import { compareVersions, WEAPON_TYPES } from '@genshin/game-data';
+import type { Rarity, WeaponType } from '@genshin/game-data';
+import { WEAPON_TYPES } from '@genshin/game-data';
 import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
-export type OwnershipFilter = 'all' | 'owned' | 'unowned';
-export type SortField = 'release' | 'name';
-export type SortDirection = 'asc' | 'desc';
-
-export interface WeaponFilterState {
-  search: string;
-  weaponTypes: Set<WeaponType>;
-  rarities: Set<Rarity>;
-  ownership: OwnershipFilter;
-  sortField: SortField;
-  sortDirection: SortDirection;
-}
+import type { SortField, WeaponFilterState } from './filtering';
 
 interface WeaponFiltersProps {
   filters: WeaponFilterState;
@@ -29,6 +18,8 @@ interface WeaponFiltersProps {
   totalCount: number;
   ownedCount: number;
   filteredOwnedCount: number;
+  showOwnership?: boolean;
+  showWeaponTypes?: boolean;
 }
 
 const WEAPON_TYPE_VALUES = Object.values(WEAPON_TYPES);
@@ -39,41 +30,6 @@ const SORT_LABELS: Record<SortField, string> = {
   name: 'Name',
 };
 
-export function filterWeapons(
-  weapons: readonly Weapon[],
-  filters: WeaponFilterState,
-  ownedWeaponIds: Set<Weapon['id']>,
-): Weapon[] {
-  const searchLower = filters.search.toLowerCase();
-
-  const result = weapons.filter((w) => {
-    if (searchLower && !w.name.toLowerCase().includes(searchLower)) return false;
-    if (filters.weaponTypes.size > 0 && !filters.weaponTypes.has(w.type)) return false;
-    if (filters.rarities.size > 0 && !filters.rarities.has(w.rarity)) return false;
-    if (filters.ownership === 'owned' && !ownedWeaponIds.has(w.id)) return false;
-    if (filters.ownership === 'unowned' && ownedWeaponIds.has(w.id)) return false;
-    return true;
-  });
-
-  result.sort((a, b) => {
-    let cmp = 0;
-    switch (filters.sortField) {
-      case 'release':
-        cmp = compareVersions(a.version, b.version);
-        if (cmp === 0) {
-          cmp = a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
-        }
-        break;
-      case 'name':
-        cmp = a.name.localeCompare(b.name);
-        break;
-    }
-    return filters.sortDirection === 'desc' ? -cmp : cmp;
-  });
-
-  return result;
-}
-
 export function WeaponFilters({
   filters,
   onChange,
@@ -81,6 +37,8 @@ export function WeaponFilters({
   totalCount,
   ownedCount,
   filteredOwnedCount,
+  showOwnership = true,
+  showWeaponTypes = true,
 }: WeaponFiltersProps) {
   function toggleWeaponType(type: WeaponType) {
     const next = new Set(filters.weaponTypes);
@@ -121,26 +79,30 @@ export function WeaponFilters({
       {/* Row 1: Filters */}
       <div className="flex flex-wrap items-center gap-1.5">
         {/* Ownership filters */}
-        {(['all', 'owned', 'unowned'] as const).map((value) => (
-          <button
-            key={value}
-            type="button"
-            onClick={() => onChange({ ...filters, ownership: value })}
-            className={cn(
-              'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
-              filters.ownership === value
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:bg-muted/80',
-            )}
-            aria-pressed={filters.ownership === value}
-          >
-            {value}
-          </button>
-        ))}
+        {/* Ownership filters */}
+        {showOwnership &&
+          (['all', 'owned', 'unowned'] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onChange({ ...filters, ownership: value })}
+              className={cn(
+                'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
+                filters.ownership === value
+                  ? 'bg-foreground text-background'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
+              )}
+              aria-pressed={filters.ownership === value}
+            >
+              {value}
+            </button>
+          ))}
 
-        <span className="self-center text-border" aria-hidden="true">
-          |
-        </span>
+        {showOwnership && (
+          <span className="self-center text-border" aria-hidden="true">
+            |
+          </span>
+        )}
 
         {/* Rarity filters */}
         {RARITY_VALUES.map((rarity) => (
@@ -161,28 +123,31 @@ export function WeaponFilters({
           </button>
         ))}
 
-        <span className="self-center text-border" aria-hidden="true">
-          |
-        </span>
+        {showWeaponTypes && (
+          <span className="self-center text-border" aria-hidden="true">
+            |
+          </span>
+        )}
 
         {/* Weapon type filters */}
-        {WEAPON_TYPE_VALUES.map((type) => (
-          <button
-            key={type}
-            type="button"
-            onClick={() => toggleWeaponType(type)}
-            className={cn(
-              'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
-              filters.weaponTypes.has(type)
-                ? 'bg-foreground text-background'
-                : 'bg-muted text-muted-foreground hover:bg-muted/80',
-            )}
-            aria-pressed={filters.weaponTypes.has(type)}
-            aria-label={`Filter by ${type}`}
-          >
-            {type}
-          </button>
-        ))}
+        {showWeaponTypes &&
+          WEAPON_TYPE_VALUES.map((type) => (
+            <button
+              key={type}
+              type="button"
+              onClick={() => toggleWeaponType(type)}
+              className={cn(
+                'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+                filters.weaponTypes.has(type)
+                  ? 'bg-foreground text-background'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
+              )}
+              aria-pressed={filters.weaponTypes.has(type)}
+              aria-label={`Filter by ${type}`}
+            >
+              {type}
+            </button>
+          ))}
       </div>
 
       {/* Row 2: Search + status + sort */}
@@ -206,7 +171,9 @@ export function WeaponFilters({
         <div className="flex-1" />
 
         <p className="text-sm text-muted-foreground">
-          {filteredCount === totalCount ? (
+          {!showOwnership ? (
+            <>{filteredCount} weapons</>
+          ) : filteredCount === totalCount ? (
             <>
               {ownedCount} / {totalCount} owned
             </>

--- a/apps/web/src/features/collection/weapons/WeaponFilters.tsx
+++ b/apps/web/src/features/collection/weapons/WeaponFilters.tsx
@@ -79,7 +79,6 @@ export function WeaponFilters({
       {/* Row 1: Filters */}
       <div className="flex flex-wrap items-center gap-1.5">
         {/* Ownership filters */}
-        {/* Ownership filters */}
         {showOwnership &&
           (['all', 'owned', 'unowned'] as const).map((value) => (
             <button

--- a/apps/web/src/features/collection/weapons/WeaponInstanceSidebar.tsx
+++ b/apps/web/src/features/collection/weapons/WeaponInstanceSidebar.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
 import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
 import type { Weapon } from '@genshin/game-data';
 import { getWeaponById } from '@genshin/game-data';
@@ -16,8 +17,6 @@ import {
 } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 
-import type { WeaponInstance, WeaponInstanceId } from './useWeaponCollectionStore';
-
 const REFINEMENT_LEVELS = Array.from(
   { length: MAX_REFINEMENT_LEVEL - MIN_REFINEMENT_LEVEL + 1 },
   (_, i) => MIN_REFINEMENT_LEVEL + i,
@@ -25,11 +24,11 @@ const REFINEMENT_LEVELS = Array.from(
 
 interface WeaponInstanceSidebarProps {
   weaponId: string | null;
-  instances: WeaponInstance[];
+  instances: CollectionWeapon[];
   onClose: () => void;
   onAdd: (weaponId: string) => void;
-  onRemove: (weaponInstanceId: WeaponInstanceId) => void;
-  onRefinementChange: (weaponInstanceId: WeaponInstanceId, level: number) => void;
+  onRemove: (collectionWeaponId: CollectionWeaponId) => void;
+  onRefinementChange: (collectionWeaponId: CollectionWeaponId, level: number) => void;
 }
 
 export function WeaponInstanceSidebar({

--- a/apps/web/src/features/collection/weapons/filtering.ts
+++ b/apps/web/src/features/collection/weapons/filtering.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Rarity, Weapon, WeaponType } from '@genshin/game-data';
+import { compareVersions } from '@genshin/game-data';
+
+export type OwnershipFilter = 'all' | 'owned' | 'unowned';
+export type SortField = 'release' | 'name';
+export type SortDirection = 'asc' | 'desc';
+
+export interface WeaponFilterState {
+  search: string;
+  weaponTypes: Set<WeaponType>;
+  rarities: Set<Rarity>;
+  ownership: OwnershipFilter;
+  sortField: SortField;
+  sortDirection: SortDirection;
+}
+
+export function initialFilterState(): WeaponFilterState {
+  return {
+    search: '',
+    weaponTypes: new Set<WeaponType>(),
+    rarities: new Set<Rarity>(),
+    ownership: 'all',
+    sortField: 'release',
+    sortDirection: 'desc',
+  };
+}
+
+export function filterWeapons(
+  weapons: readonly Weapon[],
+  filters: WeaponFilterState,
+  ownedWeaponIds: Set<Weapon['id']>,
+): Weapon[] {
+  const searchLower = filters.search.toLowerCase();
+
+  const result = weapons.filter((w) => {
+    if (searchLower && !w.name.toLowerCase().includes(searchLower)) return false;
+    if (filters.weaponTypes.size > 0 && !filters.weaponTypes.has(w.type)) return false;
+    if (filters.rarities.size > 0 && !filters.rarities.has(w.rarity)) return false;
+    if (filters.ownership === 'owned' && !ownedWeaponIds.has(w.id)) return false;
+    if (filters.ownership === 'unowned' && ownedWeaponIds.has(w.id)) return false;
+    return true;
+  });
+
+  result.sort((a, b) => {
+    let cmp = 0;
+    switch (filters.sortField) {
+      case 'release':
+        cmp = compareVersions(a.version, b.version);
+        if (cmp === 0) {
+          cmp = a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+        }
+        break;
+      case 'name':
+        cmp = a.name.localeCompare(b.name);
+        break;
+    }
+    return filters.sortDirection === 'desc' ? -cmp : cmp;
+  });
+
+  return result;
+}

--- a/apps/web/src/features/collection/weapons/useWeaponCollection.ts
+++ b/apps/web/src/features/collection/weapons/useWeaponCollection.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
 import type { Weapon } from '@genshin/game-data';
 import { useCallback, useEffect } from 'react';
 import { toast } from 'sonner';
@@ -16,16 +17,15 @@ import {
   useSetRefinementLevelMutation,
   useWeaponCollectionQuery,
 } from './useWeaponCollectionApi';
-import type { WeaponInstance, WeaponInstanceId } from './useWeaponCollectionStore';
 import { useWeaponCollectionStore } from './useWeaponCollectionStore';
 
 export interface UseWeaponCollectionResult {
-  weapons: Record<WeaponInstanceId, WeaponInstance>;
+  weapons: Record<CollectionWeaponId, CollectionWeapon>;
   isAuthenticated: boolean;
   addWeapon: (weaponId: Weapon['id']) => void;
-  removeWeapon: (weaponInstanceId: WeaponInstanceId) => void;
-  setRefinementLevel: (weaponInstanceId: WeaponInstanceId, level: number) => void;
-  getWeaponsByWeaponId: (weaponId: Weapon['id']) => WeaponInstance[];
+  removeWeapon: (collectionWeaponId: CollectionWeaponId) => void;
+  setRefinementLevel: (collectionWeaponId: CollectionWeaponId, level: number) => void;
+  getWeaponsByWeaponId: (weaponId: Weapon['id']) => CollectionWeapon[];
   isLoading: boolean;
   error: Error | null;
 }
@@ -52,8 +52,8 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
   const { mutate: setRefinementLevelApi } = useSetRefinementLevelMutation(user?.uid);
 
   const applyMutationResult = useCallback(
-    ({ instance }: WeaponMutationResult) => {
-      storeAddWeapon(instance);
+    ({ weapon }: WeaponMutationResult) => {
+      storeAddWeapon(weapon);
     },
     [storeAddWeapon],
   );
@@ -84,16 +84,16 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
   );
 
   const removeWeapon = useCallback(
-    (weaponInstanceId: WeaponInstanceId) => {
+    (collectionWeaponId: CollectionWeaponId) => {
       if (!isAuthenticated) return;
 
-      const current = useWeaponCollectionStore.getState().weapons[weaponInstanceId];
+      const current = useWeaponCollectionStore.getState().weapons[collectionWeaponId];
       if (!current) return;
 
-      storeRemoveWeapon(weaponInstanceId);
-      removeWeaponApi(weaponInstanceId, {
+      storeRemoveWeapon(collectionWeaponId);
+      removeWeaponApi(collectionWeaponId, {
         onError: () => {
-          const stillAbsent = !(weaponInstanceId in useWeaponCollectionStore.getState().weapons);
+          const stillAbsent = !(collectionWeaponId in useWeaponCollectionStore.getState().weapons);
           if (stillAbsent) {
             storeAddWeapon(current);
             toast.error('Failed to remove weapon. Change has been reverted.');
@@ -107,23 +107,23 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
   );
 
   const setRefinementLevel = useCallback(
-    (weaponInstanceId: WeaponInstanceId, level: number) => {
+    (collectionWeaponId: CollectionWeaponId, level: number) => {
       if (!isAuthenticated) return;
       if (!isValidRefinementLevel(level)) return;
 
-      const previous = useWeaponCollectionStore.getState().weapons[weaponInstanceId];
+      const previous = useWeaponCollectionStore.getState().weapons[collectionWeaponId];
       if (!previous || previous.refinementLevel === level) return;
 
-      storeSetRefinementLevel(weaponInstanceId, level);
+      storeSetRefinementLevel(collectionWeaponId, level);
       setRefinementLevelApi(
-        { weaponInstanceId, level },
+        { collectionWeaponId, level },
         {
           onSuccess: applyMutationResult,
           onError: () => {
             const currentLevel =
-              useWeaponCollectionStore.getState().weapons[weaponInstanceId]?.refinementLevel;
+              useWeaponCollectionStore.getState().weapons[collectionWeaponId]?.refinementLevel;
             if (currentLevel === level) {
-              storeSetRefinementLevel(weaponInstanceId, previous.refinementLevel);
+              storeSetRefinementLevel(collectionWeaponId, previous.refinementLevel);
               toast.error('Failed to update refinement level. Change has been reverted.');
             } else {
               toast.error('Failed to update refinement level.');

--- a/apps/web/src/features/collection/weapons/useWeaponCollectionApi.ts
+++ b/apps/web/src/features/collection/weapons/useWeaponCollectionApi.ts
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 import { assertCollectionDocument } from '@genshin/collection-json';
+import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
 import { deserialiseWeapon, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiDelete, apiGet, apiPatch, apiPost } from '@/lib/api';
 
-import type { WeaponInstance, WeaponInstanceId } from './useWeaponCollectionStore';
-
-type WeaponRecord = Record<WeaponInstanceId, WeaponInstance>;
+type WeaponRecord = Record<CollectionWeaponId, CollectionWeapon>;
 
 export interface WeaponMutationResult {
-  instance: WeaponInstance;
+  weapon: CollectionWeapon;
 }
 
 export function weaponCollectionKey(userId: string): readonly [string, string] {
@@ -25,11 +24,7 @@ export function parseWeaponCollectionResponse(response: unknown): WeaponRecord {
 
   for (const item of response.collection.items) {
     const weapon = deserialiseWeapon(item);
-    record[weapon.weaponInstanceId] = {
-      weaponInstanceId: weapon.weaponInstanceId,
-      weaponId: weapon.weaponId,
-      refinementLevel: weapon.refinementLevel,
-    };
+    record[weapon.weaponInstanceId] = weapon;
   }
 
   return record;
@@ -43,13 +38,7 @@ function parseSingleWeaponResponse(response: unknown): WeaponMutationResult {
     );
   }
   const weapon = deserialiseWeapon(response.collection.items[0]);
-  return {
-    instance: {
-      weaponInstanceId: weapon.weaponInstanceId,
-      weaponId: weapon.weaponId,
-      refinementLevel: weapon.refinementLevel,
-    },
-  };
+  return { weapon };
 }
 
 export function useWeaponCollectionQuery(userId: string | undefined) {
@@ -85,8 +74,8 @@ export function useRemoveWeaponMutation(userId: string | undefined) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (weaponInstanceId: WeaponInstanceId) => {
-      await apiDelete(`/api/weapons/${encodeURIComponent(weaponInstanceId)}`);
+    mutationFn: async (collectionWeaponId: CollectionWeaponId) => {
+      await apiDelete(`/api/weapons/${encodeURIComponent(collectionWeaponId)}`);
     },
     onSuccess: () => {
       if (userId !== undefined)
@@ -100,13 +89,13 @@ export function useSetRefinementLevelMutation(userId: string | undefined) {
 
   return useMutation({
     mutationFn: async ({
-      weaponInstanceId,
+      collectionWeaponId,
       level,
     }: {
-      weaponInstanceId: WeaponInstanceId;
+      collectionWeaponId: CollectionWeaponId;
       level: number;
     }): Promise<WeaponMutationResult> => {
-      const response = await apiPatch(`/api/weapons/${encodeURIComponent(weaponInstanceId)}`, {
+      const response = await apiPatch(`/api/weapons/${encodeURIComponent(collectionWeaponId)}`, {
         refinementLevel: level,
       });
       return parseSingleWeaponResponse(response);

--- a/apps/web/src/features/collection/weapons/useWeaponCollectionStore.ts
+++ b/apps/web/src/features/collection/weapons/useWeaponCollectionStore.ts
@@ -1,26 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionWeapon, UUID } from '@genshin/domain';
+import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
 import { isValidRefinementLevel } from '@genshin/domain';
 import type { Weapon } from '@genshin/game-data';
 import { create } from 'zustand';
 
-export interface WeaponInstance {
-  weaponInstanceId: UUID;
-  weaponId: Weapon['id'];
-  refinementLevel: number;
-}
-
-export type WeaponInstanceId = CollectionWeapon['weaponInstanceId'];
-
 interface WeaponCollectionState {
-  weapons: Record<WeaponInstanceId, WeaponInstance>;
-  setWeapons: (weapons: Record<WeaponInstanceId, WeaponInstance>) => void;
-  addWeapon: (instance: WeaponInstance) => void;
-  removeWeapon: (weaponInstanceId: WeaponInstanceId) => void;
-  setRefinementLevel: (weaponInstanceId: WeaponInstanceId, level: number) => void;
-  getWeaponsByWeaponId: (weaponId: Weapon['id']) => WeaponInstance[];
+  weapons: Record<CollectionWeaponId, CollectionWeapon>;
+  setWeapons: (weapons: Record<CollectionWeaponId, CollectionWeapon>) => void;
+  addWeapon: (weapon: CollectionWeapon) => void;
+  removeWeapon: (collectionWeaponId: CollectionWeaponId) => void;
+  setRefinementLevel: (collectionWeaponId: CollectionWeaponId, level: number) => void;
+  getWeaponsByWeaponId: (weaponId: Weapon['id']) => CollectionWeapon[];
   clearWeapons: () => void;
 }
 
@@ -31,33 +23,33 @@ export const useWeaponCollectionStore = create<WeaponCollectionState>()((set, ge
     set({ weapons });
   },
 
-  addWeapon: (instance) => {
+  addWeapon: (weapon) => {
     set((state) => ({
       weapons: {
         ...state.weapons,
-        [instance.weaponInstanceId]: instance,
+        [weapon.weaponInstanceId]: weapon,
       },
     }));
   },
 
-  removeWeapon: (weaponInstanceId) => {
+  removeWeapon: (collectionWeaponId) => {
     set((state) => {
       const weapons = { ...state.weapons };
-      delete weapons[weaponInstanceId];
+      delete weapons[collectionWeaponId];
       return { weapons };
     });
   },
 
-  setRefinementLevel: (weaponInstanceId, level) => {
+  setRefinementLevel: (collectionWeaponId, level) => {
     if (!isValidRefinementLevel(level)) return;
 
-    const entry = get().weapons[weaponInstanceId];
+    const entry = get().weapons[collectionWeaponId];
     if (!entry) return;
 
     set((state) => ({
       weapons: {
         ...state.weapons,
-        [weaponInstanceId]: { ...entry, refinementLevel: level },
+        [collectionWeaponId]: { ...entry, refinementLevel: level },
       },
     }));
   },

--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -1,19 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionCharacter } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter } from '@genshin/domain';
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { useMemo, useState } from 'react';
 
 import { CharacterSummary } from '@/components/CharacterSummary';
-import type { CharacterFilterState } from '@/features/collection/characters/CharacterFilters';
-import {
-  CharacterFilters,
-  filterCharacters,
-  initialFilterState,
-} from '@/features/collection/characters/CharacterFilters';
-import type { CharacterId } from '@/features/collection/characters/useCharacterCollectionStore';
+import { CharacterFilters } from '@/features/collection/characters/CharacterFilters';
+import type { CharacterFilterState } from '@/features/collection/characters/filtering';
+import { filterCharacters, initialFilterState } from '@/features/collection/characters/filtering';
 import { ELEMENT_BORDER_COLORS, ELEMENT_BORDER_COLORS_DIM } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
 

--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -20,11 +20,11 @@ function poolFilterState(): CharacterFilterState {
 interface CharacterPoolProps {
   characters: Record<CharacterId, CollectionCharacter>;
   assignedIds: Set<string>;
-  teamFull: boolean;
+  disabled: boolean;
   onAssign: (characterId: string) => void;
 }
 
-export function CharacterPool({ characters, assignedIds, teamFull, onAssign }: CharacterPoolProps) {
+export function CharacterPool({ characters, assignedIds, disabled, onAssign }: CharacterPoolProps) {
   const [filters, setFilters] = useState<CharacterFilterState>(poolFilterState);
 
   function handleFilterChange(next: CharacterFilterState) {
@@ -58,7 +58,7 @@ export function CharacterPool({ characters, assignedIds, teamFull, onAssign }: C
         {filteredCharacters.map((character) => {
           const owned = ownedIds.has(character.id);
           const assigned = assignedIds.has(character.id);
-          const clickable = owned && (assigned || !teamFull);
+          const clickable = !disabled && owned;
 
           const entry = characters[character.id];
 

--- a/apps/web/src/features/teams/TeamMemberPlanner.tsx
+++ b/apps/web/src/features/teams/TeamMemberPlanner.tsx
@@ -16,19 +16,23 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { ELEMENT_BORDER_COLORS } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
 
-interface TeamCharacterPlannerProps {
+interface TeamMemberPlannerProps {
   member?: TeamMember;
   collectionCharacter?: CollectionCharacter;
   collectionWeapon?: CollectionWeapon;
+  selected?: boolean;
+  onSelect?: () => void;
   onArtifactPlanChange?: (plan: ArtifactPlan | undefined) => void;
 }
 
-export function TeamCharacterPlanner({
+export function TeamMemberPlanner({
   member,
   collectionCharacter,
   collectionWeapon,
+  selected = false,
+  onSelect,
   onArtifactPlanChange,
-}: TeamCharacterPlannerProps) {
+}: TeamMemberPlannerProps) {
   const character = member ? getCharacterById(member.characterId) : undefined;
   const weapon = collectionWeapon ? getWeaponById(collectionWeapon.weaponId) : undefined;
 
@@ -37,7 +41,28 @@ export function TeamCharacterPlanner({
     : 'border-dashed border-muted-foreground/30';
 
   return (
-    <Card className={cn('border-l-4 transition-colors', borderClass)}>
+    <Card
+      className={cn(
+        'border-l-4 transition-colors',
+        borderClass,
+        onSelect && 'cursor-pointer',
+        selected && 'ring-2 ring-primary',
+      )}
+      onClick={onSelect}
+      role={onSelect ? 'button' : undefined}
+      tabIndex={onSelect ? 0 : undefined}
+      aria-pressed={onSelect ? selected : undefined}
+      onKeyDown={
+        onSelect
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSelect();
+              }
+            }
+          : undefined
+      }
+    >
       {/* Row 1: Character */}
       <CardHeader className="p-3 pb-1.5">
         {character ? (
@@ -62,21 +87,17 @@ export function TeamCharacterPlanner({
 
       <CardContent className="space-y-1.5 p-3 pt-0">
         {/* Row 2: Weapon instance */}
-        {weapon && collectionWeapon ? (
-          <div className="flex items-center gap-2">
-            <WeaponSummary weapon={weapon} />
+        <div className="flex items-center gap-2">
+          <WeaponSummary weapon={weapon} />
+          {weapon && collectionWeapon && (
             <span
               className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-muted-foreground"
               aria-label={`Refinement rank ${collectionWeapon.refinementLevel}`}
             >
               R{collectionWeapon.refinementLevel}
             </span>
-          </div>
-        ) : (
-          <div className="flex items-center gap-2">
-            <WeaponSummary />
-          </div>
-        )}
+          )}
+        </div>
 
         {/* Row 3: Artifact plan (only when character is assigned) */}
         {character && member && (

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -1,21 +1,31 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionCharacter } from '@genshin/domain';
-import type { TeamMember, TeamSlot } from '@genshin/domain';
+import type {
+  ArtifactPlan,
+  CollectionCharacter,
+  CollectionWeapon,
+  Team,
+  TeamSlot,
+} from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { Pencil } from 'lucide-react';
 import { useRef, useState } from 'react';
 
-import { TeamCharacterPlanner } from '@/components/TeamCharacterPlanner';
 import { Input } from '@/components/ui/input';
+
+import { TeamMemberPlanner } from './TeamMemberPlanner';
 
 interface TeamPlannerProps {
   slot: TeamSlot;
   name: string;
-  members: TeamMember[];
+  members: Team['members'];
   getCharacter: (characterId: string) => CollectionCharacter | undefined;
+  getCollectionWeapon: (collectionWeaponId: string) => CollectionWeapon | undefined;
+  selectedMemberIndex?: number | null;
+  onMemberSelect?: (memberIndex: number) => void;
   onNameChange: (name: string) => void;
+  onArtifactPlanChange?: (memberIndex: number, plan: ArtifactPlan | undefined) => void;
   onEdit?: () => void;
 }
 
@@ -24,7 +34,11 @@ export function TeamPlanner({
   name,
   members,
   getCharacter,
+  getCollectionWeapon,
+  selectedMemberIndex,
+  onMemberSelect,
   onNameChange,
+  onArtifactPlanChange,
   onEdit,
 }: TeamPlannerProps) {
   const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
@@ -97,10 +111,18 @@ export function TeamPlanner({
 
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         {slots.map((member, i) => (
-          <TeamCharacterPlanner
+          <TeamMemberPlanner
             key={i}
             member={member}
             collectionCharacter={member ? getCharacter(member.characterId) : undefined}
+            collectionWeapon={
+              member?.weaponInstanceId ? getCollectionWeapon(member.weaponInstanceId) : undefined
+            }
+            selected={selectedMemberIndex === i}
+            onSelect={onMemberSelect ? () => onMemberSelect(i) : undefined}
+            onArtifactPlanChange={
+              onArtifactPlanChange ? (plan) => onArtifactPlanChange(i, plan) : undefined
+            }
           />
         ))}
       </div>

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -7,6 +7,7 @@ import type {
   CollectionWeapon,
   Team,
   TeamSlot,
+  UUID,
 } from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { Pencil } from 'lucide-react';
@@ -21,7 +22,7 @@ interface TeamPlannerProps {
   name: string;
   members: Team['members'];
   getCharacter: (characterId: string) => CollectionCharacter | undefined;
-  getCollectionWeapon: (collectionWeaponId: string) => CollectionWeapon | undefined;
+  getCollectionWeapon: (collectionWeaponId: UUID) => CollectionWeapon | undefined;
   selectedMemberIndex?: number | null;
   onMemberSelect?: (memberIndex: number) => void;
   onNameChange: (name: string) => void;

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -5,9 +5,9 @@ import type {
   ArtifactPlan,
   CollectionCharacter,
   CollectionWeapon,
+  CollectionWeaponId,
   Team,
   TeamSlot,
-  UUID,
 } from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { Pencil } from 'lucide-react';
@@ -22,7 +22,7 @@ interface TeamPlannerProps {
   name: string;
   members: Team['members'];
   getCharacter: (characterId: string) => CollectionCharacter | undefined;
-  getCollectionWeapon: (collectionWeaponId: UUID) => CollectionWeapon | undefined;
+  getCollectionWeapon: (collectionWeaponId: CollectionWeaponId) => CollectionWeapon | undefined;
   selectedMemberIndex?: number | null;
   onMemberSelect?: (memberIndex: number) => void;
   onNameChange: (name: string) => void;

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionWeapon, UUID } from '@genshin/domain';
+import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
 import type { Weapon, WeaponType } from '@genshin/game-data';
 import { WEAPONS } from '@genshin/game-data';
 import { useMemo, useState } from 'react';
@@ -20,8 +20,8 @@ function poolFilterState(weaponType: WeaponType): WeaponFilterState {
 interface WeaponPoolProps {
   collectionWeapons: CollectionWeapon[];
   weaponType: WeaponType;
-  selectedCollectionWeaponId?: UUID;
-  onSelect: (collectionWeaponId: UUID) => void;
+  selectedCollectionWeaponId?: CollectionWeaponId;
+  onSelect: (collectionWeaponId: CollectionWeaponId) => void;
   onClear: () => void;
 }
 

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionWeapon, UUID } from '@genshin/domain';
+import type { Weapon, WeaponType } from '@genshin/game-data';
+import { WEAPONS } from '@genshin/game-data';
+import { useMemo, useState } from 'react';
+
+import { WeaponSummary } from '@/components/WeaponSummary';
+import type { WeaponFilterState } from '@/features/collection/weapons/filtering';
+import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
+import { WeaponFilters } from '@/features/collection/weapons/WeaponFilters';
+import { RARITY_BORDER_COLORS, RARITY_BORDER_COLORS_DIM } from '@/lib/rarityStyles';
+import { cn } from '@/lib/utils';
+
+function poolFilterState(weaponType: WeaponType): WeaponFilterState {
+  return { ...initialFilterState(), ownership: 'owned', weaponTypes: new Set([weaponType]) };
+}
+
+interface WeaponPoolProps {
+  collectionWeapons: CollectionWeapon[];
+  weaponType: WeaponType;
+  selectedCollectionWeaponId?: UUID;
+  onSelect: (collectionWeaponId: UUID) => void;
+  onClear: () => void;
+}
+
+export function WeaponPool({
+  collectionWeapons,
+  weaponType,
+  selectedCollectionWeaponId,
+  onSelect,
+  onClear,
+}: WeaponPoolProps) {
+  const [filters, setFilters] = useState<WeaponFilterState>(() => poolFilterState(weaponType));
+
+  function handleFilterChange(next: WeaponFilterState) {
+    setFilters({ ...next, ownership: 'owned' });
+  }
+
+  const ownedWeaponIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const cw of collectionWeapons) {
+      ids.add(cw.weaponId);
+    }
+    return ids;
+  }, [collectionWeapons]);
+
+  const ownedCount = ownedWeaponIds.size;
+
+  const { filteredWeapons, filteredOwnedCount } = useMemo(() => {
+    const filtered = filterWeapons(WEAPONS, filters, ownedWeaponIds);
+    return {
+      filteredWeapons: filtered,
+      filteredOwnedCount: filtered.filter((w) => ownedWeaponIds.has(w.id)).length,
+    };
+  }, [filters, ownedWeaponIds]);
+
+  const instancesByWeaponId = useMemo(() => {
+    const map = new Map<string, CollectionWeapon[]>();
+    for (const cw of collectionWeapons) {
+      const list = map.get(cw.weaponId) ?? [];
+      list.push(cw);
+      map.set(cw.weaponId, list);
+    }
+    return map;
+  }, [collectionWeapons]);
+
+  return (
+    <div className="space-y-3">
+      <WeaponFilters
+        filters={filters}
+        onChange={handleFilterChange}
+        filteredCount={filteredWeapons.length}
+        totalCount={WEAPONS.length}
+        ownedCount={ownedCount}
+        filteredOwnedCount={filteredOwnedCount}
+        showOwnership={false}
+        showWeaponTypes={false}
+      />
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {filteredWeapons.flatMap((weapon) => {
+          const instances = instancesByWeaponId.get(weapon.id) ?? [];
+          return instances.map((instance) => (
+            <PoolWeaponCard
+              key={instance.weaponInstanceId}
+              weapon={weapon}
+              refinementLevel={instance.refinementLevel}
+              selected={instance.weaponInstanceId === selectedCollectionWeaponId}
+              onClick={() => {
+                if (instance.weaponInstanceId === selectedCollectionWeaponId) {
+                  onClear();
+                } else {
+                  onSelect(instance.weaponInstanceId);
+                }
+              }}
+            />
+          ));
+        })}
+      </div>
+
+      {filteredWeapons.length === 0 && (
+        <p className="py-8 text-center text-muted-foreground">No weapons match your filters.</p>
+      )}
+    </div>
+  );
+}
+
+interface PoolWeaponCardProps {
+  weapon: Weapon;
+  refinementLevel: number;
+  selected: boolean;
+  onClick: () => void;
+}
+
+function PoolWeaponCard({ weapon, refinementLevel, selected, onClick }: PoolWeaponCardProps) {
+  const borderColors = selected ? RARITY_BORDER_COLORS : RARITY_BORDER_COLORS_DIM;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
+        borderColors[weapon.rarity] ?? 'border-l-border',
+        'cursor-pointer hover:bg-accent/50',
+      )}
+      aria-label={selected ? `Remove ${weapon.name} from team` : `Assign ${weapon.name} to team`}
+      aria-pressed={selected}
+    >
+      <WeaponSummary weapon={weapon} dimmed={!selected} />
+      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground">
+        R{refinementLevel}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/features/teams/useTeamStore.ts
+++ b/apps/web/src/features/teams/useTeamStore.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { ArtifactPlan, Team, TeamSlot, UUID } from '@genshin/domain';
+import type { ArtifactPlan, CollectionWeaponId, Team, TeamSlot } from '@genshin/domain';
 import { initialTeams, isValidMemberIndex } from '@genshin/domain';
 import { create } from 'zustand';
 
@@ -10,7 +10,11 @@ interface TeamStoreState {
 
   assignCharacter: (slot: TeamSlot, memberIndex: number, characterId: string) => void;
   removeCharacter: (slot: TeamSlot, memberIndex: number) => void;
-  assignWeapon: (slot: TeamSlot, memberIndex: number, collectionWeaponId: UUID) => void;
+  assignWeapon: (
+    slot: TeamSlot,
+    memberIndex: number,
+    collectionWeaponId: CollectionWeaponId,
+  ) => void;
   removeWeapon: (slot: TeamSlot, memberIndex: number) => void;
   setArtifactPlan: (slot: TeamSlot, memberIndex: number, plan: ArtifactPlan | undefined) => void;
   clearTeam: (slot: TeamSlot) => void;

--- a/apps/web/src/features/teams/useTeamStore.ts
+++ b/apps/web/src/features/teams/useTeamStore.ts
@@ -88,9 +88,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
         [slot]: {
           ...state.teams[slot],
           members: state.teams[slot].members.map((m, i) =>
-            i === memberIndex && m
-              ? { characterId: m.characterId, artifactPlan: m.artifactPlan }
-              : m,
+            i === memberIndex && m ? { ...m, weaponInstanceId: undefined } : m,
           ) as Team['members'],
         },
       },

--- a/apps/web/src/features/teams/useTeamStore.ts
+++ b/apps/web/src/features/teams/useTeamStore.ts
@@ -1,81 +1,110 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { TeamMember, TeamSlot } from '@genshin/domain';
-import { MAX_TEAM_MEMBERS, MAX_TEAM_SLOT, MIN_TEAM_SLOT } from '@genshin/domain';
+import type { ArtifactPlan, Team, TeamSlot, UUID } from '@genshin/domain';
+import { initialTeams, isValidMemberIndex } from '@genshin/domain';
 import { create } from 'zustand';
 
-interface TeamState {
-  name: string;
-  members: TeamMember[];
-}
-
-function createEmptyTeam(slot: TeamSlot): TeamState {
-  return { name: `Team ${slot}`, members: [] };
-}
-
-function initialTeams(): Record<TeamSlot, TeamState> {
-  return Object.fromEntries(
-    Array.from({ length: MAX_TEAM_SLOT - MIN_TEAM_SLOT + 1 }, (_, i) => {
-      const slot = (MIN_TEAM_SLOT + i) as TeamSlot;
-      return [slot, createEmptyTeam(slot)];
-    }),
-  ) as Record<TeamSlot, TeamState>;
-}
-
 interface TeamStoreState {
-  teams: Record<TeamSlot, TeamState>;
-  selectedSlot: TeamSlot | null;
+  teams: Record<TeamSlot, Team>;
 
-  selectSlot: (slot: TeamSlot) => void;
-  deselectSlot: () => void;
-  assignCharacter: (slot: TeamSlot, characterId: string) => void;
+  assignCharacter: (slot: TeamSlot, memberIndex: number, characterId: string) => void;
   removeCharacter: (slot: TeamSlot, memberIndex: number) => void;
+  assignWeapon: (slot: TeamSlot, memberIndex: number, collectionWeaponId: UUID) => void;
+  removeWeapon: (slot: TeamSlot, memberIndex: number) => void;
+  setArtifactPlan: (slot: TeamSlot, memberIndex: number, plan: ArtifactPlan | undefined) => void;
   clearTeam: (slot: TeamSlot) => void;
   setTeamName: (slot: TeamSlot, name: string) => void;
 
-  getTeam: (slot: TeamSlot) => TeamState;
+  getTeam: (slot: TeamSlot) => Team;
   isCharacterInTeam: (slot: TeamSlot, characterId: string) => boolean;
 }
 
 export const useTeamStore = create<TeamStoreState>()((set, get) => ({
   teams: initialTeams(),
-  selectedSlot: null,
 
-  selectSlot: (slot) => {
-    set({ selectedSlot: slot });
-  },
-
-  deselectSlot: () => {
-    set({ selectedSlot: null });
-  },
-
-  assignCharacter: (slot, characterId) => {
+  assignCharacter: (slot, memberIndex, characterId) => {
+    if (!isValidMemberIndex(memberIndex)) return;
     const team = get().teams[slot];
-    if (team.members.length >= MAX_TEAM_MEMBERS) return;
-    if (team.members.some((m) => m.characterId === characterId)) return;
+    if (team.members.some((m) => m?.characterId === characterId)) return;
 
     set((state) => ({
       teams: {
         ...state.teams,
         [slot]: {
           ...state.teams[slot],
-          members: [...state.teams[slot].members, { characterId }],
+          members: state.teams[slot].members.map((m, i) =>
+            i === memberIndex ? { characterId } : m,
+          ) as Team['members'],
         },
       },
     }));
   },
 
   removeCharacter: (slot, memberIndex) => {
-    const team = get().teams[slot];
-    if (memberIndex < 0 || memberIndex >= team.members.length) return;
+    if (!isValidMemberIndex(memberIndex)) return;
 
     set((state) => ({
       teams: {
         ...state.teams,
         [slot]: {
           ...state.teams[slot],
-          members: state.teams[slot].members.filter((_, i) => i !== memberIndex),
+          members: state.teams[slot].members.map((m, i) =>
+            i === memberIndex ? undefined : m,
+          ) as Team['members'],
+        },
+      },
+    }));
+  },
+
+  assignWeapon: (slot, memberIndex, collectionWeaponId) => {
+    if (!isValidMemberIndex(memberIndex)) return;
+    if (!get().teams[slot].members[memberIndex]) return;
+
+    set((state) => ({
+      teams: {
+        ...state.teams,
+        [slot]: {
+          ...state.teams[slot],
+          members: state.teams[slot].members.map((m, i) =>
+            i === memberIndex && m ? { ...m, weaponInstanceId: collectionWeaponId } : m,
+          ) as Team['members'],
+        },
+      },
+    }));
+  },
+
+  removeWeapon: (slot, memberIndex) => {
+    if (!isValidMemberIndex(memberIndex)) return;
+    if (!get().teams[slot].members[memberIndex]) return;
+
+    set((state) => ({
+      teams: {
+        ...state.teams,
+        [slot]: {
+          ...state.teams[slot],
+          members: state.teams[slot].members.map((m, i) =>
+            i === memberIndex && m
+              ? { characterId: m.characterId, artifactPlan: m.artifactPlan }
+              : m,
+          ) as Team['members'],
+        },
+      },
+    }));
+  },
+
+  setArtifactPlan: (slot, memberIndex, plan) => {
+    if (!isValidMemberIndex(memberIndex)) return;
+    if (!get().teams[slot].members[memberIndex]) return;
+
+    set((state) => ({
+      teams: {
+        ...state.teams,
+        [slot]: {
+          ...state.teams[slot],
+          members: state.teams[slot].members.map((m, i) =>
+            i === memberIndex && m ? { ...m, artifactPlan: plan } : m,
+          ) as Team['members'],
         },
       },
     }));
@@ -85,7 +114,10 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
     set((state) => ({
       teams: {
         ...state.teams,
-        [slot]: { ...state.teams[slot], members: [] },
+        [slot]: {
+          ...state.teams[slot],
+          members: [undefined, undefined, undefined, undefined],
+        },
       },
     }));
   },
@@ -102,11 +134,6 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
   getTeam: (slot) => get().teams[slot],
 
   isCharacterInTeam: (slot, characterId) => {
-    return get().teams[slot].members.some((m) => m.characterId === characterId);
+    return get().teams[slot].members.some((m) => m?.characterId === characterId);
   },
 }));
-
-export const TEAM_SLOTS: TeamSlot[] = Array.from(
-  { length: MAX_TEAM_SLOT - MIN_TEAM_SLOT + 1 },
-  (_, i) => (MIN_TEAM_SLOT + i) as TeamSlot,
-);

--- a/apps/web/src/pages/CharactersPage.tsx
+++ b/apps/web/src/pages/CharactersPage.tsx
@@ -7,12 +7,9 @@ import { Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { CharacterCard } from '@/features/collection/characters/CharacterCard';
-import type { CharacterFilterState } from '@/features/collection/characters/CharacterFilters';
-import {
-  CharacterFilters,
-  filterCharacters,
-  initialFilterState,
-} from '@/features/collection/characters/CharacterFilters';
+import { CharacterFilters } from '@/features/collection/characters/CharacterFilters';
+import type { CharacterFilterState } from '@/features/collection/characters/filtering';
+import { filterCharacters, initialFilterState } from '@/features/collection/characters/filtering';
 import { useCollection } from '@/features/collection/characters/useCharacterCollection';
 
 export function CharactersPage() {

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -23,7 +23,7 @@ export function TeamsPage() {
   const collectionWeapons = useMemo(() => Object.values(weapons), [weapons]);
 
   const getCollectionWeapon = useCallback(
-    (collectionWeaponId: string) => weapons[collectionWeaponId as UUID],
+    (collectionWeaponId: UUID) => weapons[collectionWeaponId],
     [weapons],
   );
 
@@ -175,12 +175,13 @@ export function TeamsPage() {
                   <CharacterPool
                     characters={characters}
                     assignedIds={assignedIds}
-                    teamFull={selectedMemberIndex === null}
+                    disabled={selectedMemberIndex === null}
                     onAssign={handleToggleCharacter}
                   />
                 )}
                 {activeTab === 'weapons' && selectedMember && selectedMemberWeaponType && (
                   <WeaponPool
+                    key={selectedMemberWeaponType}
                     collectionWeapons={collectionWeapons}
                     weaponType={selectedMemberWeaponType}
                     selectedCollectionWeaponId={selectedMember.weaponInstanceId}

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -1,47 +1,93 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { MAX_TEAM_MEMBERS } from '@genshin/domain';
-import { useCallback, useMemo } from 'react';
+import type { TeamMember, TeamSlot, UUID } from '@genshin/domain';
+import { TEAM_SLOTS } from '@genshin/domain';
+import { getCharacterById } from '@genshin/game-data';
+import { useCallback, useMemo, useState } from 'react';
 
 import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { useCollection } from '@/features/collection/characters/useCharacterCollection';
+import { useWeaponCollection } from '@/features/collection/weapons/useWeaponCollection';
 import { CharacterPool } from '@/features/teams/CharacterPool';
 import { TeamPlanner } from '@/features/teams/TeamPlanner';
-import { TEAM_SLOTS, useTeamStore } from '@/features/teams/useTeamStore';
+import { WeaponPool } from '@/features/teams/WeaponPool';
+import { useTeamStore } from '@/features/teams/useTeamStore';
+
+type SheetTab = 'characters' | 'weapons';
 
 export function TeamsPage() {
   const { characters, getCharacter } = useCollection();
+  const { weapons } = useWeaponCollection();
+
+  const collectionWeapons = useMemo(() => Object.values(weapons), [weapons]);
+
+  const getCollectionWeapon = useCallback(
+    (collectionWeaponId: string) => weapons[collectionWeaponId as UUID],
+    [weapons],
+  );
+
+  const [activeTab, setActiveTab] = useState<SheetTab>('characters');
+  const [selectedSlot, setSelectedSlot] = useState<TeamSlot | null>(null);
+  const [selectedMemberIndex, setSelectedMemberIndex] = useState<number | null>(null);
 
   const teams = useTeamStore((s) => s.teams);
-  const selectedSlot = useTeamStore((s) => s.selectedSlot);
-  const selectSlot = useTeamStore((s) => s.selectSlot);
-  const deselectSlot = useTeamStore((s) => s.deselectSlot);
   const assignCharacter = useTeamStore((s) => s.assignCharacter);
   const removeCharacter = useTeamStore((s) => s.removeCharacter);
   const setTeamName = useTeamStore((s) => s.setTeamName);
+  const assignWeapon = useTeamStore((s) => s.assignWeapon);
+  const removeWeapon = useTeamStore((s) => s.removeWeapon);
+  const setArtifactPlan = useTeamStore((s) => s.setArtifactPlan);
 
   const selectedTeam = selectedSlot !== null ? teams[selectedSlot] : null;
 
   const assignedIds = useMemo(
-    () => new Set(selectedTeam?.members.map((m) => m.characterId) ?? []),
+    () =>
+      new Set(
+        selectedTeam?.members
+          .filter((m): m is TeamMember => m !== undefined)
+          .map((m) => m.characterId) ?? [],
+      ),
     [selectedTeam?.members],
   );
 
-  const teamFull = (selectedTeam?.members.length ?? 0) >= MAX_TEAM_MEMBERS;
+  const selectedMember =
+    selectedTeam && selectedMemberIndex !== null
+      ? selectedTeam.members[selectedMemberIndex]
+      : undefined;
+
+  const selectedMemberWeaponType = useMemo(() => {
+    if (!selectedMember) return undefined;
+    const character = getCharacterById(selectedMember.characterId);
+    return character?.weaponType;
+  }, [selectedMember]);
 
   const handleToggleCharacter = useCallback(
     (characterId: string) => {
-      if (selectedSlot === null) return;
-      if (assignedIds.has(characterId)) {
-        const index = selectedTeam?.members.findIndex((m) => m.characterId === characterId) ?? -1;
-        if (index >= 0) removeCharacter(selectedSlot, index);
+      if (selectedSlot === null || selectedMemberIndex === null) return;
+
+      const currentMember = selectedTeam?.members[selectedMemberIndex];
+      if (currentMember?.characterId === characterId) {
+        removeCharacter(selectedSlot, selectedMemberIndex);
       } else {
-        assignCharacter(selectedSlot, characterId);
+        assignCharacter(selectedSlot, selectedMemberIndex, characterId);
       }
     },
-    [selectedSlot, assignedIds, selectedTeam?.members, assignCharacter, removeCharacter],
+    [selectedSlot, selectedMemberIndex, selectedTeam?.members, assignCharacter, removeCharacter],
   );
+
+  const handleWeaponSelect = useCallback(
+    (collectionWeaponId: UUID) => {
+      if (selectedSlot === null || selectedMemberIndex === null) return;
+      assignWeapon(selectedSlot, selectedMemberIndex, collectionWeaponId);
+    },
+    [selectedSlot, selectedMemberIndex, assignWeapon],
+  );
+
+  const handleWeaponClear = useCallback(() => {
+    if (selectedSlot === null || selectedMemberIndex === null) return;
+    removeWeapon(selectedSlot, selectedMemberIndex);
+  }, [selectedSlot, selectedMemberIndex, removeWeapon]);
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-12">
@@ -55,8 +101,13 @@ export function TeamsPage() {
               name={teams[slot].name}
               members={teams[slot].members}
               getCharacter={getCharacter}
+              getCollectionWeapon={getCollectionWeapon}
               onNameChange={(name) => setTeamName(slot, name)}
-              onEdit={() => selectSlot(slot)}
+              onArtifactPlanChange={(memberIndex, plan) => setArtifactPlan(slot, memberIndex, plan)}
+              onEdit={() => {
+                setSelectedSlot(slot);
+                setSelectedMemberIndex(null);
+              }}
             />
           </section>
         ))}
@@ -65,7 +116,11 @@ export function TeamsPage() {
       <Sheet
         open={selectedSlot !== null}
         onOpenChange={(open) => {
-          if (!open) deselectSlot();
+          if (!open) {
+            setSelectedSlot(null);
+            setSelectedMemberIndex(null);
+            setActiveTab('characters');
+          }
         }}
       >
         <SheetContent
@@ -79,26 +134,65 @@ export function TeamsPage() {
                 name={selectedTeam.name}
                 members={selectedTeam.members}
                 getCharacter={getCharacter}
+                getCollectionWeapon={getCollectionWeapon}
+                selectedMemberIndex={selectedMemberIndex}
+                onMemberSelect={setSelectedMemberIndex}
                 onNameChange={(name) => setTeamName(selectedSlot, name)}
+                onArtifactPlanChange={(memberIndex, plan) =>
+                  setArtifactPlan(selectedSlot, memberIndex, plan)
+                }
               />
 
-              <nav className="mt-4 flex gap-4 border-b border-border">
+              <nav className="mt-4 flex gap-4 border-b border-border" aria-label="Team editor tabs">
                 <button
                   type="button"
-                  className="border-b-2 border-primary px-1 pb-2 text-sm font-semibold text-foreground"
-                  aria-current="page"
+                  className={`border-b-2 px-1 pb-2 text-sm font-semibold ${
+                    activeTab === 'characters'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  }`}
+                  aria-current={activeTab === 'characters' ? 'page' : undefined}
+                  onClick={() => setActiveTab('characters')}
                 >
                   Characters
+                </button>
+                <button
+                  type="button"
+                  className={`border-b-2 px-1 pb-2 text-sm font-semibold ${
+                    activeTab === 'weapons'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  }`}
+                  aria-current={activeTab === 'weapons' ? 'page' : undefined}
+                  onClick={() => setActiveTab('weapons')}
+                >
+                  Weapons
                 </button>
               </nav>
 
               <div className="mt-3 flex-1">
-                <CharacterPool
-                  characters={characters}
-                  assignedIds={assignedIds}
-                  teamFull={teamFull}
-                  onAssign={handleToggleCharacter}
-                />
+                {activeTab === 'characters' && (
+                  <CharacterPool
+                    characters={characters}
+                    assignedIds={assignedIds}
+                    teamFull={selectedMemberIndex === null}
+                    onAssign={handleToggleCharacter}
+                  />
+                )}
+                {activeTab === 'weapons' && selectedMember && selectedMemberWeaponType && (
+                  <WeaponPool
+                    collectionWeapons={collectionWeapons}
+                    weaponType={selectedMemberWeaponType}
+                    selectedCollectionWeaponId={selectedMember.weaponInstanceId}
+                    onSelect={handleWeaponSelect}
+                    onClear={handleWeaponClear}
+                  />
+                )}
+                {activeTab === 'weapons' && !selectedMember && (
+                  <p className="text-sm text-muted-foreground">
+                    Select a team member with an assigned character to choose a weapon.
+                  </p>
+                )}
               </div>
             </>
           )}

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { TeamMember, TeamSlot, UUID } from '@genshin/domain';
+import type { CollectionWeaponId, TeamMember, TeamSlot } from '@genshin/domain';
 import { TEAM_SLOTS } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
 import { useCallback, useMemo, useState } from 'react';
@@ -23,7 +23,7 @@ export function TeamsPage() {
   const collectionWeapons = useMemo(() => Object.values(weapons), [weapons]);
 
   const getCollectionWeapon = useCallback(
-    (collectionWeaponId: UUID) => weapons[collectionWeaponId],
+    (collectionWeaponId: CollectionWeaponId) => weapons[collectionWeaponId],
     [weapons],
   );
 
@@ -77,7 +77,7 @@ export function TeamsPage() {
   );
 
   const handleWeaponSelect = useCallback(
-    (collectionWeaponId: UUID) => {
+    (collectionWeaponId: CollectionWeaponId) => {
       if (selectedSlot === null || selectedMemberIndex === null) return;
       assignWeapon(selectedSlot, selectedMemberIndex, collectionWeaponId);
     },

--- a/apps/web/src/pages/WeaponsPage.tsx
+++ b/apps/web/src/pages/WeaponsPage.tsx
@@ -1,28 +1,17 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Rarity, WeaponType } from '@genshin/game-data';
 import { WEAPONS } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
+import type { WeaponFilterState } from '@/features/collection/weapons/filtering';
+import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
 import { useWeaponCollection } from '@/features/collection/weapons/useWeaponCollection';
 import { WeaponCard } from '@/features/collection/weapons/WeaponCard';
-import type { WeaponFilterState } from '@/features/collection/weapons/WeaponFilters';
-import { filterWeapons, WeaponFilters } from '@/features/collection/weapons/WeaponFilters';
+import { WeaponFilters } from '@/features/collection/weapons/WeaponFilters';
 import { WeaponInstanceSidebar } from '@/features/collection/weapons/WeaponInstanceSidebar';
-
-function initialFilterState(): WeaponFilterState {
-  return {
-    search: '',
-    weaponTypes: new Set<WeaponType>(),
-    rarities: new Set<Rarity>(),
-    ownership: 'all',
-    sortField: 'release',
-    sortDirection: 'desc',
-  };
-}
 
 export function WeaponsPage() {
   const {
@@ -39,11 +28,7 @@ export function WeaponsPage() {
   const [filters, setFilters] = useState<WeaponFilterState>(initialFilterState);
   const [selectedWeaponId, setSelectedWeaponId] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      setSelectedWeaponId(null);
-    }
-  }, [isAuthenticated]);
+  const effectiveSelectedWeaponId = isAuthenticated ? selectedWeaponId : null;
 
   // Collect weapon IDs that have at least one instance
   const ownedWeaponIds = useMemo(() => {
@@ -72,8 +57,8 @@ export function WeaponsPage() {
   }, [filters, ownedWeaponIds]);
 
   const selectedInstances = useMemo(
-    () => (selectedWeaponId ? getWeaponsByWeaponId(selectedWeaponId) : []),
-    [selectedWeaponId, getWeaponsByWeaponId],
+    () => (effectiveSelectedWeaponId ? getWeaponsByWeaponId(effectiveSelectedWeaponId) : []),
+    [effectiveSelectedWeaponId, getWeaponsByWeaponId],
   );
 
   const handleWeaponClick = useCallback(
@@ -146,7 +131,7 @@ export function WeaponsPage() {
             key={weapon.id}
             weapon={weapon}
             instanceCount={instanceCounts[weapon.id] ?? 0}
-            selected={selectedWeaponId === weapon.id}
+            selected={effectiveSelectedWeaponId === weapon.id}
             onClick={handleWeaponClick}
           />
         ))}
@@ -157,7 +142,7 @@ export function WeaponsPage() {
       )}
 
       <WeaponInstanceSidebar
-        weaponId={selectedWeaponId}
+        weaponId={effectiveSelectedWeaponId}
         instances={selectedInstances}
         onClose={() => setSelectedWeaponId(null)}
         onAdd={handleAddWeapon}

--- a/packages/domain/src/collectionCharacter.ts
+++ b/packages/domain/src/collectionCharacter.ts
@@ -17,6 +17,8 @@ export interface CollectionCharacter {
   updatedAt: ISOTimestamp;
 }
 
+export type CharacterId = CollectionCharacter['characterId'];
+
 export function isValidConstellationLevel(value: unknown): value is number {
   return (
     typeof value === 'number' &&

--- a/packages/domain/src/collectionTeam.ts
+++ b/packages/domain/src/collectionTeam.ts
@@ -4,11 +4,8 @@
 import type { ISOTimestamp } from './isoTimestamp.js';
 import { isISOTimestamp } from './isoTimestamp.js';
 import type { TeamSlot } from './team.js';
+import { MAX_TEAM_MEMBERS, MAX_TEAM_SLOT, MIN_TEAM_SLOT } from './team.js';
 import type { TeamMember } from './teamMember.js';
-
-export const MIN_TEAM_SLOT = 1;
-export const MAX_TEAM_SLOT = 4;
-export const MAX_TEAM_MEMBERS = 4;
 
 /**
  * CollectionTeam is the persisted form of a user's team composition.

--- a/packages/domain/src/collectionWeapon.ts
+++ b/packages/domain/src/collectionWeapon.ts
@@ -19,6 +19,8 @@ export interface CollectionWeapon {
   updatedAt: ISOTimestamp;
 }
 
+export type CollectionWeaponId = CollectionWeapon['weaponInstanceId'];
+
 export function isValidRefinementLevel(value: unknown): value is number {
   return (
     typeof value === 'number' &&

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -9,24 +9,19 @@ export {
   isValidConstellationLevel,
   MAX_CONSTELLATION_LEVEL,
   MIN_CONSTELLATION_LEVEL,
+  type CharacterId,
   type CollectionCharacter,
 } from './collectionCharacter.js';
-export {
-  assertCollectionTeam,
-  isValidTeamSlot,
-  MAX_TEAM_MEMBERS,
-  MAX_TEAM_SLOT,
-  MIN_TEAM_SLOT,
-  type CollectionTeam,
-} from './collectionTeam.js';
+export { assertCollectionTeam, isValidTeamSlot, type CollectionTeam } from './collectionTeam.js';
 export {
   assertCollectionWeapon,
   isValidRefinementLevel,
   MAX_REFINEMENT_LEVEL,
   MIN_REFINEMENT_LEVEL,
   type CollectionWeapon,
+  type CollectionWeaponId,
 } from './collectionWeapon.js';
-export { isISOTimestamp, type ISOTimestamp } from './isoTimestamp.js';
+export { isISOTimestamp, nowTimestamp, type ISOTimestamp } from './isoTimestamp.js';
 export type { ProblemDetail } from './problemDetail.js';
 export {
   characterItemHref,
@@ -53,7 +48,17 @@ export {
   serialiseProfile,
   type ProfileResponse,
 } from './representations/json/profile.js';
-export type { Team, TeamSlot } from './team.js';
+export {
+  createEmptyTeam,
+  initialTeams,
+  isValidMemberIndex,
+  MAX_TEAM_MEMBERS,
+  MAX_TEAM_SLOT,
+  MIN_TEAM_SLOT,
+  TEAM_SLOTS,
+  type Team,
+  type TeamSlot,
+} from './team.js';
 export { type ArtifactPlan, type TeamMember } from './teamMember.js';
 export { validateTeam, validateTeamSlot, type TeamValidationContext } from './teamValidation.js';
 export { type ProfileUpdate, type UserProfile } from './userProfile.js';

--- a/packages/domain/src/isoTimestamp.ts
+++ b/packages/domain/src/isoTimestamp.ts
@@ -14,3 +14,7 @@ export function isISOTimestamp(value: unknown): value is ISOTimestamp {
     typeof value === 'string' && ISO_8601_DATE_TIME.test(value) && !Number.isNaN(Date.parse(value))
   );
 }
+
+export function nowTimestamp(): ISOTimestamp {
+  return new Date().toISOString() as ISOTimestamp;
+}

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -22,7 +22,8 @@ import {
 } from '@genshin/collection-json';
 
 import type { CollectionTeam } from '../../collectionTeam.js';
-import { MAX_TEAM_MEMBERS, assertCollectionTeam } from '../../collectionTeam.js';
+import { assertCollectionTeam } from '../../collectionTeam.js';
+import { MAX_TEAM_MEMBERS } from '../../team.js';
 import type { ArtifactPlan, TeamMember } from '../../teamMember.js';
 
 const TEAM_TEMPLATE: Template = {
@@ -120,7 +121,7 @@ export function deserialiseTeam(item: Item): CollectionTeam {
     members = raw ? JSON.parse(raw.value as string) : [];
   } catch (error) {
     if (error instanceof TypeError) throw error;
-    throw new TypeError('members must be valid JSON');
+    throw new TypeError('members must be valid JSON', { cause: error });
   }
   if (!Array.isArray(members)) {
     throw new TypeError(`members must be an array, got: ${JSON.stringify(members)}`);

--- a/packages/domain/src/team.ts
+++ b/packages/domain/src/team.ts
@@ -2,7 +2,12 @@
 /* SPDX-License-Identifier: MIT */
 
 import type { ISOTimestamp } from './isoTimestamp.js';
+import { nowTimestamp } from './isoTimestamp.js';
 import type { TeamMember } from './teamMember.js';
+
+export const MIN_TEAM_SLOT = 1;
+export const MAX_TEAM_SLOT = 4;
+export const MAX_TEAM_MEMBERS = 4;
 
 /**
  * Team loadout slot index for a user (1-indexed, 1-4).
@@ -13,10 +18,19 @@ import type { TeamMember } from './teamMember.js';
 export type TeamSlot = 1 | 2 | 3 | 4;
 
 /**
- * Team represents a party composition of 4 Genshin Impact characters.
+ * All valid team loadout slot values.
+ */
+export const TEAM_SLOTS: readonly TeamSlot[] = Array.from(
+  { length: MAX_TEAM_SLOT - MIN_TEAM_SLOT + 1 },
+  (_, i) => (MIN_TEAM_SLOT + i) as TeamSlot,
+);
+
+/**
+ * Team represents a party composition of up to 4 Genshin Impact characters.
  *
  * Each user has exactly 4 team loadout slots, identified by {@link TeamSlot}.
- * Each team in a loadout slot contains exactly 4 party members.
+ * Each slot in the members tuple can be `undefined` when no character is
+ * assigned yet (incomplete / in-progress teams).
  * Character and weapon data are sourced from @genshin/game-data.
  */
 export interface Team {
@@ -26,10 +40,37 @@ export interface Team {
   slot: TeamSlot;
   name: string;
   /**
-   * The 4 party members (characters plus their configuration) in this team.
+   * The 4 party member slots. A slot is `undefined` when unoccupied.
    */
-  members: [TeamMember, TeamMember, TeamMember, TeamMember];
+  members: [
+    TeamMember | undefined,
+    TeamMember | undefined,
+    TeamMember | undefined,
+    TeamMember | undefined,
+  ];
   description?: string;
   createdAt: ISOTimestamp;
   updatedAt: ISOTimestamp;
+}
+
+export function isValidMemberIndex(index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < MAX_TEAM_MEMBERS;
+}
+
+export function createEmptyTeam(slot: TeamSlot): Team {
+  const now = nowTimestamp();
+  return {
+    slot,
+    name: `Team ${slot}`,
+    members: [undefined, undefined, undefined, undefined],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function initialTeams(): Record<TeamSlot, Team> {
+  return Object.fromEntries(TEAM_SLOTS.map((slot) => [slot, createEmptyTeam(slot)])) as Record<
+    TeamSlot,
+    Team
+  >;
 }


### PR DESCRIPTION
## Summary

Implements #605 — team weapon assignment, artifact plan configuration, and the surrounding domain/store refactoring.

## Changes

### Domain (`packages/domain`)
- Add `CharacterId` and `CollectionWeaponId` type aliases
- Move team domain functions: `createEmptyTeam`, `initialTeams`, `isValidMemberIndex`, `TEAM_SLOTS`, and team constants
- Move `nowTimestamp` to `isoTimestamp.ts` (shared across stores)
- Update `Team.members` to fixed 4-tuple with `undefined` slots
- Fix missing `{ cause }` in collection-json teams deserialization

### Store (`apps/web`)
- Add `assignWeapon`, `removeWeapon`, and `setArtifactPlan` actions
- Remove selection state (moved to TeamsPage local state)
- Use domain `Team` type directly (remove local `TeamState`)
- Rename `weaponInstanceId` params to `collectionWeaponId` throughout

### Components (`apps/web`)
- Create `WeaponPool` — grid-based weapon picker with owned + weapon-type defaults
- Create `TeamMemberPlanner` (renamed from `TeamCharacterPlanner`)
- Extract character and weapon filter logic to pure `filtering.ts` modules
- Add `showOwnership` and `showWeaponTypes` props to `WeaponFilters`

## Follow-up issues
- #628 — Rename `weaponInstanceId` field in wire/storage format
- #629 — Consolidate `Team` and `CollectionTeam` types
- #630 — Weapon-first team building (bidirectional filtering)

Closes #605