### PR TITLE
feat(web): add empty-collection CTAs to character and weapon pools

### DIFF
--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -4,9 +4,12 @@
 import type { CharacterId, CollectionCharacter } from '@genshin/domain';
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
+import { Users } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { CharacterSummary } from '@/components/CharacterSummary';
+import { Button } from '@/components/ui/button';
 import { CharacterFilters } from '@/features/collection/characters/CharacterFilters';
 import type { CharacterFilterState } from '@/features/collection/characters/filtering';
 import { filterCharacters, initialFilterState } from '@/features/collection/characters/filtering';
@@ -41,6 +44,23 @@ export function CharacterPool({ characters, assignedIds, disabled, onAssign }: C
       filteredOwnedCount: filtered.filter((c) => ownedIds.has(c.id)).length,
     };
   }, [filters, ownedIds]);
+
+  if (ownedCount === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 py-12">
+        <Users className="h-10 w-10 text-muted-foreground" aria-hidden="true" focusable={false} />
+        <div className="text-center">
+          <p className="font-medium">No characters in your collection</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Visit the characters page to add characters to your collection.
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/characters">Go to Characters</Link>
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">

--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -38,6 +38,8 @@ export function CharacterPool({ characters, assignedIds, disabled, onAssign }: C
   const ownedCount = ownedIds.size;
 
   const { filteredCharacters, filteredOwnedCount } = useMemo(() => {
+    if (ownedIds.size === 0)
+      return { filteredCharacters: [] as Character[], filteredOwnedCount: 0 };
     const filtered = filterCharacters(CHARACTERS, filters, ownedIds);
     return {
       filteredCharacters: filtered,

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -81,12 +81,14 @@ export function WeaponPool({
   }, [ownedWeaponIds, weaponType]);
 
   const { filteredWeapons, filteredOwnedCount } = useMemo(() => {
+    if (ownedWeaponIds.size === 0 || !hasWeaponsOfType)
+      return { filteredWeapons: [] as Weapon[], filteredOwnedCount: 0 };
     const filtered = filterWeapons(WEAPONS, filters, ownedWeaponIds);
     return {
       filteredWeapons: filtered,
       filteredOwnedCount: filtered.filter((w) => ownedWeaponIds.has(w.id)).length,
     };
-  }, [filters, ownedWeaponIds]);
+  }, [filters, ownedWeaponIds, hasWeaponsOfType]);
 
   const instancesByWeaponId = useMemo(() => {
     const map = new Map<string, CollectionWeapon[]>();

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -4,10 +4,12 @@
 import type { CollectionWeapon, CollectionWeaponId, Team, TeamSlot } from '@genshin/domain';
 import { TEAM_SLOTS } from '@genshin/domain';
 import type { Weapon, WeaponType } from '@genshin/game-data';
-import { WEAPONS } from '@genshin/game-data';
-import { Lock } from 'lucide-react';
+import { getWeaponById, WEAPONS } from '@genshin/game-data';
+import { Lock, Swords } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 
+import { Button } from '@/components/ui/button';
 import { WeaponSummary } from '@/components/WeaponSummary';
 import type { WeaponFilterState } from '@/features/collection/weapons/filtering';
 import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
@@ -70,6 +72,14 @@ export function WeaponPool({
 
   const ownedCount = ownedWeaponIds.size;
 
+  const hasWeaponsOfType = useMemo(() => {
+    for (const cw of collectionWeapons) {
+      const weapon = getWeaponById(cw.weaponId);
+      if (weapon?.type === weaponType) return true;
+    }
+    return false;
+  }, [collectionWeapons, weaponType]);
+
   const { filteredWeapons, filteredOwnedCount } = useMemo(() => {
     const filtered = filterWeapons(WEAPONS, filters, ownedWeaponIds);
     return {
@@ -87,6 +97,40 @@ export function WeaponPool({
     }
     return map;
   }, [collectionWeapons]);
+
+  if (ownedCount === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 py-12">
+        <Swords className="h-10 w-10 text-muted-foreground" aria-hidden="true" focusable={false} />
+        <div className="text-center">
+          <p className="font-medium">No weapons in your collection</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Visit the weapons page to add weapons to your collection.
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/weapons">Go to Weapons</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (!hasWeaponsOfType) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 py-12">
+        <Swords className="h-10 w-10 text-muted-foreground" aria-hidden="true" focusable={false} />
+        <div className="text-center">
+          <p className="font-medium">No {weaponType} weapons in your collection</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Visit the weapons page to add {weaponType} weapons to your collection.
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/weapons">Go to Weapons</Link>
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -73,12 +73,12 @@ export function WeaponPool({
   const ownedCount = ownedWeaponIds.size;
 
   const hasWeaponsOfType = useMemo(() => {
-    for (const cw of collectionWeapons) {
-      const weapon = getWeaponById(cw.weaponId);
+    for (const id of ownedWeaponIds) {
+      const weapon = getWeaponById(id);
       if (weapon?.type === weaponType) return true;
     }
     return false;
-  }, [collectionWeapons, weaponType]);
+  }, [ownedWeaponIds, weaponType]);
 
   const { filteredWeapons, filteredOwnedCount } = useMemo(() => {
     const filtered = filterWeapons(WEAPONS, filters, ownedWeaponIds);

--- a/packages/game-data/src/artifacts.ts
+++ b/packages/game-data/src/artifacts.ts
@@ -489,11 +489,13 @@ export type ArtifactMinorAffix = (typeof ARTIFACT_MINOR_AFFIXES)[number];
  */
 export type ArtifactMainAffix = SandsMainAffix | GobletMainAffix | CircletMainAffix;
 
+const ARTIFACT_SETS_BY_ID = new Map(ARTIFACT_SETS.map((s) => [s.id, s]));
+
 /**
  * Helper to find artifact set by ID
  */
 export function getArtifactSetById(id: string): ArtifactSet | undefined {
-  return ARTIFACT_SETS.find((set) => set.id === id);
+  return ARTIFACT_SETS_BY_ID.get(id);
 }
 
 /**

--- a/packages/game-data/src/characters.ts
+++ b/packages/game-data/src/characters.ts
@@ -1165,11 +1165,13 @@ export const CHARACTERS: Character[] = [
   },
 ];
 
+const CHARACTERS_BY_ID = new Map(CHARACTERS.map((c) => [c.id, c]));
+
 /**
  * Helper to find character by ID
  */
 export function getCharacterById(id: string): Character | undefined {
-  return CHARACTERS.find((char) => char.id === id);
+  return CHARACTERS_BY_ID.get(id);
 }
 
 /**

--- a/packages/game-data/src/weapons.ts
+++ b/packages/game-data/src/weapons.ts
@@ -282,11 +282,13 @@ export const WEAPONS: Weapon[] = [
   },
 ];
 
+const WEAPONS_BY_ID = new Map(WEAPONS.map((w) => [w.id, w]));
+
 /**
  * Helper to find weapon by ID
  */
 export function getWeaponById(id: string): Weapon | undefined {
-  return WEAPONS.find((weapon) => weapon.id === id);
+  return WEAPONS_BY_ID.get(id);
 }
 
 /**


### PR DESCRIPTION
## Summary

When the character or weapon pool on the teams page is empty, display an empty-state prompt directing users to the corresponding collection page.

## Changes

**`CharacterPool`** — When the user owns no characters (`ownedCount === 0`), hides filters and the grid, showing a centered CTA with a `Users` icon and a "Go to Characters" button linking to `/characters`.

**`WeaponPool`** — Three-tier empty state:
1. **No weapons at all** (`ownedCount === 0`) → "No weapons in your collection" with CTA to `/weapons`
2. **No weapons of the required type** (`!hasWeaponsOfType`) → "No {type} weapons in your collection" with CTA to `/weapons` — covers the case where a user owns weapons but none matching the selected character's weapon type
3. **Filters narrowed to zero** → existing "No weapons match your filters." message (unchanged)

**`game-data` getById helpers** — Replaced linear `.find()` scans with pre-built `Map` lookups in `getCharacterById`, `getWeaponById`, and `getArtifactSetById` for O(1) access. Also deduped the `hasWeaponsOfType` check to iterate unique weapon IDs instead of raw collection instances.

## Follow-up

- #666 — Pre-filter the weapons collection page by weapon type when navigating from the `!hasWeaponsOfType` CTA

Closes #643