### PR TITLE
fix(web): reduce team editor sheet height for smaller viewports

### DIFF
--- a/apps/web/src/features/teams/TeamMemberPlanner.tsx
+++ b/apps/web/src/features/teams/TeamMemberPlanner.tsx
@@ -7,14 +7,14 @@ import type {
   CollectionWeapon,
   TeamMember,
 } from '@genshin/domain';
-import { getCharacterById, getWeaponById } from '@genshin/game-data';
+import { getCharacterById } from '@genshin/game-data';
 
 import { ArtifactPlanner } from '@/components/ArtifactPlanner';
-import { CharacterSummary } from '@/components/CharacterSummary';
-import { WeaponSummary } from '@/components/WeaponSummary';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { ELEMENT_BORDER_COLORS } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
+
+import { TeamMemberSummary } from './TeamMemberSummary';
 
 interface TeamMemberPlannerProps {
   member?: TeamMember;
@@ -34,7 +34,6 @@ export function TeamMemberPlanner({
   onArtifactPlanChange,
 }: TeamMemberPlannerProps) {
   const character = member ? getCharacterById(member.characterId) : undefined;
-  const weapon = collectionWeapon ? getWeaponById(collectionWeapon.weaponId) : undefined;
 
   const borderClass = character
     ? ELEMENT_BORDER_COLORS[character.element]
@@ -63,47 +62,19 @@ export function TeamMemberPlanner({
           : undefined
       }
     >
-      {/* Row 1: Character */}
       <CardHeader className="p-3 pb-1.5">
-        {character ? (
-          <div className="flex items-center gap-2">
-            <CharacterSummary character={character} />
-
-            {collectionCharacter && (
-              <span
-                className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground"
-                aria-label={`Constellation level ${collectionCharacter.constellationLevel}`}
-              >
-                C{collectionCharacter.constellationLevel}
-              </span>
-            )}
-          </div>
-        ) : (
-          <div className="flex items-center gap-2">
-            <CharacterSummary />
-          </div>
-        )}
+        <TeamMemberSummary
+          member={member}
+          collectionCharacter={collectionCharacter}
+          collectionWeapon={collectionWeapon}
+        />
       </CardHeader>
 
-      <CardContent className="space-y-1.5 p-3 pt-0">
-        {/* Row 2: Weapon instance */}
-        <div className="flex items-center gap-2">
-          <WeaponSummary weapon={weapon} />
-          {weapon && collectionWeapon && (
-            <span
-              className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-muted-foreground"
-              aria-label={`Refinement rank ${collectionWeapon.refinementLevel}`}
-            >
-              R{collectionWeapon.refinementLevel}
-            </span>
-          )}
-        </div>
-
-        {/* Row 3: Artifact plan (only when character is assigned) */}
-        {character && member && (
+      {character && member && (
+        <CardContent className="p-3 pt-0">
           <ArtifactPlanner plan={member.artifactPlan} onChange={onArtifactPlanChange} />
-        )}
-      </CardContent>
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/apps/web/src/features/teams/TeamMemberPlanner.tsx
+++ b/apps/web/src/features/teams/TeamMemberPlanner.tsx
@@ -11,7 +11,7 @@ import { getCharacterById } from '@genshin/game-data';
 
 import { ArtifactPlanner } from '@/components/ArtifactPlanner';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { ELEMENT_BORDER_COLORS } from '@/lib/elementStyles';
+import { elementBorderClass } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
 
 import { TeamMemberSummary } from './TeamMemberSummary';
@@ -35,9 +35,7 @@ export function TeamMemberPlanner({
 }: TeamMemberPlannerProps) {
   const character = member ? getCharacterById(member.characterId) : undefined;
 
-  const borderClass = character
-    ? ELEMENT_BORDER_COLORS[character.element]
-    : 'border-dashed border-muted-foreground/30';
+  const borderClass = elementBorderClass(character?.element);
 
   return (
     <Card

--- a/apps/web/src/features/teams/TeamMemberSummary.tsx
+++ b/apps/web/src/features/teams/TeamMemberSummary.tsx
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionCharacter, CollectionWeapon, TeamMember } from '@genshin/domain';
+import { getCharacterById, getWeaponById } from '@genshin/game-data';
+
+import { CharacterSummary } from '@/components/CharacterSummary';
+import { WeaponSummary } from '@/components/WeaponSummary';
+
+interface TeamMemberSummaryProps {
+  member?: TeamMember;
+  collectionCharacter?: CollectionCharacter;
+  collectionWeapon?: CollectionWeapon;
+}
+
+export function TeamMemberSummary({
+  member,
+  collectionCharacter,
+  collectionWeapon,
+}: TeamMemberSummaryProps) {
+  const character = member ? getCharacterById(member.characterId) : undefined;
+  const weapon = collectionWeapon ? getWeaponById(collectionWeapon.weaponId) : undefined;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <CharacterSummary character={character} />
+        {collectionCharacter && (
+          <span
+            className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground"
+            aria-label={`Constellation level ${collectionCharacter.constellationLevel}`}
+          >
+            C{collectionCharacter.constellationLevel}
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <WeaponSummary weapon={weapon} />
+        {weapon && collectionWeapon && (
+          <span
+            className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-muted-foreground"
+            aria-label={`Refinement rank ${collectionWeapon.refinementLevel}`}
+          >
+            R{collectionWeapon.refinementLevel}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/teams/TeamStrip.tsx
+++ b/apps/web/src/features/teams/TeamStrip.tsx
@@ -10,7 +10,7 @@ import type {
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
 
-import { ELEMENT_BORDER_COLORS } from '@/lib/elementStyles';
+import { elementBorderClass } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
 
 import { TeamMemberSummary } from './TeamMemberSummary';
@@ -38,9 +38,7 @@ export function TeamStrip({
         const character = member ? getCharacterById(member.characterId) : undefined;
 
         const selected = selectedIndex === i;
-        const borderClass = character
-          ? ELEMENT_BORDER_COLORS[character.element]
-          : 'border-l-dashed border-l-muted-foreground/30';
+        const borderClass = elementBorderClass(character?.element);
 
         return (
           <button

--- a/apps/web/src/features/teams/TeamStrip.tsx
+++ b/apps/web/src/features/teams/TeamStrip.tsx
@@ -1,36 +1,46 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Team } from '@genshin/domain';
+import type {
+  CollectionCharacter,
+  CollectionWeapon,
+  CollectionWeaponId,
+  Team,
+} from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
-import { UserRound } from 'lucide-react';
 
-import { getElementIconPath } from '@/lib/elements';
-import { ELEMENT_BORDER_ALL_COLORS } from '@/lib/elementStyles';
+import { ELEMENT_BORDER_COLORS } from '@/lib/elementStyles';
 import { cn } from '@/lib/utils';
+
+import { TeamMemberSummary } from './TeamMemberSummary';
 
 interface TeamStripProps {
   members: Team['members'];
   selectedIndex: number | null;
   onSelect: (index: number) => void;
+  getCharacter: (characterId: string) => CollectionCharacter | undefined;
+  getCollectionWeapon: (collectionWeaponId: CollectionWeaponId) => CollectionWeapon | undefined;
 }
 
-export function TeamStrip({ members, selectedIndex, onSelect }: TeamStripProps) {
+export function TeamStrip({
+  members,
+  selectedIndex,
+  onSelect,
+  getCharacter,
+  getCollectionWeapon,
+}: TeamStripProps) {
   const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
 
   return (
-    <div className="flex items-center justify-center gap-3 border-b border-border py-3 sm:hidden">
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
       {slots.map((member, i) => {
         const character = member ? getCharacterById(member.characterId) : undefined;
 
         const selected = selectedIndex === i;
-        const borderClass =
-          selected && character
-            ? ELEMENT_BORDER_ALL_COLORS[character.element]
-            : selected
-              ? 'border-primary'
-              : 'border-transparent';
+        const borderClass = character
+          ? ELEMENT_BORDER_COLORS[character.element]
+          : 'border-l-dashed border-l-muted-foreground/30';
 
         return (
           <button
@@ -38,25 +48,21 @@ export function TeamStrip({ members, selectedIndex, onSelect }: TeamStripProps) 
             type="button"
             onClick={() => onSelect(i)}
             className={cn(
-              'flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-muted border-2 transition-colors',
+              'rounded-lg border border-border border-l-4 p-2 text-left transition-colors',
               borderClass,
+              'cursor-pointer hover:bg-accent/50',
+              selected && 'bg-accent/50',
             )}
             aria-label={character ? `Select ${character.name}` : `Select empty slot ${i + 1}`}
-            aria-pressed={selectedIndex === i}
+            aria-pressed={selected}
           >
-            {character ? (
-              <img
-                src={getElementIconPath(character.element)}
-                alt={character.element}
-                className="h-6 w-6"
-              />
-            ) : (
-              <UserRound
-                className="h-5 w-5 text-muted-foreground/40"
-                aria-hidden="true"
-                focusable={false}
-              />
-            )}
+            <TeamMemberSummary
+              member={member}
+              collectionCharacter={member ? getCharacter(member.characterId) : undefined}
+              collectionWeapon={
+                member?.weaponInstanceId ? getCollectionWeapon(member.weaponInstanceId) : undefined
+              }
+            />
           </button>
         );
       })}

--- a/apps/web/src/lib/elementStyles.ts
+++ b/apps/web/src/lib/elementStyles.ts
@@ -62,3 +62,7 @@ export const ELEMENT_BORDER_ALL_COLORS: Record<Element, string> = {
   Geo: 'border-geo',
   Dendro: 'border-dendro',
 };
+
+export function elementBorderClass(element?: Element): string {
+  return element ? ELEMENT_BORDER_COLORS[element] : 'border-dashed border-muted-foreground/30';
+}

--- a/apps/web/src/pages/TeamsPage.tsx
+++ b/apps/web/src/pages/TeamsPage.tsx
@@ -6,7 +6,7 @@ import { TEAM_SLOTS } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
 import { useCallback, useMemo, useState } from 'react';
 
-import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetHeader } from '@/components/ui/sheet';
 import { useCollection } from '@/features/collection/characters/useCharacterCollection';
 import { useWeaponCollection } from '@/features/collection/weapons/useWeaponCollection';
 import { CharacterPool } from '@/features/teams/CharacterPool';
@@ -126,27 +126,15 @@ export function TeamsPage() {
         >
           {selectedSlot !== null && selectedTeam && (
             <>
-              <TeamStrip
-                members={selectedTeam.members}
-                selectedIndex={selectedMemberIndex}
-                onSelect={setSelectedMemberIndex}
-              />
-
-              <div className="hidden sm:block">
-                <TeamPlanner
-                  slot={selectedSlot}
-                  name={selectedTeam.name}
+              <SheetHeader className="pt-6">
+                <TeamStrip
                   members={selectedTeam.members}
+                  selectedIndex={selectedMemberIndex}
+                  onSelect={setSelectedMemberIndex}
                   getCharacter={getCharacter}
                   getCollectionWeapon={getCollectionWeapon}
-                  selectedMemberIndex={selectedMemberIndex}
-                  onMemberSelect={setSelectedMemberIndex}
-                  onNameChange={(name) => setTeamName(selectedSlot, name)}
-                  onArtifactPlanChange={(memberIndex, plan) =>
-                    setArtifactPlan(selectedSlot, memberIndex, plan)
-                  }
                 />
-              </div>
+              </SheetHeader>
 
               <nav className="mt-4 flex gap-4 border-b border-border" aria-label="Team editor tabs">
                 <button


### PR DESCRIPTION
## Summary

Fixes #663 — the team editor sheet was too tall on smaller viewports because it embedded the full TeamPlanner (with artifact planning) inside the sheet.

## Changes

- **TeamMemberSummary** (new): Borderless fragment composing `CharacterSummary` + `WeaponSummary` with C/R badges, following the same pattern as the existing summary components.
- **TeamStrip**: Rewritten to use `TeamMemberSummary` inside compact button cards. Now visible at all breakpoints (removed `sm:hidden`). Selection uses `bg-accent/50` instead of rings.
- **TeamMemberPlanner**: Refactored to compose `TeamMemberSummary` + `ArtifactPlanner`, removing duplicated character/weapon rendering.
- **TeamsPage**: Removed the in-sheet `TeamPlanner` block. Moved `TeamStrip` into `SheetHeader` with `pt-6` to clear the sheet's close button.
- **sheet.tsx**: Unchanged — kept stock shadcn default.

## How it works

The sheet now shows the compact member strip (character + weapon per slot) instead of full planner cards with artifact planning. This dramatically reduces vertical space, making all character slots reachable on smaller viewports.

## Testing

- Typechecks pass
- Visual verification via Playwright screenshot