### PR TITLE
fix(infra): add firebase.clients.update to RW deployer role

### DIFF
--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -48,6 +48,7 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "firebase.clients.delete",
     "firebase.clients.get",
     "firebase.clients.list",
+    "firebase.clients.update",
     "firebase.projects.get",
     "firebase.projects.update",
     "firebaseauth.configs.create",


### PR DESCRIPTION
The `githubDeployerApplier` custom role was missing `firebase.clients.update`, which caused the dev `terraform-apply` workflow to fail with a 403 when PR #641 renamed the Firebase Web App display name.

### What changed
Added `firebase.clients.update` to the RW custom role in `infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf`.

### How verified
- Bootstrap applied successfully
- Dev environment `terraform apply` succeeded after the role update