### PR TITLE
feat: prevent weapon from being equipped by different characters across teams

### DIFF
--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -425,6 +425,21 @@ describe('Team routes', () => {
         expect(body.detail).toContain('Weapon instance not in collection');
       });
 
+      it('returns 400 when duplicate weapon instance IDs in same team', async () => {
+        const res = await app.request(
+          authedRequest('PUT', '/api/teams/1', {
+            members: [
+              { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
+              { characterId: 'xingqiu', weaponInstanceId: 'uuid-1' },
+            ],
+          }),
+        );
+
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { detail: string };
+        expect(body.detail).toContain('Duplicate weapon instance IDs in team');
+      });
+
       it('returns 400 when weapon equipped by different character in another team', async () => {
         vi.mocked(listTeams).mockResolvedValue([
           {

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -211,6 +211,7 @@ describe('Team routes', () => {
     beforeEach(() => {
       mockCharacterOwned();
       mockWeaponOwned();
+      vi.mocked(listTeams).mockResolvedValue([]);
     });
 
     let res: Response;
@@ -422,6 +423,51 @@ describe('Team routes', () => {
         expect(res.status).toBe(400);
         const body = (await res.json()) as { detail: string };
         expect(body.detail).toContain('Weapon instance not in collection');
+      });
+
+      it('returns 400 when weapon equipped by different character in another team', async () => {
+        vi.mocked(listTeams).mockResolvedValue([
+          {
+            ...FAKE_TEAM,
+            slot: 2,
+            members: [{ characterId: 'ganyu', weaponInstanceId: 'uuid-1' as UUID }],
+          },
+        ]);
+
+        const res = await app.request(
+          authedRequest('PUT', '/api/teams/1', {
+            members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }],
+          }),
+        );
+
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { detail: string };
+        expect(body.detail).toContain('already equipped by character');
+      });
+
+      it('allows same character to carry same weapon across teams', async () => {
+        vi.mocked(listTeams).mockResolvedValue([
+          {
+            ...FAKE_TEAM,
+            slot: 2,
+            members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' as UUID }],
+          },
+        ]);
+        vi.mocked(saveTeam).mockResolvedValue({
+          team: {
+            ...FAKE_TEAM,
+            members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' as UUID }],
+          },
+          created: false,
+        });
+
+        const res = await app.request(
+          authedRequest('PUT', '/api/teams/1', {
+            members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }],
+          }),
+        );
+
+        expect(res.status).toBe(200);
       });
 
       it('returns 400 for unknown artifact set', async () => {

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -136,6 +136,12 @@ async function validateMembers(userId: string, members: TeamMember[]): Promise<v
     throw new HTTPException(400, { message: 'Duplicate character IDs in team' });
   }
 
+  // No duplicate weapon instance IDs
+  const weaponIds = members.filter((m) => m.weaponInstanceId).map((m) => m.weaponInstanceId!);
+  if (new Set(weaponIds).size !== weaponIds.length) {
+    throw new HTTPException(400, { message: 'Duplicate weapon instance IDs in team' });
+  }
+
   await Promise.all(
     members.map(async (member) => {
       // Character must be in user's collection

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -21,6 +21,7 @@ import {
   teamItemDocument,
   teamListDocument,
   validateArtifactPlan,
+  validateTeams,
 } from '@genshin/domain';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -93,6 +94,14 @@ teams.put(
 
     if (body.members && body.members.length > 0) {
       await validateMembers(userId, body.members);
+
+      // Cross-team weapon uniqueness: a weapon instance can only be equipped
+      // by one character at a time across all teams (#635).
+      const allTeams = await listTeams(userId);
+      const crossTeamIssues = validateTeams(slot, body.members, allTeams);
+      if (crossTeamIssues.length > 0) {
+        throw new HTTPException(400, { message: crossTeamIssues[0].message });
+      }
     }
 
     const { team, created } = await saveTeam(userId, slot, {

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -1,17 +1,32 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
+import type { CollectionWeapon, CollectionWeaponId, Team, TeamSlot } from '@genshin/domain';
+import { TEAM_SLOTS } from '@genshin/domain';
 import type { Weapon, WeaponType } from '@genshin/game-data';
 import { WEAPONS } from '@genshin/game-data';
+import { Lock } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { WeaponSummary } from '@/components/WeaponSummary';
 import type { WeaponFilterState } from '@/features/collection/weapons/filtering';
 import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
 import { WeaponFilters } from '@/features/collection/weapons/WeaponFilters';
+import { useTeamStore } from '@/features/teams/useTeamStore';
 import { RARITY_BORDER_COLORS } from '@/lib/rarityStyles';
 import { cn } from '@/lib/utils';
+
+function buildEquippedWeapons(teams: Record<TeamSlot, Team>): Map<CollectionWeaponId, string> {
+  const map = new Map<CollectionWeaponId, string>();
+  for (const slot of TEAM_SLOTS) {
+    for (const m of teams[slot].members) {
+      if (m?.weaponInstanceId) {
+        map.set(m.weaponInstanceId, m.characterId);
+      }
+    }
+  }
+  return map;
+}
 
 function poolFilterState(weaponType: WeaponType): WeaponFilterState {
   return { ...initialFilterState(), ownership: 'owned', weaponTypes: new Set([weaponType]) };
@@ -21,6 +36,8 @@ interface WeaponPoolProps {
   collectionWeapons: CollectionWeapon[];
   weaponType: WeaponType;
   selectedCollectionWeaponId?: CollectionWeaponId;
+  slot: TeamSlot;
+  memberIndex: number;
   onSelect: (collectionWeaponId: CollectionWeaponId) => void;
   onClear: () => void;
 }
@@ -29,9 +46,14 @@ export function WeaponPool({
   collectionWeapons,
   weaponType,
   selectedCollectionWeaponId,
+  slot,
+  memberIndex,
   onSelect,
   onClear,
 }: WeaponPoolProps) {
+  const teams = useTeamStore((s) => s.teams);
+  const currentCharacterId = teams[slot].members[memberIndex]?.characterId;
+  const equippedWeapons = useMemo(() => buildEquippedWeapons(teams), [teams]);
   const [filters, setFilters] = useState<WeaponFilterState>(() => poolFilterState(weaponType));
 
   function handleFilterChange(next: WeaponFilterState) {
@@ -83,21 +105,26 @@ export function WeaponPool({
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {filteredWeapons.flatMap((weapon) => {
             const instances = instancesByWeaponId.get(weapon.id) ?? [];
-            return instances.map((instance) => (
-              <PoolWeaponCard
-                key={instance.weaponInstanceId}
-                weapon={weapon}
-                refinementLevel={instance.refinementLevel}
-                selected={instance.weaponInstanceId === selectedCollectionWeaponId}
-                onClick={() => {
-                  if (instance.weaponInstanceId === selectedCollectionWeaponId) {
-                    onClear();
-                  } else {
-                    onSelect(instance.weaponInstanceId);
-                  }
-                }}
-              />
-            ));
+            return instances.map((instance) => {
+              const equippedBy = equippedWeapons.get(instance.weaponInstanceId);
+              const equippedByOther = equippedBy !== undefined && equippedBy !== currentCharacterId;
+              return (
+                <PoolWeaponCard
+                  key={instance.weaponInstanceId}
+                  weapon={weapon}
+                  refinementLevel={instance.refinementLevel}
+                  selected={instance.weaponInstanceId === selectedCollectionWeaponId}
+                  equipped={equippedByOther}
+                  onClick={() => {
+                    if (instance.weaponInstanceId === selectedCollectionWeaponId) {
+                      onClear();
+                    } else {
+                      onSelect(instance.weaponInstanceId);
+                    }
+                  }}
+                />
+              );
+            });
           })}
         </div>
 
@@ -113,23 +140,45 @@ interface PoolWeaponCardProps {
   weapon: Weapon;
   refinementLevel: number;
   selected: boolean;
+  equipped: boolean;
   onClick: () => void;
 }
 
-function PoolWeaponCard({ weapon, refinementLevel, selected, onClick }: PoolWeaponCardProps) {
+function weaponCardLabel(weapon: Weapon, equipped: boolean, selected: boolean): string {
+  if (equipped) return `${weapon.name} is equipped by another character`;
+  if (selected) return `Remove ${weapon.name} from character`;
+  return `Assign ${weapon.name} to character`;
+}
+
+function PoolWeaponCard({
+  weapon,
+  refinementLevel,
+  selected,
+  equipped,
+  onClick,
+}: PoolWeaponCardProps) {
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={equipped ? undefined : onClick}
+      disabled={equipped}
       className={cn(
         'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
         selected ? (RARITY_BORDER_COLORS[weapon.rarity] ?? 'border-l-border') : 'border-l-border',
-        'cursor-pointer hover:bg-accent/50',
+        equipped ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-accent/50',
       )}
-      aria-label={selected ? `Remove ${weapon.name} from team` : `Assign ${weapon.name} to team`}
+      aria-label={weaponCardLabel(weapon, equipped, selected)}
       aria-pressed={selected}
     >
-      <WeaponSummary weapon={weapon} dimmed={!selected} />
+      <WeaponSummary weapon={weapon} dimmed={!selected || equipped} />
+      {equipped && (
+        <Lock
+          className="shrink-0 text-destructive"
+          size={14}
+          aria-hidden="true"
+          focusable={false}
+        />
+      )}
       <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground">
         R{refinementLevel}
       </span>

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -200,6 +200,8 @@ export function TeamsPage() {
                     collectionWeapons={collectionWeapons}
                     weaponType={selectedMemberWeaponType}
                     selectedCollectionWeaponId={selectedMember.weaponInstanceId}
+                    slot={selectedSlot!}
+                    memberIndex={selectedMemberIndex!}
                     onSelect={handleWeaponSelect}
                     onClear={handleWeaponClear}
                   />

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -60,6 +60,11 @@ export {
   type TeamSlot,
 } from './team.js';
 export { type ArtifactPlan, type TeamMember } from './teamMember.js';
-export { validateTeam, validateTeamSlot, type TeamValidationContext } from './teamValidation.js';
+export {
+  validateTeam,
+  validateTeams,
+  validateTeamSlot,
+  type TeamValidationContext,
+} from './teamValidation.js';
 export { type ProfileUpdate, type UserProfile } from './userProfile.js';
 export type { UUID } from './uuid.js';

--- a/packages/domain/src/teamValidation.ts
+++ b/packages/domain/src/teamValidation.ts
@@ -15,6 +15,7 @@
 import type { ValidationIssue } from '@genshin/validation';
 import { issue, prefixPaths } from '@genshin/validation';
 import { validateArtifactPlan } from './artifactPlanValidation.js';
+import type { TeamSlot } from './team.js';
 import type { TeamMember } from './teamMember.js';
 
 /**
@@ -93,11 +94,77 @@ export function validateTeam(
     }
   }
 
+  // Per-team weapon uniqueness: no duplicate weapon instance IDs ------
+  const seenWeapons = new Set<string>();
+  for (const [i, member] of team.members.entries()) {
+    if (member.weaponInstanceId) {
+      if (seenWeapons.has(member.weaponInstanceId)) {
+        issues.push(
+          issue(
+            `Duplicate weapon instance ID: ${member.weaponInstanceId}`,
+            `members[${i}].weaponInstanceId`,
+          ),
+        );
+      }
+      seenWeapons.add(member.weaponInstanceId);
+    }
+  }
+
   // Per-member artifact plan validation --------------------------------
   for (const [i, member] of team.members.entries()) {
     if (member.artifactPlan) {
       issues.push(
         ...prefixPaths(validateArtifactPlan(member.artifactPlan), `members[${i}].artifactPlan`),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// validateTeams
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate cross-team invariants for the team being saved.
+ *
+ * Currently checks weapon uniqueness: a weapon instance can only be equipped
+ * by one character at a time across all teams. The same character carrying
+ * the same weapon on multiple teams is allowed (Genshin Impact semantics).
+ *
+ * @param slot - The team slot being saved.
+ * @param currentMembers - Members of the team being saved.
+ * @param allTeams - All persisted teams for the user (may include the team being saved).
+ */
+export function validateTeams(
+  slot: TeamSlot,
+  currentMembers: TeamMember[],
+  allTeams: { slot: TeamSlot; members: TeamMember[] }[],
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  // Build a map of weaponInstanceId → characterId from other teams.
+  const equippedWeapons = new Map<string, string>();
+  for (const team of allTeams) {
+    if (team.slot === slot) continue;
+    for (const member of team.members) {
+      if (member.weaponInstanceId) {
+        equippedWeapons.set(member.weaponInstanceId, member.characterId);
+      }
+    }
+  }
+
+  for (const [i, member] of currentMembers.entries()) {
+    if (!member.weaponInstanceId) continue;
+
+    const existingOwner = equippedWeapons.get(member.weaponInstanceId);
+    if (existingOwner && existingOwner !== member.characterId) {
+      issues.push(
+        issue(
+          `Weapon instance ${member.weaponInstanceId} is already equipped by character ${existingOwner}`,
+          `members[${i}].weaponInstanceId`,
+        ),
       );
     }
   }


### PR DESCRIPTION
## Summary

Prevents a weapon instance from being equipped by different characters across teams, while still allowing the same character to carry the same weapon on multiple teams (Genshin Impact semantics).

## Changes

### Domain (`packages/domain`)
- **`validateTeam()`**: Added per-team duplicate weapon instance check
- **`validateTeams()`**: New cross-team weapon uniqueness validator (replaces the more narrowly scoped `validateWeaponUniquenessAcrossTeams`)
- **`validateTeamSlot()`**: Kept in domain (input parsing for team slots)

### API (`apps/api`)
- PUT `/teams/:slot` now calls `validateTeams()` to enforce cross-team weapon uniqueness, returning 400 on violation
- 2 new tests: weapon equipped by different character (400) and same character carrying same weapon across teams (200)

### Frontend (`apps/web`)
- **WeaponPool**: Disabled weapon cards show a lock icon and reduced opacity when equipped by another character
- Equipped-weapons map computed via `useMemo` (derived state, not stored in zustand)
- Replaced `currentCharacterId` prop with `slot` + `memberIndex` (component reads character from store)
- Extracted `weaponCardLabel()` helper to replace nested ternaries in aria-label

Closes #635