### PR TITLE
feat(web): persist team compositions via the API

### DIFF
--- a/apps/web/src/features/teams/useTeamApi.ts
+++ b/apps/web/src/features/teams/useTeamApi.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { assertCollectionDocument } from '@genshin/collection-json';
+import type { CollectionTeam, TeamMember, TeamSlot } from '@genshin/domain';
+import { deserialiseTeam } from '@genshin/domain';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { apiDelete, apiGet, apiPut } from '@/lib/api';
+
+export interface SaveTeamPayload {
+  slot: TeamSlot;
+  name: string;
+  members: TeamMember[];
+  description?: string;
+}
+
+export function teamKey(userId: string): readonly [string, string] {
+  return ['teams', userId] as const;
+}
+
+export function parseTeamsResponse(response: unknown): CollectionTeam[] {
+  assertCollectionDocument(response);
+  return response.collection.items.map((item) => deserialiseTeam(item));
+}
+
+export function useTeamsQuery(userId: string | undefined) {
+  return useQuery({
+    queryKey: teamKey(userId ?? ''),
+    queryFn: async () => {
+      const response = await apiGet('/api/teams');
+      return parseTeamsResponse(response);
+    },
+    enabled: userId !== undefined,
+  });
+}
+
+export function useSaveTeamMutation(userId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ slot, name, members, description }: SaveTeamPayload) => {
+      await apiPut(`/api/teams/${encodeURIComponent(slot)}`, { name, members, description });
+    },
+    onSuccess: () => {
+      if (userId !== undefined) queryClient.invalidateQueries({ queryKey: teamKey(userId) });
+    },
+  });
+}
+
+export function useDeleteTeamMutation(userId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (slot: TeamSlot) => {
+      await apiDelete(`/api/teams/${encodeURIComponent(slot)}`);
+    },
+    onSuccess: () => {
+      if (userId !== undefined) queryClient.invalidateQueries({ queryKey: teamKey(userId) });
+    },
+  });
+}

--- a/apps/web/src/features/teams/useTeamStore.ts
+++ b/apps/web/src/features/teams/useTeamStore.ts
@@ -19,6 +19,9 @@ interface TeamStoreState {
   setArtifactPlan: (slot: TeamSlot, memberIndex: number, plan: ArtifactPlan | undefined) => void;
   clearTeam: (slot: TeamSlot) => void;
   setTeamName: (slot: TeamSlot, name: string) => void;
+  setTeam: (slot: TeamSlot, team: Team) => void;
+  setTeams: (teams: Record<TeamSlot, Team>) => void;
+  resetTeams: () => void;
 
   getTeam: (slot: TeamSlot) => Team;
   isCharacterInTeam: (slot: TeamSlot, characterId: string) => boolean;
@@ -131,6 +134,20 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
         [slot]: { ...state.teams[slot], name },
       },
     }));
+  },
+
+  setTeam: (slot, team) => {
+    set((state) => ({
+      teams: { ...state.teams, [slot]: team },
+    }));
+  },
+
+  setTeams: (teams) => {
+    set({ teams });
+  },
+
+  resetTeams: () => {
+    set({ teams: initialTeams() });
   },
 
   getTeam: (slot) => get().teams[slot],

--- a/apps/web/src/features/teams/useTeams.ts
+++ b/apps/web/src/features/teams/useTeams.ts
@@ -103,6 +103,7 @@ export function useTeams(): UseTeamsResult {
     const handler = (e: BeforeUnloadEvent) => {
       if (isSavingRef.current) {
         e.preventDefault();
+        e.returnValue = '';
       }
     };
     window.addEventListener('beforeunload', handler);
@@ -122,12 +123,17 @@ export function useTeams(): UseTeamsResult {
     storeSetTeams(collectionTeamsToStore(apiTeams));
   }, [apiTeams, storeSetTeams]);
 
