### PR TITLE
feat(web): improve visual distinction between owned and unowned weapons

### DIFF
--- a/apps/web/src/features/collection/weapons/WeaponCard.tsx
+++ b/apps/web/src/features/collection/weapons/WeaponCard.tsx
@@ -4,7 +4,7 @@
 import type { Weapon } from '@genshin/game-data';
 
 import { WeaponSummary } from '@/components/WeaponSummary';
-import { RARITY_BORDER_COLORS, RARITY_BORDER_COLORS_DIM } from '@/lib/rarityStyles';
+import { RARITY_BORDER_COLORS } from '@/lib/rarityStyles';
 import { cn } from '@/lib/utils';
 
 interface WeaponCardProps {
@@ -16,7 +16,6 @@ interface WeaponCardProps {
 
 export function WeaponCard({ weapon, instanceCount, selected = false, onClick }: WeaponCardProps) {
   const owned = instanceCount > 0;
-  const borderColors = owned ? RARITY_BORDER_COLORS : RARITY_BORDER_COLORS_DIM;
 
   return (
     <button
@@ -24,7 +23,7 @@ export function WeaponCard({ weapon, instanceCount, selected = false, onClick }:
       onClick={() => onClick?.(weapon.id)}
       className={cn(
         'relative flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
-        borderColors[weapon.rarity] ?? 'border-l-border',
+        owned ? (RARITY_BORDER_COLORS[weapon.rarity] ?? 'border-l-border') : 'border-l-border',
         selected && 'ring-2 ring-primary ring-offset-2 ring-offset-background',
         'cursor-pointer hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       )}

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -10,7 +10,7 @@ import { WeaponSummary } from '@/components/WeaponSummary';
 import type { WeaponFilterState } from '@/features/collection/weapons/filtering';
 import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
 import { WeaponFilters } from '@/features/collection/weapons/WeaponFilters';
-import { RARITY_BORDER_COLORS, RARITY_BORDER_COLORS_DIM } from '@/lib/rarityStyles';
+import { RARITY_BORDER_COLORS } from '@/lib/rarityStyles';
 import { cn } from '@/lib/utils';
 
 function poolFilterState(weaponType: WeaponType): WeaponFilterState {
@@ -115,15 +115,13 @@ interface PoolWeaponCardProps {
 }
 
 function PoolWeaponCard({ weapon, refinementLevel, selected, onClick }: PoolWeaponCardProps) {
-  const borderColors = selected ? RARITY_BORDER_COLORS : RARITY_BORDER_COLORS_DIM;
-
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
         'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
-        borderColors[weapon.rarity] ?? 'border-l-border',
+        selected ? (RARITY_BORDER_COLORS[weapon.rarity] ?? 'border-l-border') : 'border-l-border',
         'cursor-pointer hover:bg-accent/50',
       )}
       aria-label={selected ? `Remove ${weapon.name} from team` : `Assign ${weapon.name} to team`}

--- a/apps/web/src/lib/rarityStyles.ts
+++ b/apps/web/src/lib/rarityStyles.ts
@@ -10,11 +10,3 @@ export const RARITY_BORDER_COLORS: Record<Rarity, string> = {
   2: 'border-l-muted-foreground',
   1: 'border-l-muted-foreground',
 };
-
-export const RARITY_BORDER_COLORS_DIM: Record<Rarity, string> = {
-  5: 'border-l-geo-dark/30',
-  4: 'border-l-geo/30',
-  3: 'border-l-muted-foreground/30',
-  2: 'border-l-muted-foreground/30',
-  1: 'border-l-muted-foreground/30',
-};


### PR DESCRIPTION
## Summary

Drop the dim rarity border for unowned weapons in favour of a plain border, matching the owned/unowned pattern already used by character cards. Owned weapons stand out via their rarity-coloured left border while unowned cards recede with a neutral border and dimmed content.

## Changes

- **WeaponCard**: show rarity border only when owned
- **PoolWeaponCard**: show rarity border only when selected
- **rarityStyles**: remove unused `RARITY_BORDER_COLORS_DIM`

Closes #618