### PR TITLE
feat(web): make team editing sheet responsive on small screens

### DIFF
--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -43,7 +43,7 @@ export function CharacterPool({ characters, assignedIds, disabled, onAssign }: C
   }, [filters, ownedIds]);
 
   return (
-    <div className="space-y-3">
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
       <CharacterFilters
         filters={filters}
         onChange={handleFilterChange}
@@ -54,30 +54,34 @@ export function CharacterPool({ characters, assignedIds, disabled, onAssign }: C
         showOwnership={false}
       />
 
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {filteredCharacters.map((character) => {
-          const owned = ownedIds.has(character.id);
-          const assigned = assignedIds.has(character.id);
-          const clickable = !disabled && owned;
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filteredCharacters.map((character) => {
+            const owned = ownedIds.has(character.id);
+            const assigned = assignedIds.has(character.id);
+            const clickable = !disabled && owned;
 
-          const entry = characters[character.id];
+            const entry = characters[character.id];
 
-          return (
-            <PoolCharacterCard
-              key={character.id}
-              character={character}
-              constellationLevel={entry?.constellationLevel ?? 0}
-              assigned={assigned}
-              disabled={!clickable}
-              onClick={() => onAssign(character.id)}
-            />
-          );
-        })}
+            return (
+              <PoolCharacterCard
+                key={character.id}
+                character={character}
+                constellationLevel={entry?.constellationLevel ?? 0}
+                assigned={assigned}
+                disabled={!clickable}
+                onClick={() => onAssign(character.id)}
+              />
+            );
+          })}
+        </div>
+
+        {filteredCharacters.length === 0 && (
+          <p className="py-8 text-center text-muted-foreground">
+            No characters match your filters.
+          </p>
+        )}
       </div>
-
-      {filteredCharacters.length === 0 && (
-        <p className="py-8 text-center text-muted-foreground">No characters match your filters.</p>
-      )}
     </div>
   );
 }

