### PR TITLE
feat(web): add Vitest infrastructure and test suite

### DIFF
--- a/.github/actions/setup-and-typecheck/action.yml
+++ b/.github/actions/setup-and-typecheck/action.yml
@@ -1,0 +1,24 @@
+---
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Setup and typecheck
+description: Checkout, install Node.js + pnpm, and run typecheck for a workspace package
+
+inputs:
+  filter:
+    description: 'Turborepo filter (e.g. @genshin/web)'
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - uses: ./.github/actions/setup-node-pnpm
+
+    - name: Typecheck
+      shell: bash
+      run: pnpm turbo run typecheck --filter="${{ inputs.filter }}"

--- a/.github/actions/setup-and-typecheck/action.yml
+++ b/.github/actions/setup-and-typecheck/action.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 name: Setup and typecheck
-description: Checkout, install Node.js + pnpm, and run typecheck for a workspace package
+description: Install Node.js + pnpm, and run typecheck for a workspace package
 
 inputs:
   filter:
@@ -14,9 +14,6 @@ runs:
   using: composite
 
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-
     - uses: ./.github/actions/setup-node-pnpm
 
     - name: Typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup-and-typecheck
         with:
           filter: '@genshin/web'
@@ -43,6 +46,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup-and-typecheck
         with:
           filter: '@genshin/api'
@@ -64,6 +70,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup-and-typecheck
         with:
           filter: '@genshin/game-data'
@@ -85,6 +94,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup-and-typecheck
         with:
           filter: '@genshin/domain'
@@ -98,6 +110,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup-and-typecheck
         with:
           filter: '@genshin/collection-json'
@@ -119,6 +134,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup-and-typecheck
         with:
           filter: '@genshin/validation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,17 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-and-typecheck
+        with:
+          filter: '@genshin/web'
 
-      - uses: ./.github/actions/setup-node-pnpm
-
-      - name: Typecheck
-        run: pnpm turbo run typecheck --filter=@genshin/web
+      - uses: ./.github/actions/test-and-upload-coverage
+        with:
+          filter: '@genshin/web'
+          coverage-file: apps/web/coverage/lcov.info
+          results-file: apps/web/test-results/junit.xml
+          flag: web
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build
         run: pnpm turbo run build --filter=@genshin/web
@@ -39,13 +43,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-node-pnpm
-
-      - name: Typecheck
-        run: pnpm turbo run typecheck --filter=@genshin/api
+      - uses: ./.github/actions/setup-and-typecheck
+        with:
+          filter: '@genshin/api'
 
       - uses: ./.github/actions/test-and-upload-coverage
         with:
@@ -64,16 +64,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-node-pnpm
-
-      - name: Build
-        run: pnpm turbo run build --filter=@genshin/game-data
-
-      - name: Typecheck
-        run: pnpm turbo run typecheck --filter=@genshin/game-data
+      - uses: ./.github/actions/setup-and-typecheck
+        with:
+          filter: '@genshin/game-data'
 
       - uses: ./.github/actions/test-and-upload-coverage
         with:
@@ -83,22 +76,21 @@ jobs:
           flag: game-data
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Build
+        run: pnpm turbo run build --filter=@genshin/game-data
+
   domain:
     name: Domain
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-node-pnpm
+      - uses: ./.github/actions/setup-and-typecheck
+        with:
+          filter: '@genshin/domain'
 
       - name: Build
         run: pnpm turbo run build --filter=@genshin/domain
-
-      - name: Typecheck
-        run: pnpm turbo run typecheck --filter=@genshin/domain
 
   collection-json:
     name: Collection JSON
@@ -106,16 +98,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-node-pnpm
-
-      - name: Build
-        run: pnpm turbo run build --filter=@genshin/collection-json
-
-      - name: Typecheck
-        run: pnpm turbo run typecheck --filter=@genshin/collection-json
+      - uses: ./.github/actions/setup-and-typecheck
+        with:
+          filter: '@genshin/collection-json'
 
       - uses: ./.github/actions/test-and-upload-coverage
         with:
@@ -125,22 +110,21 @@ jobs:
           flag: collection-json
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Build
+        run: pnpm turbo run build --filter=@genshin/collection-json
+
   validation:
     name: Validation
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-node-pnpm
+      - uses: ./.github/actions/setup-and-typecheck
+        with:
+          filter: '@genshin/validation'
 
       - name: Build
         run: pnpm turbo run build --filter=@genshin/validation
-
-      - name: Typecheck
-        run: pnpm turbo run typecheck --filter=@genshin/validation
 
 # ---------------------------------------------------------------------------
 # Maintenance notes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,6 @@
     "lint:css": "stylelint 'src/**/*.css' --fix",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:ui": "vitest --ui",
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "lint:css": "stylelint 'src/**/*.css' --fix",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ui": "vitest --ui",
     "typecheck": "tsc -b --noEmit"
   },
@@ -38,15 +38,20 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@tailwindcss/postcss": "4.2.2",
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.3.0",
+    "@testing-library/user-event": "14.6.1",
     "@types/node": "25.5.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/coverage-v8": "4.1.2",
     "autoprefixer": "^10.4.27",
     "eslint": "10.1.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "26.1.0",
     "postcss": "^8.5.8",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "stylelint": "17.6.0",
@@ -55,6 +60,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "6.0.2",
     "typescript-eslint": "8.58.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "vitest": "4.1.2"
   }
 }

