### PR TITLE
fix: correct character pool dimming and add slot-aware selection styling

### DIFF
--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CharacterId, CollectionCharacter } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter, TeamSlot } from '@genshin/domain';
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
-import { Users } from 'lucide-react';
+import { Lock, Users } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -13,7 +13,8 @@ import { Button } from '@/components/ui/button';
 import { CharacterFilters } from '@/features/collection/characters/CharacterFilters';
 import type { CharacterFilterState } from '@/features/collection/characters/filtering';
 import { filterCharacters, initialFilterState } from '@/features/collection/characters/filtering';
-import { ELEMENT_BORDER_COLORS, ELEMENT_BORDER_COLORS_DIM } from '@/lib/elementStyles';
+import { useTeamStore } from '@/features/teams/useTeamStore';
+import { ELEMENT_BORDER_COLORS, ELEMENT_SELECTED_RINGS } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
 
 function poolFilterState(): CharacterFilterState {
@@ -22,12 +23,23 @@ function poolFilterState(): CharacterFilterState {
 
 interface CharacterPoolProps {
   characters: Record<CharacterId, CollectionCharacter>;
-  assignedIds: Set<string>;
-  disabled: boolean;
+  slot: TeamSlot;
+  memberIndex: number;
   onAssign: (characterId: string) => void;
 }
 
-export function CharacterPool({ characters, assignedIds, disabled, onAssign }: CharacterPoolProps) {
+export function CharacterPool({ characters, slot, memberIndex, onAssign }: CharacterPoolProps) {
+  const members = useTeamStore((s) => s.teams[slot].members);
+  const currentSlotCharacterId = members[memberIndex]?.characterId;
+  const otherSlotIds = useMemo(
+    () =>
+      new Set(
+        members
+          .filter((m, i): m is NonNullable<typeof m> => m !== undefined && i !== memberIndex)
+          .map((m) => m.characterId),
+      ),
+    [members, memberIndex],
+  );
   const [filters, setFilters] = useState<CharacterFilterState>(poolFilterState);
 
   function handleFilterChange(next: CharacterFilterState) {
@@ -80,8 +92,9 @@ export function CharacterPool({ characters, assignedIds, disabled, onAssign }: C
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {filteredCharacters.map((character) => {
             const owned = ownedIds.has(character.id);
-            const assigned = assignedIds.has(character.id);
-            const clickable = !disabled && owned;
+            const assignedToCurrentSlot = character.id === currentSlotCharacterId;
+            const assignedToOtherSlot = otherSlotIds.has(character.id);
+            const clickable = owned && !assignedToOtherSlot;
 
             const entry = characters[character.id];
 
@@ -90,7 +103,8 @@ export function CharacterPool({ characters, assignedIds, disabled, onAssign }: C
                 key={character.id}
                 character={character}
                 constellationLevel={entry?.constellationLevel ?? 0}
-                assigned={assigned}
+                assignedToCurrentSlot={assignedToCurrentSlot}
+                assignedToOtherSlot={assignedToOtherSlot}
                 disabled={!clickable}
                 onClick={() => onAssign(character.id)}
               />
@@ -111,7 +125,8 @@ export function CharacterPool({ characters, assignedIds, disabled, onAssign }: C
 interface PoolCharacterCardProps {
   character: Character;
   constellationLevel: number;
-  assigned: boolean;
+  assignedToCurrentSlot: boolean;
+  assignedToOtherSlot: boolean;
   disabled: boolean;
   onClick: () => void;
 }
@@ -119,11 +134,14 @@ interface PoolCharacterCardProps {
 function PoolCharacterCard({
   character,
   constellationLevel,
-  assigned,
+  assignedToCurrentSlot,
+  assignedToOtherSlot,
   disabled,
   onClick,
 }: PoolCharacterCardProps) {
-  const borderColors = assigned ? ELEMENT_BORDER_COLORS : ELEMENT_BORDER_COLORS_DIM;
+  let ariaLabel = `Add ${character.name} to slot`;
+  if (assignedToCurrentSlot) ariaLabel = `Remove ${character.name} from slot`;
+  else if (assignedToOtherSlot) ariaLabel = `${character.name} is assigned to another slot`;
 
   return (
     <button
@@ -132,14 +150,23 @@ function PoolCharacterCard({
       disabled={disabled}
       className={cn(
         'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
-        borderColors[character.element],
+        ELEMENT_BORDER_COLORS[character.element],
+        assignedToCurrentSlot && `ring-2 ring-inset ${ELEMENT_SELECTED_RINGS[character.element]}`,
         disabled && 'cursor-not-allowed opacity-40',
         !disabled && 'cursor-pointer hover:bg-accent/50',
       )}
-      aria-label={assigned ? `Remove ${character.name} from team` : `Add ${character.name} to team`}
-      aria-pressed={assigned}
+      aria-label={ariaLabel}
+      aria-pressed={assignedToCurrentSlot}
     >
-      <CharacterSummary character={character} dimmed={!assigned} />
+      <CharacterSummary character={character} dimmed={false} />
+      {assignedToOtherSlot && (
+        <Lock
+          className="shrink-0 text-destructive"
+          size={14}
+          aria-hidden="true"
+          focusable={false}
+        />
+      )}
       <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground">
         C{constellationLevel}
       </span>

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -15,7 +15,7 @@ import type { WeaponFilterState } from '@/features/collection/weapons/filtering'
 import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
 import { WeaponFilters } from '@/features/collection/weapons/WeaponFilters';
 import { useTeamStore } from '@/features/teams/useTeamStore';
-import { RARITY_BORDER_COLORS } from '@/lib/rarityStyles';
+import { RARITY_BORDER_COLORS, RARITY_SELECTED_RINGS } from '@/lib/rarityStyles';
 import { cn } from '@/lib/utils';
 
 function buildEquippedWeapons(teams: Record<TeamSlot, Team>): Map<CollectionWeaponId, string> {
@@ -210,13 +210,14 @@ function PoolWeaponCard({
       disabled={equipped}
       className={cn(
         'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
-        selected ? (RARITY_BORDER_COLORS[weapon.rarity] ?? 'border-l-border') : 'border-l-border',
-        equipped ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-accent/50',
+        RARITY_BORDER_COLORS[weapon.rarity] ?? 'border-l-border',
+        selected && `ring-2 ring-inset ${RARITY_SELECTED_RINGS[weapon.rarity] ?? 'ring-border'}`,
+        equipped ? 'cursor-not-allowed opacity-40' : 'cursor-pointer hover:bg-accent/50',
       )}
       aria-label={weaponCardLabel(weapon, equipped, selected)}
       aria-pressed={selected}
     >
-      <WeaponSummary weapon={weapon} dimmed={!selected || equipped} />
+      <WeaponSummary weapon={weapon} dimmed={false} />
       {equipped && (
         <Lock
           className="shrink-0 text-destructive"

--- a/apps/web/src/lib/rarityStyles.ts
+++ b/apps/web/src/lib/rarityStyles.ts
@@ -10,3 +10,11 @@ export const RARITY_BORDER_COLORS: Record<Rarity, string> = {
   2: 'border-l-muted-foreground',
   1: 'border-l-muted-foreground',
 };
+
+export const RARITY_SELECTED_RINGS: Record<Rarity, string> = {
+  5: 'ring-geo-dark',
+  4: 'ring-geo',
+  3: 'ring-muted-foreground',
+  2: 'ring-muted-foreground',
+  1: 'ring-muted-foreground',
+};

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -184,6 +184,11 @@ export function TeamsPage() {
                     onAssign={handleToggleCharacter}
                   />
                 )}
+                {activeTab === 'characters' && selectedMemberIndex === null && (
+                  <p className="text-sm text-muted-foreground">
+                    Select a team member to choose a character.
+                  </p>
+                )}
                 {activeTab === 'weapons' && selectedMember && selectedMemberWeaponType && (
                   <WeaponPool
                     key={selectedMemberWeaponType}

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionWeaponId, TeamMember, TeamSlot } from '@genshin/domain';
+import type { CollectionWeaponId, TeamSlot } from '@genshin/domain';
 import { TEAM_SLOTS } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
 import { useCallback, useMemo, useState } from 'react';
@@ -43,16 +43,6 @@ export function TeamsPage() {
   } = useTeams();
 
   const selectedTeam = selectedSlot !== null ? teams[selectedSlot] : null;
-
-  const assignedIds = useMemo(
-    () =>
-      new Set(
-        selectedTeam?.members
-          .filter((m): m is TeamMember => m !== undefined)
-          .map((m) => m.characterId) ?? [],
-      ),
-    [selectedTeam?.members],
-  );
 
   const selectedMember =
     selectedTeam && selectedMemberIndex !== null
@@ -186,11 +176,11 @@ export function TeamsPage() {
               </nav>
 
               <div className="mt-3 flex min-h-0 flex-1 flex-col">
-                {activeTab === 'characters' && (
+                {activeTab === 'characters' && selectedMemberIndex !== null && (
                   <CharacterPool
                     characters={characters}
-                    assignedIds={assignedIds}
-                    disabled={selectedMemberIndex === null}
+                    slot={selectedSlot!}
+                    memberIndex={selectedMemberIndex}
                     onAssign={handleToggleCharacter}
                   />
                 )}


### PR DESCRIPTION
## Summary

Fixes #652 — character pool dimming was inverted (available characters appeared dimmed while the assigned one was bright).

## Changes

- **Three-state character pool cards**: characters now show as bright (available), ring-highlighted (assigned to current slot), or dimmed with a lock icon (assigned to another slot in the same team).
- **Ring-based selection styling**: replaced the old dim/bright border toggle with `ring-2 ring-inset` in the character's element color for the selected state. Applied the same pattern to weapon pool cards using new `RARITY_SELECTED_RINGS`.
- **Slot-aware store reads**: `CharacterPool` now takes `slot` + `memberIndex` props and reads team state directly from the store (matching `WeaponPool`'s pattern), instead of receiving pre-computed assignment sets.
- **Removed unused props**: cleaned up `assignedIds`, `disabled`, and `TeamMember` import from `TeamsPage`.