--- a/apps/web/src/features/teams/TeamPlanner.tsx
+++ b/apps/web/src/features/teams/TeamPlanner.tsx
@@ -102,7 +102,7 @@ export function TeamPlanner({
           <button
             type="button"
             onClick={onEdit}
-            className="ml-auto rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
+            className="ml-auto hidden rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-primary hover:text-primary-foreground sm:block"
             aria-label={`Edit ${name}`}
           >
             Edit

--- a/apps/web/src/features/teams/TeamStrip.tsx
+++ b/apps/web/src/features/teams/TeamStrip.tsx
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Team } from '@genshin/domain';
+import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+import { getCharacterById } from '@genshin/game-data';
+import { UserRound } from 'lucide-react';
+
+import { getElementIconPath } from '@/lib/elements';
+import { ELEMENT_BORDER_ALL_COLORS } from '@/lib/elementStyles';
+import { cn } from '@/lib/utils';
+
+interface TeamStripProps {
+  members: Team['members'];
+  selectedIndex: number | null;
+  onSelect: (index: number) => void;
+}
+
+export function TeamStrip({ members, selectedIndex, onSelect }: TeamStripProps) {
+  const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
+
+  return (
+    <div className="flex items-center justify-center gap-3 border-b border-border py-3 sm:hidden">
+      {slots.map((member, i) => {
+        const character = member ? getCharacterById(member.characterId) : undefined;
+
+        const selected = selectedIndex === i;
+        const borderClass =
+          selected && character
+            ? ELEMENT_BORDER_ALL_COLORS[character.element]
+            : selected
+              ? 'border-primary'
+              : 'border-transparent';
+
+        return (
+          <button
+            key={i}
+            type="button"
+            onClick={() => onSelect(i)}
+            className={cn(
+              'flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-muted border-2 transition-colors',
+              borderClass,
+            )}
+            aria-label={character ? `Select ${character.name}` : `Select empty slot ${i + 1}`}
+            aria-pressed={selectedIndex === i}
+          >
+            {character ? (
+              <img
+                src={getElementIconPath(character.element)}
+                alt={character.element}
+                className="h-6 w-6"
+              />
+            ) : (
+              <UserRound
+                className="h-5 w-5 text-muted-foreground/40"
+                aria-hidden="true"
+                focusable={false}
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -67,7 +67,7 @@ export function WeaponPool({
   }, [collectionWeapons]);
 
   return (
-    <div className="space-y-3">
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
       <WeaponFilters
         filters={filters}
         onChange={handleFilterChange}
@@ -79,30 +79,32 @@ export function WeaponPool({
         showWeaponTypes={false}
       />
 
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {filteredWeapons.flatMap((weapon) => {
-          const instances = instancesByWeaponId.get(weapon.id) ?? [];
-          return instances.map((instance) => (
-            <PoolWeaponCard
-              key={instance.weaponInstanceId}
-              weapon={weapon}
-              refinementLevel={instance.refinementLevel}
-              selected={instance.weaponInstanceId === selectedCollectionWeaponId}
-              onClick={() => {
-                if (instance.weaponInstanceId === selectedCollectionWeaponId) {
-                  onClear();
-                } else {
-                  onSelect(instance.weaponInstanceId);
-                }
-              }}
-            />
-          ));
-        })}
-      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filteredWeapons.flatMap((weapon) => {
+            const instances = instancesByWeaponId.get(weapon.id) ?? [];
+            return instances.map((instance) => (
+              <PoolWeaponCard
+                key={instance.weaponInstanceId}
+                weapon={weapon}
+                refinementLevel={instance.refinementLevel}
+                selected={instance.weaponInstanceId === selectedCollectionWeaponId}
+                onClick={() => {
+                  if (instance.weaponInstanceId === selectedCollectionWeaponId) {
+                    onClear();
+                  } else {
+                    onSelect(instance.weaponInstanceId);
+                  }
+                }}
+              />
+            ));
+          })}
+        </div>
 
-      {filteredWeapons.length === 0 && (
-        <p className="py-8 text-center text-muted-foreground">No weapons match your filters.</p>
-      )}
+        {filteredWeapons.length === 0 && (
+          <p className="py-8 text-center text-muted-foreground">No weapons match your filters.</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/elementStyles.ts
+++ b/apps/web/src/lib/elementStyles.ts
@@ -52,3 +52,13 @@ export const ELEMENT_BG_COLORS: Record<Element, string> = {
   Geo: 'bg-geo-dark text-white',
   Dendro: 'bg-dendro-dark text-white',
 };
+
+export const ELEMENT_BORDER_ALL_COLORS: Record<Element, string> = {
+  Pyro: 'border-pyro',
+  Hydro: 'border-hydro',
+  Electro: 'border-electro',
+  Cryo: 'border-cryo',
+  Anemo: 'border-anemo',
+  Geo: 'border-geo',
+  Dendro: 'border-dendro',
+};

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -11,6 +11,7 @@ import { useCollection } from '@/features/collection/characters/useCharacterColl
 import { useWeaponCollection } from '@/features/collection/weapons/useWeaponCollection';
 import { CharacterPool } from '@/features/teams/CharacterPool';
 import { TeamPlanner } from '@/features/teams/TeamPlanner';
+import { TeamStrip } from '@/features/teams/TeamStrip';
 import { WeaponPool } from '@/features/teams/WeaponPool';
 import { useTeams } from '@/features/teams/useTeams';
 
@@ -110,6 +111,10 @@ export function TeamsPage() {
                 setSelectedSlot(slot);
                 setSelectedMemberIndex(null);
               }}
+              onMemberSelect={(memberIndex) => {
+                setSelectedSlot(slot);
+                setSelectedMemberIndex(memberIndex);
+              }}
             />
           </section>
         ))}
@@ -127,23 +132,31 @@ export function TeamsPage() {
       >
         <SheetContent
           side="bottom"
-          className="mx-auto flex w-full max-w-7xl flex-col overflow-y-auto rounded-t-xl top-[124px]"
+          className="mx-auto flex w-full max-w-7xl flex-col overflow-hidden rounded-t-xl top-0 sm:top-[124px]"
         >
           {selectedSlot !== null && selectedTeam && (
             <>
-              <TeamPlanner
-                slot={selectedSlot}
-                name={selectedTeam.name}
+              <TeamStrip
                 members={selectedTeam.members}
-                getCharacter={getCharacter}
-                getCollectionWeapon={getCollectionWeapon}
-                selectedMemberIndex={selectedMemberIndex}
-                onMemberSelect={setSelectedMemberIndex}
-                onNameChange={(name) => setTeamName(selectedSlot, name)}
-                onArtifactPlanChange={(memberIndex, plan) =>
-                  setArtifactPlan(selectedSlot, memberIndex, plan)
-                }
+                selectedIndex={selectedMemberIndex}
+                onSelect={setSelectedMemberIndex}
               />
+
+              <div className="hidden sm:block">
+                <TeamPlanner
+                  slot={selectedSlot}
+                  name={selectedTeam.name}
+                  members={selectedTeam.members}
+                  getCharacter={getCharacter}
+                  getCollectionWeapon={getCollectionWeapon}
+                  selectedMemberIndex={selectedMemberIndex}
+                  onMemberSelect={setSelectedMemberIndex}
+                  onNameChange={(name) => setTeamName(selectedSlot, name)}
+                  onArtifactPlanChange={(memberIndex, plan) =>
+                    setArtifactPlan(selectedSlot, memberIndex, plan)
+                  }
+                />
+              </div>
 
               <nav className="mt-4 flex gap-4 border-b border-border" aria-label="Team editor tabs">
                 <button
@@ -172,7 +185,7 @@ export function TeamsPage() {
                 </button>
               </nav>
 
-              <div className="mt-3 flex-1">
+              <div className="mt-3 flex min-h-0 flex-1 flex-col">
                 {activeTab === 'characters' && (
                   <CharacterPool
                     characters={characters}


### PR DESCRIPTION
## Summary

Make the team editing sheet usable on small screens by adding a compact mobile slot strip, full-height sheet, and independent pool scrolling.

## Changes

- **TeamStrip** — new component showing 4 element-icon circles for slot selection on mobile (`sm:hidden`)
- **Full-height sheet** — on mobile the sheet fills the viewport (`top-0`); on desktop it starts below the header (`sm:top-[124px]`)
- **Pool scroll isolation** — only the character/weapon card grids scroll; filters and tabs stay pinned
- **Tap-to-select** — tapping a team member card on the main page opens the sheet with that member pre-selected
- **Edit button hidden on mobile** — member cards are tapped directly, so the separate Edit button is unnecessary below `sm`
- **ELEMENT_BORDER_ALL_COLORS** — new element style map for full-border coloring on the strip

## Issues

Closes #626
Closes #636