--- a/apps/web/src/components/CharacterSummary.test.tsx
+++ b/apps/web/src/components/CharacterSummary.test.tsx
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { CharacterSummary } from './CharacterSummary';
+
+const AMBER = {
+  id: 'amber',
+  name: 'Amber',
+  element: 'Pyro' as const,
+  weaponType: 'Bow' as const,
+  rarity: 4 as const,
+  region: 'Mondstadt',
+  version: '1.0',
+};
+
+describe('CharacterSummary', () => {
+  it('renders placeholder when no character is provided', () => {
+    const { container } = render(<CharacterSummary />);
+
+    expect(screen.getByText('No character')).toBeInTheDocument();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders the element icon with correct src path', () => {
+    render(<CharacterSummary character={AMBER} />);
+
+    const img = screen.getByAltText('Pyro');
+    expect(img).toHaveAttribute('src', '/elements/pyro.png');
+  });
+
+  it('applies dimmed styling when dimmed prop is true', () => {
+    render(<CharacterSummary character={AMBER} dimmed />);
+
+    const img = screen.getByAltText('Pyro');
+    expect(img.className).toContain('opacity-30');
+  });
+});

--- a/apps/web/src/components/Footer.test.tsx
+++ b/apps/web/src/components/Footer.test.tsx
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Footer } from './Footer';
+
+describe('Footer', () => {
+  it('opens links in new tabs with proper security attributes', () => {
+    render(<Footer />);
+
+    const links = screen.getAllByRole('link');
+    for (const link of links) {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+});

--- a/apps/web/src/components/Nav.test.tsx
+++ b/apps/web/src/components/Nav.test.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { Nav } from './Nav';
+
+function renderNav(initialRoute = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Nav />
+    </MemoryRouter>,
+  );
+}
+
+describe('Nav', () => {
+  it('marks the Teams link as active on the root route', () => {
+    renderNav('/');
+
+    const teamsLink = screen.getByRole('link', { name: 'Teams' });
+    expect(teamsLink.className).toContain('border-blue-500');
+  });
+
+  it('marks the Characters link as active on /characters', () => {
+    renderNav('/characters');
+
+    const charactersLink = screen.getByRole('link', { name: 'Characters' });
+    expect(charactersLink.className).toContain('border-blue-500');
+
+    const teamsLink = screen.getByRole('link', { name: 'Teams' });
+    expect(teamsLink.className).toContain('border-transparent');
+  });
+
+  it('marks the Weapons link as active on /weapons', () => {
+    renderNav('/weapons');
+
+    const weaponsLink = screen.getByRole('link', { name: 'Weapons' });
+    expect(weaponsLink.className).toContain('border-blue-500');
+  });
+});

--- a/apps/web/src/components/WeaponSummary.test.tsx
+++ b/apps/web/src/components/WeaponSummary.test.tsx
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { WeaponSummary } from './WeaponSummary';
+
+const AMOS_BOW = {
+  id: 'amos-bow',
+  name: "Amos' Bow",
+  type: 'Bow' as const,
+  rarity: 5 as const,
+  baseATK: 46,
+  version: '1.0',
+};
+
+describe('WeaponSummary', () => {
+  it('renders placeholder when no weapon is provided', () => {
+    render(<WeaponSummary />);
+
+    expect(screen.getByText('No weapon')).toBeInTheDocument();
+  });
+
+  it('applies dimmed styling when dimmed prop is true', () => {
+    const { container } = render(<WeaponSummary weapon={AMOS_BOW} dimmed />);
+
+    const typeBox = container.querySelector('.opacity-30');
+    expect(typeBox).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/collection/characters/filtering.test.ts
+++ b/apps/web/src/features/collection/characters/filtering.test.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Character } from '@genshin/game-data';
+import { describe, expect, it } from 'vitest';
+
+import { filterCharacters, initialFilterState } from './filtering';
+
+const CHARACTERS: Character[] = [
+  {
+    id: 'amber',
+    name: 'Amber',
+    element: 'Pyro',
+    weaponType: 'Bow',
+    rarity: 4,
+    region: 'Mondstadt',
+    version: '1.0',
+  },
+  {
+    id: 'ganyu',
+    name: 'Ganyu',
+    element: 'Cryo',
+    weaponType: 'Bow',
+    rarity: 5,
+    region: 'Liyue',
+    version: '1.2',
+  },
+  {
+    id: 'xiangling',
+    name: 'Xiangling',
+    element: 'Pyro',
+    weaponType: 'Polearm',
+    rarity: 4,
+    region: 'Liyue',
+    version: '1.0',
+  },
+  {
+    id: 'zhongli',
+    name: 'Zhongli',
+    element: 'Geo',
+    weaponType: 'Polearm',
+    rarity: 5,
+    region: 'Liyue',
+    version: '1.1',
+  },
+];
+
+describe('filterCharacters', () => {
+  const ownedIds = new Set(['amber', 'xiangling']);
+
+  it('returns all characters with default filters', () => {
+    const result = filterCharacters(CHARACTERS, initialFilterState(), ownedIds);
+
+    expect(result).toHaveLength(4);
+  });
+
+  it('filters by search text (case-insensitive)', () => {
+    const filters = { ...initialFilterState(), search: 'gan' };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('ganyu');
+  });
+
+  it('filters by element', () => {
+    const filters = { ...initialFilterState(), elements: new Set<Character['element']>(['Pyro']) };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => c.element === 'Pyro')).toBe(true);
+  });
+
+  it('filters by rarity', () => {
+    const filters = { ...initialFilterState(), rarities: new Set<Character['rarity']>([5]) };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => c.rarity === 5)).toBe(true);
+  });
+
+  it('filters by ownership: owned', () => {
+    const filters = { ...initialFilterState(), ownership: 'owned' as const };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => ownedIds.has(c.id))).toBe(true);
+  });
+
+  it('filters by ownership: unowned', () => {
+    const filters = { ...initialFilterState(), ownership: 'unowned' as const };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => !ownedIds.has(c.id))).toBe(true);
+  });
+
+  it('combines multiple filters', () => {
+    const filters = {
+      ...initialFilterState(),
+      elements: new Set<Character['element']>(['Pyro']),
+      ownership: 'owned' as const,
+    };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('sorts by name ascending', () => {
+    const filters = {
+      ...initialFilterState(),
+      sortField: 'name' as const,
+      sortDirection: 'asc' as const,
+    };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    expect(result[0].name).toBe('Amber');
+    expect(result[result.length - 1].name).toBe('Zhongli');
+  });
+
+  it('sorts by release descending (default)', () => {
+    const result = filterCharacters(CHARACTERS, initialFilterState(), ownedIds);
+
+    // Version 1.2 should come first in desc order
+    expect(result[0].id).toBe('ganyu');
+  });
+
+  it('sorts by release ascending', () => {
+    const filters = {
+      ...initialFilterState(),
+      sortField: 'release' as const,
+      sortDirection: 'asc' as const,
+    };
+
+    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+
+    // Version 1.0 characters should come first
+    expect(result[0].version).toBe('1.0');
+  });
+});

