### PR TITLE
fix(web): clean up navigation after home page removal

### DIFF
--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -16,7 +16,7 @@ export function NotFoundPage() {
           to="/"
           className="mt-6 inline-block rounded-md bg-primary px-6 py-3 text-primary-foreground transition hover:bg-primary/90"
         >
-          Back to Home
+          Back to Teams
         </Link>
       </div>
     </div>


### PR DESCRIPTION
### Summary

Update the 404 page link text from "Back to Home" to "Back to Teams" to reflect that `/` now renders TeamsPage.

### What changed

- **`NotFoundPage.tsx`**: Changed link text from "Back to Home" to "Back to Teams"

### What was already clean

The navigation bar was already streamlined by prior work (#603):
- Three clear nav links: Teams, Characters, Weapons
- No redundant "Home" link
- Active state highlights correctly via `NavLink` with `end` prop

### Acceptance criteria

- [x] No redundant nav links
- [x] Active state highlights correctly on all routes
- [x] Typecheck and lint pass

Closes #623