### PR TITLE
feat(web): replace footer tech stack text with user-facing links

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -10,7 +10,7 @@ export function Footer() {
     <footer className="border-t border-border bg-muted py-8">
       <div className="mx-auto max-w-7xl px-4 text-center text-sm text-muted-foreground">
         <nav aria-label="Footer">
-          <ul className="flex justify-center gap-6">
+          <ul className="flex flex-wrap justify-center gap-x-6 gap-y-2">
             <li>
               <a
                 href={`${GITHUB_REPO}/issues/new?template=bug-report.yml`}

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,12 +1,62 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { GAME_DATA_VERSION } from '@genshin/game-data';
+
+const GITHUB_REPO = 'https://github.com/dungeon-studio/genshin.dungeon.studio';
+
 export function Footer() {
   return (
     <footer className="border-t border-border bg-muted py-8">
       <div className="mx-auto max-w-7xl px-4 text-center text-sm text-muted-foreground">
-        <p>Built with React 19 + TypeScript + Vite</p>
-        <p className="mt-2 text-xs text-muted-foreground/70">© 2026 Dungeon Studio</p>
+        <nav aria-label="Footer">
+          <ul className="flex justify-center gap-6">
+            <li>
+              <a
+                href={`${GITHUB_REPO}/issues/new?template=bug-report.yml`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-offset-4 hover:underline"
+              >
+                Report an issue
+              </a>
+            </li>
+            <li>
+              <a
+                href={`${GITHUB_REPO}/issues/new?template=feature-request.yml`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-offset-4 hover:underline"
+              >
+                Request a feature
+              </a>
+            </li>
+            <li>
+              <a
+                href={`${GITHUB_REPO}/discussions`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-offset-4 hover:underline"
+              >
+                Discussions
+              </a>
+            </li>
+            <li>
+              <a
+                href={GITHUB_REPO}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-offset-4 hover:underline"
+              >
+                GitHub
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <p className="mt-4 text-xs text-muted-foreground/70">
+          Game data current as of {GAME_DATA_VERSION}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground/70">© 2026 Dungeon Studio</p>
       </div>
     </footer>
   );

--- a/packages/game-data/src/index.ts
+++ b/packages/game-data/src/index.ts
@@ -66,4 +66,4 @@ export {
 } from './artifacts.js';
 
 // Versions
-export { compareVersions } from './versions.js';
+export { compareVersions, GAME_DATA_VERSION } from './versions.js';

--- a/packages/game-data/src/versions.test.ts
+++ b/packages/game-data/src/versions.test.ts
@@ -3,7 +3,8 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { compareVersions } from './versions.js';
+import { CHARACTERS } from './characters.js';
+import { compareVersions, GAME_DATA_VERSION } from './versions.js';
 
 describe('compareVersions', () => {
   describe('numeric versions', () => {
@@ -47,6 +48,20 @@ describe('compareVersions', () => {
     it('places Luna versions after numeric versions', () => {
       expect(compareVersions('5.8', 'Luna I')).toBeLessThan(0);
       expect(compareVersions('Luna I', '5.8')).toBeGreaterThan(0);
+    });
+  });
+
+  describe('GAME_DATA_VERSION', () => {
+    it('is a valid version string for compareVersions', () => {
+      expect(() => compareVersions(GAME_DATA_VERSION, '1.0')).not.toThrow();
+    });
+
+    it('is >= the latest version in CHARACTERS', () => {
+      const maxCharacterVersion = CHARACTERS.reduce(
+        (max, c) => (compareVersions(c.version, max) > 0 ? c.version : max),
+        CHARACTERS[0].version,
+      );
+      expect(compareVersions(GAME_DATA_VERSION, maxCharacterVersion)).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/packages/game-data/src/versions.ts
+++ b/packages/game-data/src/versions.ts
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+/** The game version the static data in this package covers. */
+export const GAME_DATA_VERSION = 'Luna IV';
+
 // Luna versions map to [major, minor] tuples in the 6.x series (after 5.x, the last numeric era).
 const LUNA_VERSIONS: Record<string, readonly [number, number]> = {
   'Luna I': [6, 0],


### PR DESCRIPTION
## Summary

Replaces the footer's "Built with React 19 + TypeScript + Vite" text with user-facing links and a game data version indicator.

## Changes

- **`apps/web/src/components/Footer.tsx`** — Footer now contains:
  - Report an issue (links to bug report template)
  - Request a feature (links to feature request template)
  - Discussions (links to GitHub Discussions)
  - GitHub (links to repository)
  - Game data version indicator ("Game data current as of Luna IV")
  - Copyright line preserved
- **`packages/game-data/src/versions.ts`** — Added `GAME_DATA_VERSION` constant
- **`packages/game-data/src/index.ts`** — Exported `GAME_DATA_VERSION`

## Follow-up issues

- #645 — Release notes / changelog link (0.1.0)
- #647 — Privacy policy & terms of service (1.0.0)
- #648 — Status page link (1.0.0)

Closes #621