-  // Helper: save a team slot after an optimistic store update, rolling back on failure.
+  // Helper: save a team slot after an optimistic store update, rolling back on failure
+  // only if the store still reflects this request's optimistic value.
   const saveAfterMutation = useCallback(
     (slot: TeamSlot, previousTeam: Team) => {
-      const updatedTeam = useTeamStore.getState().teams[slot];
-      saveTeamApi(teamToSavePayload(updatedTeam), {
+      const optimisticTeam = useTeamStore.getState().teams[slot];
+      saveTeamApi(teamToSavePayload(optimisticTeam), {
         onError: () => {
+          if (useTeamStore.getState().teams[slot] !== optimisticTeam) {
+            toast.error('Failed to save team.');
+            return;
+          }
           storeSetTeam(slot, previousTeam);
           toast.error('Failed to save team. Change has been reverted.');
         },
@@ -196,8 +202,13 @@ export function useTeams(): UseTeamsResult {
       const previousTeam = { ...useTeamStore.getState().teams[slot] };
       storeClearTeam(slot);
       if (isAuthenticated) {
+        const optimisticClearedTeam = useTeamStore.getState().teams[slot];
         deleteTeamApi(slot, {
           onError: () => {
+            if (useTeamStore.getState().teams[slot] !== optimisticClearedTeam) {
+              toast.error('Failed to clear team.');
+              return;
+            }
             storeSetTeam(slot, previousTeam);
             toast.error('Failed to clear team. Change has been reverted.');
           },

--- a/apps/web/src/features/teams/useTeams.ts
+++ b/apps/web/src/features/teams/useTeams.ts
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type {
+  ArtifactPlan,
+  CollectionTeam,
+  CollectionWeaponId,
+  Team,
+  TeamMember,
+  TeamSlot,
+} from '@genshin/domain';
+import { initialTeams } from '@genshin/domain';
+import { useCallback, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+import { useAuth } from '@/features/auth/useAuth';
+
+import type { SaveTeamPayload } from './useTeamApi';
+import { useDeleteTeamMutation, useSaveTeamMutation, useTeamsQuery } from './useTeamApi';
+import { useTeamStore } from './useTeamStore';
+
+export interface UseTeamsResult {
+  teams: Record<TeamSlot, Team>;
+  assignCharacter: (slot: TeamSlot, memberIndex: number, characterId: string) => void;
+  removeCharacter: (slot: TeamSlot, memberIndex: number) => void;
+  assignWeapon: (
+    slot: TeamSlot,
+    memberIndex: number,
+    collectionWeaponId: CollectionWeaponId,
+  ) => void;
+  removeWeapon: (slot: TeamSlot, memberIndex: number) => void;
+  setArtifactPlan: (slot: TeamSlot, memberIndex: number, plan: ArtifactPlan | undefined) => void;
+  clearTeam: (slot: TeamSlot) => void;
+  setTeamName: (slot: TeamSlot, name: string) => void;
+  getTeam: (slot: TeamSlot) => Team;
+  isCharacterInTeam: (slot: TeamSlot, characterId: string) => boolean;
+  isSaving: boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+function collectionTeamsToStore(apiTeams: CollectionTeam[]): Record<TeamSlot, Team> {
+  const teams = initialTeams();
+
+  for (const ct of apiTeams) {
+    const members: Team['members'] = [undefined, undefined, undefined, undefined];
+    for (let i = 0; i < ct.members.length && i < 4; i++) {
+      members[i] = ct.members[i];
+    }
+    teams[ct.slot] = {
+      slot: ct.slot,
+      name: ct.name,
+      members,
+      description: ct.description,
+      createdAt: ct.createdAt,
+      updatedAt: ct.updatedAt,
+    };
+  }
+
+  return teams;
+}
+
+function teamToSavePayload(team: Team): SaveTeamPayload {
+  return {
+    slot: team.slot,
+    name: team.name,
+    members: team.members.filter((m): m is TeamMember => m !== undefined),
+    description: team.description,
+  };
+}
+
+export function useTeams(): UseTeamsResult {
+  const { user, loading: authLoading } = useAuth();
+  const isAuthenticated = user !== null;
+
+  const teams = useTeamStore((s) => s.teams);
+  const storeAssignCharacter = useTeamStore((s) => s.assignCharacter);
+  const storeRemoveCharacter = useTeamStore((s) => s.removeCharacter);
+  const storeAssignWeapon = useTeamStore((s) => s.assignWeapon);
+  const storeRemoveWeapon = useTeamStore((s) => s.removeWeapon);
+  const storeSetArtifactPlan = useTeamStore((s) => s.setArtifactPlan);
+  const storeClearTeam = useTeamStore((s) => s.clearTeam);
+  const storeSetTeamName = useTeamStore((s) => s.setTeamName);
+  const storeSetTeam = useTeamStore((s) => s.setTeam);
+  const storeSetTeams = useTeamStore((s) => s.setTeams);
+  const storeResetTeams = useTeamStore((s) => s.resetTeams);
+
+  const { data: apiTeams, error: queryError, isLoading: queryLoading } = useTeamsQuery(user?.uid);
+
+  const { mutate: saveTeamApi, isPending: isSavePending } = useSaveTeamMutation(user?.uid);
+  const { mutate: deleteTeamApi, isPending: isDeletePending } = useDeleteTeamMutation(user?.uid);
+
+  const isSaving = isSavePending || isDeletePending;
+
+  // Track isSaving in a ref so the beforeunload handler always sees the latest value.
+  const isSavingRef = useRef(isSaving);
+  useEffect(() => {
+    isSavingRef.current = isSaving;
+  }, [isSaving]);
+
+  // Warn the user if they try to leave with unsaved changes in flight.
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isSavingRef.current) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, []);
+
+  // Reset store on logout
+  useEffect(() => {
+    if (!user) {
+      storeResetTeams();
+    }
+  }, [user, storeResetTeams]);
+
+  // Populate store from API data
+  useEffect(() => {
+    if (!apiTeams) return;
+    storeSetTeams(collectionTeamsToStore(apiTeams));
+  }, [apiTeams, storeSetTeams]);
+
+  // Helper: save a team slot after an optimistic store update, rolling back on failure.
+  const saveAfterMutation = useCallback(
+    (slot: TeamSlot, previousTeam: Team) => {
+      const updatedTeam = useTeamStore.getState().teams[slot];
+      saveTeamApi(teamToSavePayload(updatedTeam), {
+        onError: () => {
+          storeSetTeam(slot, previousTeam);
+          toast.error('Failed to save team. Change has been reverted.');
+        },
+      });
+    },
+    [saveTeamApi, storeSetTeam],
+  );
+
+  const assignCharacter = useCallback(
+    (slot: TeamSlot, memberIndex: number, characterId: string) => {
+      const previousTeam = { ...useTeamStore.getState().teams[slot] };
+      storeAssignCharacter(slot, memberIndex, characterId);
+      if (isAuthenticated) {
+        saveAfterMutation(slot, previousTeam);
+      }
+    },
+    [isAuthenticated, storeAssignCharacter, saveAfterMutation],
+  );
+
+  const removeCharacter = useCallback(
+    (slot: TeamSlot, memberIndex: number) => {
+      const previousTeam = { ...useTeamStore.getState().teams[slot] };
+      storeRemoveCharacter(slot, memberIndex);
+      if (isAuthenticated) {
+        saveAfterMutation(slot, previousTeam);
+      }
+    },
+    [isAuthenticated, storeRemoveCharacter, saveAfterMutation],
+  );
+
+  const assignWeapon = useCallback(
+    (slot: TeamSlot, memberIndex: number, collectionWeaponId: CollectionWeaponId) => {
+      const previousTeam = { ...useTeamStore.getState().teams[slot] };
+      storeAssignWeapon(slot, memberIndex, collectionWeaponId);
+      if (isAuthenticated) {
+        saveAfterMutation(slot, previousTeam);
+      }
+    },
+    [isAuthenticated, storeAssignWeapon, saveAfterMutation],
+  );
+
+  const removeWeapon = useCallback(
+    (slot: TeamSlot, memberIndex: number) => {
+      const previousTeam = { ...useTeamStore.getState().teams[slot] };
+      storeRemoveWeapon(slot, memberIndex);
+      if (isAuthenticated) {
+        saveAfterMutation(slot, previousTeam);
+      }
+    },
+    [isAuthenticated, storeRemoveWeapon, saveAfterMutation],
+  );
+
+  const setArtifactPlan = useCallback(
+    (slot: TeamSlot, memberIndex: number, plan: ArtifactPlan | undefined) => {
+      const previousTeam = { ...useTeamStore.getState().teams[slot] };
+      storeSetArtifactPlan(slot, memberIndex, plan);
+      if (isAuthenticated) {
+        saveAfterMutation(slot, previousTeam);
+      }
+    },
+    [isAuthenticated, storeSetArtifactPlan, saveAfterMutation],
+  );
+
+  const clearTeam = useCallback(
+    (slot: TeamSlot) => {
+      const previousTeam = { ...useTeamStore.getState().teams[slot] };
+      storeClearTeam(slot);
+      if (isAuthenticated) {
+        deleteTeamApi(slot, {
+          onError: () => {
+            storeSetTeam(slot, previousTeam);
+            toast.error('Failed to clear team. Change has been reverted.');
+          },
+        });
+      }
+    },
+    [isAuthenticated, storeClearTeam, deleteTeamApi, storeSetTeam],
+  );
+
+  const setTeamName = useCallback(
+    (slot: TeamSlot, name: string) => {
+      const previousTeam = { ...useTeamStore.getState().teams[slot] };
+      storeSetTeamName(slot, name);
+      if (isAuthenticated) {
+        saveAfterMutation(slot, previousTeam);
+      }
+    },
+    [isAuthenticated, storeSetTeamName, saveAfterMutation],
+  );
+
+  const getTeam = useCallback((slot: TeamSlot) => teams[slot], [teams]);
+
+  const isCharacterInTeam = useCallback(
+    (slot: TeamSlot, characterId: string) =>
+      teams[slot].members.some((m) => m?.characterId === characterId),
+    [teams],
+  );
+
+  const error = isAuthenticated ? (queryError ?? null) : null;
+
+  return {
+    teams,
+    assignCharacter,
+    removeCharacter,
+    assignWeapon,
+    removeWeapon,
+    setArtifactPlan,
+    clearTeam,
+    setTeamName,
+    getTeam,
+    isCharacterInTeam,
+    isSaving,
+    isLoading: authLoading || (isAuthenticated && queryLoading),
+    error,
+  };
+}

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -12,7 +12,7 @@ import { useWeaponCollection } from '@/features/collection/weapons/useWeaponColl
 import { CharacterPool } from '@/features/teams/CharacterPool';
 import { TeamPlanner } from '@/features/teams/TeamPlanner';
 import { WeaponPool } from '@/features/teams/WeaponPool';
-import { useTeamStore } from '@/features/teams/useTeamStore';
+import { useTeams } from '@/features/teams/useTeams';
 
 type SheetTab = 'characters' | 'weapons';
 
@@ -31,13 +31,15 @@ export function TeamsPage() {
   const [selectedSlot, setSelectedSlot] = useState<TeamSlot | null>(null);
   const [selectedMemberIndex, setSelectedMemberIndex] = useState<number | null>(null);
 
-  const teams = useTeamStore((s) => s.teams);
-  const assignCharacter = useTeamStore((s) => s.assignCharacter);
-  const removeCharacter = useTeamStore((s) => s.removeCharacter);
-  const setTeamName = useTeamStore((s) => s.setTeamName);
-  const assignWeapon = useTeamStore((s) => s.assignWeapon);
-  const removeWeapon = useTeamStore((s) => s.removeWeapon);
-  const setArtifactPlan = useTeamStore((s) => s.setArtifactPlan);
+  const {
+    teams,
+    assignCharacter,
+    removeCharacter,
+    setTeamName,
+    assignWeapon,
+    removeWeapon,
+    setArtifactPlan,
+  } = useTeams();
 
   const selectedTeam = selectedSlot !== null ? teams[selectedSlot] : null;
 


### PR DESCRIPTION
## Summary

Adds TanStack Query hooks and an orchestrator hook to load and save team compositions through the team CRUD API, so teams survive page refreshes and sync across devices.

Closes #606

## Changes

- **`useTeamApi.ts`** (new): TanStack Query hooks following the character/weapon collection pattern
  - `useTeamsQuery(userId)`: fetches all teams via `GET /api/teams`, parses Collection+JSON using `deserialiseTeam`
  - `useSaveTeamMutation(userId)`: `PUT /api/teams/:slot` to upsert a team, invalidates query on success
  - `useDeleteTeamMutation(userId)`: `DELETE /api/teams/:slot`, invalidates query on success
  - Query key: `['teams', userId]`

- **`useTeams.ts`** (new): Orchestrator combining `useTeamStore` + `useTeamApi`
  - On query resolution: populates the zustand store with server data
  - On store mutations (assign, remove, weapon, artifact, name): fires save mutation
  - Optimistic updates with rollback on failure, toast error notifications
  - Unauthenticated users work locally without API calls
  - `isSaving` flag exposed for UI indicators
  - `beforeunload` warning when saves are in flight

- **`useTeamStore.ts`** (modified): Added `setTeam`, `setTeams`, and `resetTeams` actions for API sync and rollback

- **`TeamsPage.tsx`** (modified): Replaced direct `useTeamStore` access with `useTeams` orchestrator

## Known limitations

- Member slot positions shift after save/reload when gaps exist (#637)
- Weapons can be assigned across teams to different characters (#635)
- Clicking a team member doesn't open the editor sheet pre-selected (#636)

## Testing

- Typecheck passes (`pnpm turbo run typecheck --filter=@genshin/web`)
- Lint passes (`pnpm --filter @genshin/web lint`)
- Manual testing confirms teams persist across page refreshes when logged in
- Pre-commit hooks pass