### PR TITLE
feat(web): auto-populate weapon when reusing a character across teams

### DIFF
--- a/apps/web/src/features/teams/useTeamStore.ts
+++ b/apps/web/src/features/teams/useTeamStore.ts
@@ -35,13 +35,27 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
     const team = get().teams[slot];
     if (team.members.some((m) => m?.characterId === characterId)) return;
 
+    // Auto-populate weapon from another team where this character already has one equipped.
+    const allTeams = get().teams;
+    let existingWeaponId: CollectionWeaponId | undefined;
+    for (const other of Object.values(allTeams)) {
+      if (other.slot === slot) continue;
+      const match = other.members.find((m) => m?.characterId === characterId && m.weaponInstanceId);
+      if (match?.weaponInstanceId) {
+        existingWeaponId = match.weaponInstanceId;
+        break;
+      }
+    }
+
     set((state) => ({
       teams: {
         ...state.teams,
         [slot]: {
           ...state.teams[slot],
           members: state.teams[slot].members.map((m, i) =>
-            i === memberIndex ? { characterId } : m,
+            i === memberIndex
+              ? { characterId, ...(existingWeaponId && { weaponInstanceId: existingWeaponId }) }
+              : m,
           ) as Team['members'],
         },
       },


### PR DESCRIPTION
## Summary

When a character that already has a weapon equipped on another team is added to a new team, the weapon is now automatically assigned to the new slot. Subsequent weapon changes on either team remain independent.

## Changes

- **`apps/web/src/features/teams/useTeamStore.ts`**: The `assignCharacter` action now scans other teams for the same character. If one is found with a weapon equipped, the `weaponInstanceId` is copied to the new team member.

## Testing

- Typecheck passes.
- No automated web tests yet (tracked in #526).

## Follow-up

- #671 — Extract the cross-team iteration pattern into a shared domain helper.

Closes #660