--- a/apps/web/src/features/collection/characters/useCharacterCollectionStore.test.ts
+++ b/apps/web/src/features/collection/characters/useCharacterCollectionStore.test.ts
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CharacterId, CollectionCharacter, ISOTimestamp } from '@genshin/domain';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { mergeCollections, useCollectionStore } from './useCharacterCollectionStore';
+
+function makeCharacter(id: string, constellationLevel = 0): CollectionCharacter {
+  return {
+    characterId: id as CharacterId,
+    constellationLevel,
+    createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
+    updatedAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
+  };
+}
+
+describe('useCollectionStore', () => {
+  beforeEach(() => {
+    useCollectionStore.getState().clearCharacters();
+  });
+
+  describe('addCharacter', () => {
+    it('adds a character with minimum constellation level', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+
+      const entry = useCollectionStore.getState().characters['amber'];
+      expect(entry).toBeDefined();
+      expect(entry.constellationLevel).toBe(0);
+    });
+
+    it('does not overwrite an existing character', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+      const original = useCollectionStore.getState().characters['amber'];
+
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+      const after = useCollectionStore.getState().characters['amber'];
+
+      expect(after.createdAt).toBe(original.createdAt);
+    });
+  });
+
+  describe('removeCharacter', () => {
+    it('removes a character from the collection', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+      useCollectionStore.getState().removeCharacter('amber' as CharacterId);
+
+      expect(useCollectionStore.getState().characters['amber']).toBeUndefined();
+    });
+
+    it('is a no-op for nonexistent characters', () => {
+      useCollectionStore.getState().removeCharacter('nonexistent' as CharacterId);
+
+      expect(Object.keys(useCollectionStore.getState().characters)).toHaveLength(0);
+    });
+  });
+
+  describe('setConstellationLevel', () => {
+    it('updates the constellation level of an owned character', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, 3);
+
+      expect(useCollectionStore.getState().characters['amber'].constellationLevel).toBe(3);
+    });
+
+    it('ignores invalid constellation levels', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, -1);
+      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, 7);
+
+      expect(useCollectionStore.getState().characters['amber'].constellationLevel).toBe(0);
+    });
+
+    it('ignores updates for characters not in the collection', () => {
+      useCollectionStore.getState().setConstellationLevel('missing' as CharacterId, 3);
+
+      expect(useCollectionStore.getState().characters['missing']).toBeUndefined();
+    });
+  });
+
+  describe('isOwned', () => {
+    it('returns true for owned characters', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+
+      expect(useCollectionStore.getState().isOwned('amber' as CharacterId)).toBe(true);
+    });
+
+    it('returns false for unowned characters', () => {
+      expect(useCollectionStore.getState().isOwned('amber' as CharacterId)).toBe(false);
+    });
+  });
+
+  describe('replaceCharacters', () => {
+    it('replaces the entire collection', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+      useCollectionStore
+        .getState()
+        .replaceCharacters({ xiangling: makeCharacter('xiangling') } as Record<
+          CharacterId,
+          CollectionCharacter
+        >);
+
+      expect(useCollectionStore.getState().characters['amber']).toBeUndefined();
+      expect(useCollectionStore.getState().characters['xiangling']).toBeDefined();
+    });
+  });
+
+  describe('clearCharacters', () => {
+    it('empties the collection', () => {
+      useCollectionStore.getState().addCharacter('amber' as CharacterId);
+      useCollectionStore.getState().addCharacter('xiangling' as CharacterId);
+      useCollectionStore.getState().clearCharacters();
+
+      expect(Object.keys(useCollectionStore.getState().characters)).toHaveLength(0);
+    });
+  });
+});
+
+describe('mergeCollections', () => {
+  it('unions local and server collections', () => {
+    const local = { amber: makeCharacter('amber') } as Record<CharacterId, CollectionCharacter>;
+    const server = { xiangling: makeCharacter('xiangling') } as Record<
+      CharacterId,
+      CollectionCharacter
+    >;
+
+    const merged = mergeCollections(local, server);
+
+    expect(merged['amber']).toBeDefined();
+    expect(merged['xiangling']).toBeDefined();
+  });
+
+  it('keeps the higher constellation level on conflict', () => {
+    const local = { amber: makeCharacter('amber', 3) } as Record<CharacterId, CollectionCharacter>;
+    const server = { amber: makeCharacter('amber', 1) } as Record<CharacterId, CollectionCharacter>;
+
+    const merged = mergeCollections(local, server);
+
+    expect(merged['amber'].constellationLevel).toBe(3);
+  });
+
+  it('keeps server value when server constellation is higher', () => {
+    const local = { amber: makeCharacter('amber', 1) } as Record<CharacterId, CollectionCharacter>;
+    const server = { amber: makeCharacter('amber', 5) } as Record<CharacterId, CollectionCharacter>;
+
+    const merged = mergeCollections(local, server);
+
+    expect(merged['amber'].constellationLevel).toBe(5);
+  });
+
+  it('returns server collection when local is empty', () => {
+    const server = { amber: makeCharacter('amber', 2) } as Record<CharacterId, CollectionCharacter>;
+
+    const merged = mergeCollections({}, server);
+
+    expect(merged).toEqual(server);
+  });
+});

