### PR TITLE
fix: preserve team member slot positions across save/reload

### DIFF
--- a/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
+++ b/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
@@ -24,9 +24,11 @@ export const teamPutRequestV1 = {
       },
       members: {
         type: 'array',
-        items: { $ref: '#/$defs/teamMember' },
+        items: {
+          oneOf: [{ $ref: '#/$defs/teamMember' }, { type: 'null' }],
+        },
         maxItems: 4,
-        description: 'Team members (0-4; partial teams are valid)',
+        description: 'Team members (0-4; null represents an empty slot)',
       },
     },
     additionalProperties: false,

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionTeam, ISOTimestamp, TeamSlot } from '@genshin/domain';
+import type { CollectionTeam, ISOTimestamp, TeamMember, TeamSlot } from '@genshin/domain';
 
 export interface MemberDocumentData {
   characterId: string;
@@ -18,21 +18,33 @@ export interface MemberDocumentData {
 
 export interface DocumentData {
   name: string;
-  members: MemberDocumentData[];
+  members: (MemberDocumentData | null)[];
   description?: string;
   createdAt: string;
   updatedAt: string;
+}
+
+function memberFromDocument(m: MemberDocumentData): TeamMember {
+  return {
+    characterId: m.characterId,
+    ...(m.weaponInstanceId ? { weaponInstanceId: m.weaponInstanceId } : {}),
+    ...(m.artifactPlan ? { artifactPlan: m.artifactPlan } : {}),
+  } as TeamMember;
+}
+
+function memberToDocument(m: TeamMember): MemberDocumentData {
+  return {
+    characterId: m.characterId,
+    ...(m.weaponInstanceId ? { weaponInstanceId: m.weaponInstanceId } : {}),
+    ...(m.artifactPlan ? { artifactPlan: m.artifactPlan } : {}),
+  };
 }
 
 export function fromDocument(slot: TeamSlot, data: DocumentData): CollectionTeam {
   return {
     slot,
     name: data.name,
-    members: data.members.map((m) => ({
-      characterId: m.characterId,
-      ...(m.weaponInstanceId ? { weaponInstanceId: m.weaponInstanceId } : {}),
-      ...(m.artifactPlan ? { artifactPlan: m.artifactPlan } : {}),
-    })) as CollectionTeam['members'],
+    members: data.members.map((m) => (m === null ? null : memberFromDocument(m))),
     ...(data.description !== undefined ? { description: data.description } : {}),
     createdAt: data.createdAt as ISOTimestamp,
     updatedAt: data.updatedAt as ISOTimestamp,
@@ -42,11 +54,7 @@ export function fromDocument(slot: TeamSlot, data: DocumentData): CollectionTeam
 export function toDocument(team: CollectionTeam): DocumentData {
   return {
     name: team.name,
-    members: team.members.map((m) => ({
-      characterId: m.characterId,
-      ...(m.weaponInstanceId ? { weaponInstanceId: m.weaponInstanceId } : {}),
-      ...(m.artifactPlan ? { artifactPlan: m.artifactPlan } : {}),
-    })),
+    members: team.members.map((m) => (m === null ? null : memberToDocument(m))),
     ...(team.description !== undefined ? { description: team.description } : {}),
     createdAt: team.createdAt,
     updatedAt: team.updatedAt,

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -100,7 +100,7 @@ teams.put(
         // Cross-team weapon uniqueness: a weapon instance can only be equipped
         // by one character at a time across all teams (#635).
         const allTeams = await listTeams(userId);
-        const crossTeamIssues = validateTeams(slot, nonNullMembers, allTeams);
+        const crossTeamIssues = validateTeams(slot, body.members, allTeams);
         if (crossTeamIssues.length > 0) {
           throw new HTTPException(400, { message: crossTeamIssues[0].message });
         }

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -40,7 +40,7 @@ teams.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: teamItem
 interface UpdateTeamBody {
   name?: string;
   description?: string;
-  members?: TeamMember[];
+  members?: (TeamMember | null)[];
 }
 
 function parseSlot(param: string): TeamSlot {
@@ -93,14 +93,17 @@ teams.put(
     const body = c.get('validatedBody') as UpdateTeamBody;
 
     if (body.members && body.members.length > 0) {
-      await validateMembers(userId, body.members);
+      const nonNullMembers = body.members.filter((m): m is TeamMember => m !== null);
+      if (nonNullMembers.length > 0) {
+        await validateMembers(userId, nonNullMembers);
 
-      // Cross-team weapon uniqueness: a weapon instance can only be equipped
-      // by one character at a time across all teams (#635).
-      const allTeams = await listTeams(userId);
-      const crossTeamIssues = validateTeams(slot, body.members, allTeams);
-      if (crossTeamIssues.length > 0) {
-        throw new HTTPException(400, { message: crossTeamIssues[0].message });
+        // Cross-team weapon uniqueness: a weapon instance can only be equipped
+        // by one character at a time across all teams (#635).
+        const allTeams = await listTeams(userId);
+        const crossTeamIssues = validateTeams(slot, nonNullMembers, allTeams);
+        if (crossTeamIssues.length > 0) {
+          throw new HTTPException(400, { message: crossTeamIssues[0].message });
+        }
       }
     }
 

--- a/apps/web/src/features/teams/useTeamApi.ts
+++ b/apps/web/src/features/teams/useTeamApi.ts
@@ -11,7 +11,7 @@ import { apiDelete, apiGet, apiPut } from '@/lib/api';
 export interface SaveTeamPayload {
   slot: TeamSlot;
   name: string;
-  members: TeamMember[];
+  members: (TeamMember | null)[];
   description?: string;
 }
 

--- a/apps/web/src/features/teams/useTeams.ts
+++ b/apps/web/src/features/teams/useTeams.ts
@@ -6,7 +6,6 @@ import type {
   CollectionTeam,
   CollectionWeaponId,
   Team,
-  TeamMember,
   TeamSlot,
 } from '@genshin/domain';
 import { initialTeams } from '@genshin/domain';
@@ -45,7 +44,7 @@ function collectionTeamsToStore(apiTeams: CollectionTeam[]): Record<TeamSlot, Te
   for (const ct of apiTeams) {
     const members: Team['members'] = [undefined, undefined, undefined, undefined];
     for (let i = 0; i < ct.members.length && i < 4; i++) {
-      members[i] = ct.members[i];
+      members[i] = ct.members[i] ?? undefined;
     }
     teams[ct.slot] = {
       slot: ct.slot,
@@ -64,7 +63,7 @@ function teamToSavePayload(team: Team): SaveTeamPayload {
   return {
     slot: team.slot,
     name: team.name,
-    members: team.members.filter((m): m is TeamMember => m !== undefined),
+    members: team.members.map((m) => m ?? null),
     description: team.description,
   };
 }

--- a/packages/domain/src/collectionTeam.ts
+++ b/packages/domain/src/collectionTeam.ts
@@ -10,13 +10,14 @@ import type { TeamMember } from './teamMember.js';
 /**
  * CollectionTeam is the persisted form of a user's team composition.
  *
- * Each user has up to 4 team loadout slots (1–4). Members is 0–4 entries;
- * partial teams (with holes) are valid input for downstream optimizers.
+ * Each user has up to 4 team loadout slots (1–4). Members is a 4-element
+ * array where `null` represents an empty slot, preserving positional
+ * information across API round-trips.
  */
 export interface CollectionTeam {
   slot: TeamSlot;
   name: string;
-  members: TeamMember[];
+  members: (TeamMember | null)[];
   description?: string;
   createdAt: ISOTimestamp;
   updatedAt: ISOTimestamp;

--- a/packages/domain/src/collectionTeam.ts
+++ b/packages/domain/src/collectionTeam.ts
@@ -10,8 +10,8 @@ import type { TeamMember } from './teamMember.js';
 /**
  * CollectionTeam is the persisted form of a user's team composition.
  *
- * Each user has up to 4 team loadout slots (1–4). Members is a 4-element
- * array where `null` represents an empty slot, preserving positional
+ * Each user has up to 4 team loadout slots (1–4). Members is an array with
+ * 0 to 4 entries where `null` represents an empty slot, preserving positional
  * information across API round-trips.
  */
 export interface CollectionTeam {
@@ -56,7 +56,8 @@ export function assertCollectionTeam(value: unknown): asserts value is Collectio
     );
   }
   for (const member of data.members) {
-    if (typeof member !== 'object' || member === null || typeof member.characterId !== 'string') {
+    if (member === null) continue;
+    if (typeof member !== 'object' || typeof member.characterId !== 'string') {
       throw new TypeError(
         `CollectionTeam.members entries must have a string characterId, got: ${JSON.stringify(member)}`,
       );

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -129,7 +129,9 @@ export function deserialiseTeam(item: Item): CollectionTeam {
   const data: Record<string, unknown> = Object.fromEntries(
     item.data.filter((d) => d.name !== 'members').map((d) => [d.name, d.value]),
   );
-  data.members = members.map((m: unknown, i: number) => deserialiseTeamMember(m, i));
+  data.members = members.map((m: unknown, i: number) =>
+    m === null ? null : deserialiseTeamMember(m, i),
+  );
   assertCollectionTeam(data);
   return data;
 }

--- a/packages/domain/src/teamValidation.ts
+++ b/packages/domain/src/teamValidation.ts
@@ -54,7 +54,7 @@ export function validateTeamSlot(slot: unknown): ValidationIssue[] {
  * offline / anonymous validation on the web).
  */
 export function validateTeam(
-  team: { name: string; members: TeamMember[]; description?: string },
+  team: { name: string; members: (TeamMember | null)[]; description?: string },
   context?: TeamValidationContext,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
@@ -67,6 +67,7 @@ export function validateTeam(
   // Per-team uniqueness: no duplicate character IDs --------------------
   const seen = new Set<string>();
   for (const [i, member] of team.members.entries()) {
+    if (member === null) continue;
     if (seen.has(member.characterId)) {
       issues.push(
         issue(`Duplicate character ID: ${member.characterId}`, `members[${i}].characterId`),
@@ -78,6 +79,7 @@ export function validateTeam(
   // Ownership checks (when collection context is available) ------------
   if (context) {
     for (const [i, member] of team.members.entries()) {
+      if (member === null) continue;
       if (!context.ownedCharacterIds.has(member.characterId)) {
         issues.push(
           issue(`Character not in collection: ${member.characterId}`, `members[${i}].characterId`),
@@ -97,6 +99,7 @@ export function validateTeam(
   // Per-team weapon uniqueness: no duplicate weapon instance IDs ------
   const seenWeapons = new Set<string>();
   for (const [i, member] of team.members.entries()) {
+    if (member === null) continue;
     if (member.weaponInstanceId) {
       if (seenWeapons.has(member.weaponInstanceId)) {
         issues.push(
@@ -112,6 +115,7 @@ export function validateTeam(
 
   // Per-member artifact plan validation --------------------------------
   for (const [i, member] of team.members.entries()) {
+    if (member === null) continue;
     if (member.artifactPlan) {
       issues.push(
         ...prefixPaths(validateArtifactPlan(member.artifactPlan), `members[${i}].artifactPlan`),
@@ -139,8 +143,8 @@ export function validateTeam(
  */
 export function validateTeams(
   slot: TeamSlot,
-  currentMembers: TeamMember[],
-  allTeams: { slot: TeamSlot; members: TeamMember[] }[],
+  currentMembers: (TeamMember | null)[],
+  allTeams: { slot: TeamSlot; members: (TeamMember | null)[] }[],
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
@@ -149,14 +153,14 @@ export function validateTeams(
   for (const team of allTeams) {
     if (team.slot === slot) continue;
     for (const member of team.members) {
-      if (member.weaponInstanceId) {
+      if (member !== null && member.weaponInstanceId) {
         equippedWeapons.set(member.weaponInstanceId, member.characterId);
       }
     }
   }
 
   for (const [i, member] of currentMembers.entries()) {
-    if (!member.weaponInstanceId) continue;
+    if (member === null || !member.weaponInstanceId) continue;
 
     const existingOwner = equippedWeapons.get(member.weaponInstanceId);
     if (existingOwner && existingOwner !== member.characterId) {


### PR DESCRIPTION
## Summary

Fixes #637 — team member positions shift to the first slots after save and reload.

## Root cause

`teamToSavePayload` in `useTeams.ts` used `.filter()` to strip empty slots, which collapsed `[undefined, undefined, CharC, undefined]` → `[CharC]`. On reload, the character appeared in slot 1 instead of slot 3.

## Solution

Allow `null` entries in the `members` array across the full stack so empty slots preserve their position index.

### Changes

| Layer | File | Change |
|-------|------|--------|
| Domain | `collectionTeam.ts` | `members` type → `(TeamMember \| null)[]`; assertion skips null |
| Domain | `teamValidation.ts` | `validateTeam` / `validateTeams` skip null entries |
| Domain | `teams.ts` (collection-json) | `deserialiseTeam` passes null through |
| API | `put-request-v1.ts` | JSON Schema `members.items` accepts `null` via `oneOf` |
| API | `document.ts` | Extracted `memberFromDocument` / `memberToDocument` helpers; null round-trip to Firestore |
| API | `teams.ts` (route) | Filters nulls before domain validation |
| Web | `useTeams.ts` | `.filter()` → `.map(m => m ?? null)` (root cause fix) |
| Web | `useTeamApi.ts` | `SaveTeamPayload.members` accepts null |

## Testing

- All 214 existing tests pass (169 API + 24 collection-json + 20 game-data + 1 validation)
- Typecheck clean
- Manual verification: characters stay in assigned slots after save/reload