### PR TITLE
feat(web): simplify branding to Genshin Planner

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
   // SPDX-License-Identifier: MIT
-  "name": "Genshin Team Builder",
+  "name": "Genshin Planner",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
 
   "features": {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SPDX-License-Identifier: MIT
 <!-- vale Google.Acronyms = YES -->
 <!-- markdownlint-enable MD041 -->
 
-# Genshin team builder
+# Genshin Planner
 
 By [Alex Brandt](https://github.com/alunduil) · [Repository](https://github.com/dungeon-studio/genshin.dungeon.studio)
 
@@ -24,7 +24,7 @@ By [Alex Brandt](https://github.com/alunduil) · [Repository](https://github.com
 
 ## About
 
-Experiment with team compositions without the spreadsheets. Genshin Team Builder is an early stage project that aims to let you describe your character collection to an AI assistant and, when implemented, get personalized team recommendations. Whether you're optimizing for Abyss clears or just want to try new playstyles, the goal is to provide suggestions tailored to _your_ roster.
+Experiment with team compositions without the spreadsheets. Genshin Planner is an early stage project that aims to let you describe your character collection to an AI assistant and, when implemented, get personalized team recommendations. Whether you're optimizing for Abyss clears or just want to try new playstyles, the goal is to provide suggestions tailored to _your_ roster.
 
 ## Who's it for
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,10 +5,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      name="description"
-      content="AI-powered Genshin Impact team builder — track your collection and get personalized recommendations based on your characters."
-    />
+    <meta name="description" content="Plan your Genshin Impact teams and manage your collection." />
     <meta name="theme-color" content="#1a1a2e" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link
@@ -26,7 +23,7 @@
       media="(prefers-color-scheme: dark)"
     />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <title>Genshin Team Builder | genshin.dungeon.studio</title>
+    <title>Genshin Planner | genshin.dungeon.studio</title>
   </head>
   <body>
     <script>

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
     <footer className="border-t border-border bg-muted py-8">
       <div className="mx-auto max-w-7xl px-4 text-center text-sm text-muted-foreground">
         <p>Built with React 19 + TypeScript + Vite</p>
-        <p className="mt-2 text-xs text-muted-foreground/70">© 2026 Genshin Team Builder</p>
+        <p className="mt-2 text-xs text-muted-foreground/70">© 2026 Dungeon Studio</p>
       </div>
     </footer>
   );

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -32,7 +32,7 @@ export function Header() {
             height={32}
             className="hidden dark:block"
           />
-          Genshin Team Builder
+          Genshin Planner
         </Link>
         <div className="flex items-center gap-3">
           {!loading && (user ? <UserMenu user={user} /> : <LoginButton />)}

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -5,9 +5,9 @@ export function HomePage() {
   return (
     <div className="mx-auto max-w-7xl px-4 py-12">
       <div className="text-center">
-        <h1 className="text-4xl font-bold text-foreground">Welcome to Genshin Team Builder</h1>
+        <h1 className="text-4xl font-bold text-foreground">Welcome to Genshin Planner</h1>
         <p className="mt-4 text-lg text-muted-foreground">
-          AI-powered team building companion for Genshin Impact
+          Plan your teams and manage your collection
         </p>
       </div>
 

--- a/infrastructure/terraform/environments/dev/web.tf
+++ b/infrastructure/terraform/environments/dev/web.tf
@@ -49,7 +49,7 @@ resource "google_firebase_hosting_custom_domain" "web" {
 resource "google_firebase_web_app" "web" {
   provider     = google-beta
   project      = var.gcp_dev_project_id
-  display_name = "Genshin Team Builder (dev)"
+  display_name = "Genshin Planner (dev)"
 
   depends_on = [google_firebase_project.default]
 }


### PR DESCRIPTION
## Summary

Simplify user-facing branding from "Genshin Team Builder" to **Genshin Planner**.

## Changes

- **`index.html`**: Updated `<title>` and meta description
- **`Header.tsx`**: Brand text → Genshin Planner
- **`Footer.tsx`**: Copyright → Dungeon Studio
- **`HomePage.tsx`**: Welcome heading and subtitle
- **`devcontainer.json`**: Container name
- **`README.md`**: Project heading and about text
- **`web.tf`**: Firebase display name (dev)

Closes #619