--- a/apps/web/src/features/collection/weapons/WeaponCard.test.tsx
+++ b/apps/web/src/features/collection/weapons/WeaponCard.test.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WeaponCard } from './WeaponCard';
+
+const SWORD = {
+  id: 'dull-blade',
+  name: 'Dull Blade',
+  type: 'Sword' as const,
+  rarity: 1 as const,
+  baseATK: 23,
+  version: '1.0',
+};
+
+describe('WeaponCard', () => {
+  it('shows the instance count badge when owned', () => {
+    render(<WeaponCard weapon={SWORD} instanceCount={3} />);
+
+    expect(screen.getByText('×3')).toBeInTheDocument();
+  });
+
+  it('hides the instance count badge when not owned', () => {
+    render(<WeaponCard weapon={SWORD} instanceCount={0} />);
+
+    expect(screen.queryByText(/×/)).not.toBeInTheDocument();
+  });
+
+  it('has the correct aria-label', () => {
+    render(<WeaponCard weapon={SWORD} instanceCount={2} />);
+
+    expect(screen.getByRole('button', { name: 'Dull Blade, 2 owned' })).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', async () => {
+    const onClick = vi.fn();
+    render(<WeaponCard weapon={SWORD} instanceCount={1} onClick={onClick} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledWith('dull-blade');
+  });
+
+  it('applies selected ring styles', () => {
+    render(<WeaponCard weapon={SWORD} instanceCount={1} selected />);
+
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('ring-primary');
+  });
+});

--- a/apps/web/src/features/collection/weapons/filtering.test.ts
+++ b/apps/web/src/features/collection/weapons/filtering.test.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Weapon } from '@genshin/game-data';
+import { describe, expect, it } from 'vitest';
+
+import { filterWeapons, initialFilterState } from './filtering';
+
+const WEAPONS: Weapon[] = [
+  { id: 'dull-blade', name: 'Dull Blade', type: 'Sword', rarity: 1, baseATK: 23, version: '1.0' },
+  { id: 'amos-bow', name: "Amos' Bow", type: 'Bow', rarity: 5, baseATK: 46, version: '1.0' },
+  {
+    id: 'staff-of-homa',
+    name: 'Staff of Homa',
+    type: 'Polearm',
+    rarity: 5,
+    baseATK: 46,
+    version: '1.3',
+  },
+  { id: 'the-catch', name: 'The Catch', type: 'Polearm', rarity: 4, baseATK: 42, version: '2.1' },
+];
+
+describe('filterWeapons', () => {
+  const ownedIds = new Set(['amos-bow', 'the-catch']);
+
+  it('returns all weapons with default filters', () => {
+    const result = filterWeapons(WEAPONS, initialFilterState(), ownedIds);
+
+    expect(result).toHaveLength(4);
+  });
+
+  it('filters by search text (case-insensitive)', () => {
+    const filters = { ...initialFilterState(), search: 'homa' };
+
+    const result = filterWeapons(WEAPONS, filters, ownedIds);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('staff-of-homa');
+  });
+
+  it('filters by weapon type', () => {
+    const filters = {
+      ...initialFilterState(),
+      weaponTypes: new Set<Weapon['type']>(['Polearm']),
+    };
+
+    const result = filterWeapons(WEAPONS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((w) => w.type === 'Polearm')).toBe(true);
+  });
+
+  it('filters by rarity', () => {
+    const filters = { ...initialFilterState(), rarities: new Set<Weapon['rarity']>([5]) };
+
+    const result = filterWeapons(WEAPONS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((w) => w.rarity === 5)).toBe(true);
+  });
+
+  it('filters by ownership: owned', () => {
+    const filters = { ...initialFilterState(), ownership: 'owned' as const };
+
+    const result = filterWeapons(WEAPONS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((w) => ownedIds.has(w.id))).toBe(true);
+  });
+
+  it('filters by ownership: unowned', () => {
+    const filters = { ...initialFilterState(), ownership: 'unowned' as const };
+
+    const result = filterWeapons(WEAPONS, filters, ownedIds);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((w) => !ownedIds.has(w.id))).toBe(true);
+  });
+
+  it('sorts by name ascending', () => {
+    const filters = {
+      ...initialFilterState(),
+      sortField: 'name' as const,
+      sortDirection: 'asc' as const,
+    };
+
+    const result = filterWeapons(WEAPONS, filters, ownedIds);
+
+    expect(result[0].name).toBe("Amos' Bow");
+    expect(result[result.length - 1].name).toBe('The Catch');
+  });
+
+  it('sorts by release descending (default)', () => {
+    const result = filterWeapons(WEAPONS, initialFilterState(), ownedIds);
+
+    // Version 2.1 should come first
+    expect(result[0].id).toBe('the-catch');
+  });
+});

--- a/apps/web/src/features/collection/weapons/useWeaponCollectionStore.test.ts
+++ b/apps/web/src/features/collection/weapons/useWeaponCollectionStore.test.ts
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionWeapon, CollectionWeaponId, ISOTimestamp } from '@genshin/domain';
+import type { Weapon } from '@genshin/game-data';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useWeaponCollectionStore } from './useWeaponCollectionStore';
+
+function makeWeapon(
+  weaponInstanceId: string,
+  weaponId: string,
+  refinementLevel = 1,
+): CollectionWeapon {
+  return {
+    weaponInstanceId: weaponInstanceId as CollectionWeaponId,
+    weaponId: weaponId as Weapon['id'],
+    refinementLevel,
+    createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
+    updatedAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
+  };
+}
+
+describe('useWeaponCollectionStore', () => {
+  beforeEach(() => {
+    useWeaponCollectionStore.getState().clearWeapons();
+  });
+
+  describe('addWeapon', () => {
+    it('adds a weapon to the collection', () => {
+      const weapon = makeWeapon('inst-1', 'sword-1');
+      useWeaponCollectionStore.getState().addWeapon(weapon);
+
+      expect(useWeaponCollectionStore.getState().weapons['inst-1' as CollectionWeaponId]).toEqual(
+        weapon,
+      );
+    });
+  });
+
+  describe('removeWeapon', () => {
+    it('removes a weapon by instance id', () => {
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().removeWeapon('inst-1' as CollectionWeaponId);
+
+      expect(
+        useWeaponCollectionStore.getState().weapons['inst-1' as CollectionWeaponId],
+      ).toBeUndefined();
+    });
+  });
+
+  describe('setRefinementLevel', () => {
+    it('updates the refinement level', () => {
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().setRefinementLevel('inst-1' as CollectionWeaponId, 3);
+
+      expect(
+        useWeaponCollectionStore.getState().weapons['inst-1' as CollectionWeaponId].refinementLevel,
+      ).toBe(3);
+    });
+
+    it('ignores invalid refinement levels', () => {
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().setRefinementLevel('inst-1' as CollectionWeaponId, 0);
+      useWeaponCollectionStore.getState().setRefinementLevel('inst-1' as CollectionWeaponId, 6);
+
+      expect(
+        useWeaponCollectionStore.getState().weapons['inst-1' as CollectionWeaponId].refinementLevel,
+      ).toBe(1);
+    });
+
+    it('ignores updates for nonexistent weapons', () => {
+      useWeaponCollectionStore
+        .getState()
+        .setRefinementLevel('nonexistent' as CollectionWeaponId, 3);
+
+      expect(Object.keys(useWeaponCollectionStore.getState().weapons)).toHaveLength(0);
+    });
+  });
+
+  describe('getWeaponsByWeaponId', () => {
+    it('returns all instances of a specific weapon', () => {
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-2', 'sword-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-3', 'bow-1'));
+
+      const swords = useWeaponCollectionStore
+        .getState()
+        .getWeaponsByWeaponId('sword-1' as Weapon['id']);
+
+      expect(swords).toHaveLength(2);
+    });
+
+    it('returns empty array when no instances exist', () => {
+      const result = useWeaponCollectionStore
+        .getState()
+        .getWeaponsByWeaponId('missing' as Weapon['id']);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('setWeapons', () => {
+    it('replaces the entire collection', () => {
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+
+      const newWeapons = {
+        ['inst-2' as CollectionWeaponId]: makeWeapon('inst-2', 'bow-1'),
+      };
+      useWeaponCollectionStore.getState().setWeapons(newWeapons);
+
+      expect(
+        useWeaponCollectionStore.getState().weapons['inst-1' as CollectionWeaponId],
+      ).toBeUndefined();
+      expect(
+        useWeaponCollectionStore.getState().weapons['inst-2' as CollectionWeaponId],
+      ).toBeDefined();
+    });
+  });
+
+  describe('clearWeapons', () => {
+    it('empties the collection', () => {
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-2', 'bow-1'));
+      useWeaponCollectionStore.getState().clearWeapons();
+
+      expect(Object.keys(useWeaponCollectionStore.getState().weapons)).toHaveLength(0);
+    });
+  });
+});

--- a/apps/web/src/features/teams/useTeamStore.test.ts
+++ b/apps/web/src/features/teams/useTeamStore.test.ts
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionWeaponId, ISOTimestamp, Team, TeamSlot } from '@genshin/domain';
+import { initialTeams } from '@genshin/domain';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useTeamStore } from './useTeamStore';
+
+describe('useTeamStore', () => {
+  beforeEach(() => {
+    useTeamStore.getState().resetTeams();
+  });
+
+  describe('initial state', () => {
+    it('starts with four empty teams', () => {
+      const { teams } = useTeamStore.getState();
+
+      expect(Object.keys(teams)).toHaveLength(4);
+      for (const slot of [1, 2, 3, 4] as TeamSlot[]) {
+        const team = teams[slot];
+        expect(team.slot).toBe(slot);
+        expect(team.name).toBe(`Team ${slot}`);
+        expect(team.members).toEqual([undefined, undefined, undefined, undefined]);
+      }
+    });
+  });
+
+  describe('assignCharacter', () => {
+    it('assigns a character to the specified slot and member index', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+
+      const team = useTeamStore.getState().teams[1];
+      expect(team.members[0]).toEqual({ characterId: 'amber' });
+      expect(team.members[1]).toBeUndefined();
+    });
+
+    it('ignores invalid member indices', () => {
+      useTeamStore.getState().assignCharacter(1, -1, 'amber');
+      useTeamStore.getState().assignCharacter(1, 4, 'amber');
+
+      const team = useTeamStore.getState().teams[1];
+      expect(team.members).toEqual([undefined, undefined, undefined, undefined]);
+    });
+
+    it('prevents duplicate characters in the same team', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().assignCharacter(1, 1, 'amber');
+
+      const team = useTeamStore.getState().teams[1];
+      expect(team.members[0]).toEqual({ characterId: 'amber' });
+      expect(team.members[1]).toBeUndefined();
+    });
+
+    it('auto-populates weapon from another team', () => {
+      const weaponId = 'weapon-instance-1' as CollectionWeaponId;
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().assignWeapon(1, 0, weaponId);
+
+      useTeamStore.getState().assignCharacter(2, 0, 'amber');
+
+      const team2 = useTeamStore.getState().teams[2];
+      expect(team2.members[0]?.weaponInstanceId).toBe(weaponId);
+    });
+  });
+
+  describe('removeCharacter', () => {
+    it('removes a character from the specified position', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().removeCharacter(1, 0);
+
+      const team = useTeamStore.getState().teams[1];
+      expect(team.members[0]).toBeUndefined();
+    });
+
+    it('ignores invalid member indices', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().removeCharacter(1, 5);
+
+      expect(useTeamStore.getState().teams[1].members[0]).toEqual({ characterId: 'amber' });
+    });
+  });
+
+  describe('assignWeapon', () => {
+    it('assigns a weapon to an existing team member', () => {
+      const weaponId = 'weapon-1' as CollectionWeaponId;
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().assignWeapon(1, 0, weaponId);
+
+      expect(useTeamStore.getState().teams[1].members[0]?.weaponInstanceId).toBe(weaponId);
+    });
+
+    it('does nothing if no character occupies the slot', () => {
+      const weaponId = 'weapon-1' as CollectionWeaponId;
+      useTeamStore.getState().assignWeapon(1, 0, weaponId);
+
+      expect(useTeamStore.getState().teams[1].members[0]).toBeUndefined();
+    });
+  });
+
+  describe('removeWeapon', () => {
+    it('removes the weapon from a team member', () => {
+      const weaponId = 'weapon-1' as CollectionWeaponId;
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().assignWeapon(1, 0, weaponId);
+      useTeamStore.getState().removeWeapon(1, 0);
+
+      expect(useTeamStore.getState().teams[1].members[0]?.weaponInstanceId).toBeUndefined();
+    });
+  });
+
+  describe('clearTeam', () => {
+    it('removes all members from a team', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().assignCharacter(1, 1, 'xiangling');
+      useTeamStore.getState().clearTeam(1);
+
+      expect(useTeamStore.getState().teams[1].members).toEqual([
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ]);
+    });
+  });
+
+  describe('setTeamName', () => {
+    it('updates the team name', () => {
+      useTeamStore.getState().setTeamName(1, 'National Team');
+
+      expect(useTeamStore.getState().teams[1].name).toBe('National Team');
+    });
+  });
+
+  describe('setTeams', () => {
+    it('replaces all teams', () => {
+      const newTeams = initialTeams();
+      newTeams[1].name = 'Custom';
+      useTeamStore.getState().setTeams(newTeams);
+
+      expect(useTeamStore.getState().teams[1].name).toBe('Custom');
+    });
+  });
+
+  describe('resetTeams', () => {
+    it('restores teams to initial state', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().setTeamName(2, 'Modified');
+      useTeamStore.getState().resetTeams();
+
+      const { teams } = useTeamStore.getState();
+      expect(teams[1].members[0]).toBeUndefined();
+      expect(teams[2].name).toBe('Team 2');
+    });
+  });
+
+  describe('isCharacterInTeam', () => {
+    it('returns true when the character is in the team', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+
+      expect(useTeamStore.getState().isCharacterInTeam(1, 'amber')).toBe(true);
+    });
+
+    it('returns false when the character is not in the team', () => {
+      expect(useTeamStore.getState().isCharacterInTeam(1, 'amber')).toBe(false);
+    });
+  });
+
+  describe('setArtifactPlan', () => {
+    it('sets an artifact plan on a team member', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      const plan = { sands: 'ATK Percentage' as const };
+      useTeamStore.getState().setArtifactPlan(1, 0, plan);
+
+      expect(useTeamStore.getState().teams[1].members[0]?.artifactPlan).toEqual(plan);
+    });
+
+    it('does nothing if no character occupies the slot', () => {
+      const plan = { sands: 'ATK Percentage' as const };
+      useTeamStore.getState().setArtifactPlan(1, 0, plan);
+
+      expect(useTeamStore.getState().teams[1].members[0]).toBeUndefined();
+    });
+
+    it('clears an artifact plan when given undefined', () => {
+      useTeamStore.getState().assignCharacter(1, 0, 'amber');
+      useTeamStore.getState().setArtifactPlan(1, 0, { sands: 'ATK Percentage' as const });
+      useTeamStore.getState().setArtifactPlan(1, 0, undefined);
+
+      expect(useTeamStore.getState().teams[1].members[0]?.artifactPlan).toBeUndefined();
+    });
+  });
+
+  describe('setTeam', () => {
+    it('replaces a single team', () => {
+      const custom: Team = {
+        slot: 3,
+        name: 'Freeze',
+        members: [{ characterId: 'ganyu' }, undefined, undefined, undefined],
+        createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
+        updatedAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
+      };
+      useTeamStore.getState().setTeam(3, custom);
+
+      expect(useTeamStore.getState().teams[3]).toEqual(custom);
+      // Other teams unchanged
+      expect(useTeamStore.getState().teams[1].name).toBe('Team 1');
+    });
+  });
+});

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/firebase', () => ({
+  auth: { currentUser: null },
+}));
+
+// Must import after the mock is registered
+const { ApiError, apiGet, apiPut, apiPost, apiPatch, apiDelete } = await import('./api');
+
+describe('API methods (unauthenticated)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('apiGet sends a GET request and returns parsed JSON', async () => {
+    const payload = { name: 'Traveler' };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await apiGet('/profiles/me');
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(result).toEqual(payload);
+  });
+
+  it('apiPut sends a PUT request with JSON body', async () => {
+    const body = { name: 'Updated' };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await apiPut('/profiles/me', body);
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init?.method).toBe('PUT');
+    expect(init?.body).toBe(JSON.stringify(body));
+  });
+
+  it('apiPost sends a POST request with JSON body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: '1' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await apiPost('/weapons', { weaponId: 'sword-1' });
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init?.method).toBe('POST');
+  });
+
+  it('apiPatch sends a PATCH request', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await apiPatch('/weapons/1', { refinementLevel: 3 });
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init?.method).toBe('PATCH');
+  });
+
+  it('apiDelete sends a DELETE request', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await apiDelete('/teams/1');
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init?.method).toBe('DELETE');
+  });
+
+  it('returns undefined for 204 No Content responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const result = await apiGet('/some-path');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws ApiError with problem detail for application/problem+json errors', async () => {
+    const problem = {
+      type: 'about:blank',
+      title: 'Not Found',
+      status: 404,
+      detail: 'Resource not found',
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(problem), {
+        status: 404,
+        headers: { 'Content-Type': 'application/problem+json' },
+      }),
+    );
+
+    await expect(apiGet('/missing')).rejects.toThrow(ApiError);
+    await vi.restoreAllMocks();
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(problem), {
+        status: 404,
+        headers: { 'Content-Type': 'application/problem+json' },
+      }),
+    );
+
+    await expect(apiGet('/missing')).rejects.toMatchObject({
+      problem: expect.objectContaining({ status: 404, detail: 'Resource not found' }),
+    });
+  });
+
+  it('throws ApiError with synthesized problem for non-JSON errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Internal Server Error', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+    );
+
+    await expect(apiGet('/broken')).rejects.toThrow(ApiError);
+  });
+});

--- a/apps/web/src/lib/styles.test.ts
+++ b/apps/web/src/lib/styles.test.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { elementBorderClass } from './elementStyles';
+
+describe('elementBorderClass', () => {
+  it('returns a dashed fallback when element is undefined', () => {
+    expect(elementBorderClass(undefined)).toBe('border-dashed border-muted-foreground/30');
+  });
+});

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import '@testing-library/jest-dom/vitest';

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  define: {
+    'import.meta.env.VITE_API_BASE_URL': JSON.stringify('http://localhost:8080'),
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+    },
+  },
+});

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,9 @@ flag_management:
     - name: game-data
       paths:
         - packages/game-data/src/**
+    - name: web
+      paths:
+        - apps/web/src/**
 
 component_management:
   individual_components:
@@ -67,6 +70,24 @@ component_management:
         - packages/game-data/src/versions.ts
       flag_regexes:
         - game-data
+    - component_id: web-components
+      name: 'Web: Components'
+      paths:
+        - apps/web/src/components/**
+      flag_regexes:
+        - web
+    - component_id: web-features
+      name: 'Web: Features'
+      paths:
+        - apps/web/src/features/**
+      flag_regexes:
+        - web
+    - component_id: web-lib
+      name: 'Web: Lib'
+      paths:
+        - apps/web/src/lib/**
+      flag_regexes:
+        - web
     - component_id: collection-json
       name: Collection JSON
       paths:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         version: 25.5.2
       '@vitest/coverage-v8':
         specifier: 4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
       eslint:
         specifier: 10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -104,7 +104,7 @@ importers:
         version: 8.58.0(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   apps/web:
     dependencies:
@@ -175,6 +175,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: 4.2.2
         version: 4.2.2
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: 25.5.2
         version: 25.5.2
@@ -187,6 +196,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.0
         version: 6.0.1(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/coverage-v8':
+        specifier: 4.1.2
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
@@ -202,6 +214,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      jsdom:
+        specifier: 26.1.0
+        version: 26.1.0
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -229,6 +244,9 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vitest:
+        specifier: 4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   packages/collection-json:
     devDependencies:
@@ -237,7 +255,7 @@ importers:
         version: 10.0.1(eslint@10.1.0(jiti@2.6.1))
       '@vitest/coverage-v8':
         specifier: 4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
       eslint:
         specifier: 10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -249,7 +267,7 @@ importers:
         version: 8.58.0(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   packages/domain:
     dependencies:
@@ -286,7 +304,7 @@ importers:
         version: 25.5.2
       '@vitest/coverage-v8':
         specifier: 4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
       eslint:
         specifier: 10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -298,7 +316,7 @@ importers:
         version: 8.58.0(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   packages/validation:
     devDependencies:
@@ -317,9 +335,15 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -376,6 +400,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -398,12 +426,36 @@ packages:
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
   '@csstools/css-calc@3.1.1':
     resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0':
     resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
@@ -418,6 +470,10 @@ packages:
     peerDependenciesMeta:
       css-tree:
         optional: true
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
@@ -1482,6 +1538,35 @@ packages:
   '@tanstack/virtual-core@3.13.23':
     resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -1518,6 +1603,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
@@ -1719,6 +1807,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1733,6 +1825,13 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -1825,6 +1924,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1905,10 +2008,17 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1916,6 +2026,10 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1926,12 +2040,19 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1943,6 +2064,12 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1972,6 +2099,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -2356,6 +2487,10 @@ packages:
   hookified@2.1.1:
     resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
@@ -2385,6 +2520,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
@@ -2406,6 +2545,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2443,6 +2586,9 @@ packages:
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -2482,6 +2628,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2653,6 +2808,9 @@ packages:
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -2673,6 +2831,10 @@ packages:
     resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2718,6 +2880,10 @@ packages:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2785,6 +2951,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
@@ -2817,6 +2986,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2937,6 +3109,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proto3-json-serializer@2.0.2:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
@@ -2968,6 +3144,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3028,6 +3207,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3068,6 +3251,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3076,6 +3262,13 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3168,6 +3361,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strnum@2.2.2:
     resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
 
@@ -3209,6 +3406,9 @@ packages:
 
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -3252,12 +3452,27 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3431,6 +3646,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3441,6 +3660,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   websocket-driver@0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
     engines: {node: '>=0.8.0'}
@@ -3448,6 +3671,19 @@ packages:
   websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3484,6 +3720,25 @@ packages:
   write-file-atomic@7.0.1:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3536,7 +3791,17 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3615,6 +3880,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -3652,10 +3919,28 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
   '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -3664,6 +3949,8 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
 
@@ -4676,6 +4963,41 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.23': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.18.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tootallnate/once@2.0.0':
     optional: true
 
@@ -4701,6 +5023,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/caseless@0.12.5':
     optional: true
@@ -4851,7 +5175,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))':
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -4863,7 +5187,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -4948,6 +5272,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
@@ -4960,6 +5286,12 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   array-union@2.1.0: {}
 
@@ -5046,6 +5378,11 @@ snapshots:
   caniuse-lite@1.0.30001784: {}
 
   chai@6.2.2: {}
+
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -5140,20 +5477,36 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
   delayed-stream@1.0.0:
     optional: true
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -5162,6 +5515,10 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5197,6 +5554,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@6.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -5750,6 +6109,10 @@ snapshots:
 
   hookified@2.1.1: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-entities@2.6.0:
     optional: true
 
@@ -5790,6 +6153,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   idb@7.1.1: {}
 
   ignore@5.3.2: {}
@@ -5804,6 +6171,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -5828,6 +6197,8 @@ snapshots:
   is-path-inside@4.0.0: {}
 
   is-plain-object@5.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-stream@2.0.1:
     optional: true
@@ -5864,6 +6235,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -6009,6 +6407,8 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
+  lodash@4.18.1: {}
+
   long@5.3.2: {}
 
   lru-cache@10.4.3: {}
@@ -6029,6 +6429,8 @@ snapshots:
   lucide-react@1.7.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -6070,6 +6472,8 @@ snapshots:
 
   mime@3.0.0:
     optional: true
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -6116,6 +6520,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  nwsapi@2.2.23: {}
+
   object-hash@3.0.0: {}
 
   obug@2.1.1: {}
@@ -6153,6 +6559,10 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -6205,6 +6615,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proto3-json-serializer@2.0.2:
     dependencies:
       protobufjs: 7.5.4
@@ -6243,6 +6659,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -6296,6 +6714,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   require-directory@2.1.1: {}
 
@@ -6355,6 +6778,8 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6364,6 +6789,12 @@ snapshots:
       tslib: 2.8.1
 
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -6441,6 +6872,10 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strnum@2.2.2:
     optional: true
 
@@ -6514,6 +6949,8 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   table@6.9.0:
     dependencies:
       ajv: 8.18.0
@@ -6564,12 +7001,26 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3:
     optional: true
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -6678,7 +7129,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
@@ -6703,8 +7154,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.5.2
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   web-streams-polyfill@3.3.3: {}
 
@@ -6713,6 +7169,8 @@ snapshots:
   webidl-conversions@3.0.1:
     optional: true
 
+  webidl-conversions@7.0.0: {}
+
   websocket-driver@0.7.4:
     dependencies:
       http-parser-js: 0.5.10
@@ -6720,6 +7178,17 @@ snapshots:
       websocket-extensions: 0.1.4
 
   websocket-extensions@0.1.4: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -6759,6 +7228,12 @@ snapshots:
   write-file-atomic@7.0.1:
     dependencies:
       signal-exit: 4.1.0
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

Fixes #665 — `@genshin/web` test script fails because vitest was not in `devDependencies`.

Adds Vitest infrastructure to `@genshin/web` and an initial test suite of **85 tests across 12 files** with **95.9% statement coverage** on tested source files.

## Changes

### Test infrastructure
- Added `vitest`, `@vitest/coverage-v8`, `jsdom`, `@testing-library/react`, `@testing-library/jest-dom`, and `@testing-library/user-event` to `devDependencies`
- Created `vitest.config.ts` with jsdom environment, `@/` path alias, setup files, junit reporter, and v8 coverage
- Updated `tsconfig.node.json` to include `vitest.config.ts`
- Created `src/test/setup.ts` for jest-dom matchers
- Changed test script from `"vitest"` to `"vitest run"`

### Test suite (85 tests)
- **Zustand stores** (44 tests): `useTeamStore`, `useCharacterCollectionStore`, `useWeaponCollectionStore` — covers CRUD, validation guards, boundary checks, merge logic
- **Filtering logic** (18 tests): character and weapon filtering with search, element/type, rarity, ownership, combined filters, and sort
- **API client** (8 tests): all HTTP methods, 204 handling, problem+json error parsing, non-JSON error synthesis
- **Components** (14 tests): `CharacterSummary`, `WeaponSummary`, `Nav` (route-dependent active states), `Footer` (security attributes), `WeaponCard` (interactions)
- **Utilities** (1 test): `elementBorderClass` undefined-element fallback

### CI and coverage
- Extracted Checkout → setup-node-pnpm → Typecheck into a shared `setup-and-typecheck` composite action
- Standardised all CI jobs to **Typecheck → Test → Build** ordering (previously inconsistent)
- Added `test-and-upload-coverage` step to the web job
- Added `web` flag and three components (`Web: Components`, `Web: Features`, `Web: Lib`) to `codecov.yml`

## Follow-up issues
- #675 — TanStack Query hook integration tests (Tier 3, milestone 1.0.0)
- #676 — Playwright E2E smoke tests (Tier 4, milestone 1.1.0)
- #677 — `@genshin/domain` Vitest coverage (milestone 0.1.0)
- #678 — `@genshin/validation` Vitest coverage (milestone 0.1.0)