### PR TITLE
feat(web): pre-filter weapons page by type from teams CTA

### DIFF
--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -128,7 +128,7 @@ export function WeaponPool({
           </p>
         </div>
         <Button asChild>
-          <Link to="/weapons">Go to Weapons</Link>
+          <Link to={`/weapons?type=${weaponType}`}>Go to Weapons</Link>
         </Button>
       </div>
     );

--- a/apps/web/src/pages/WeaponsPage.tsx
+++ b/apps/web/src/pages/WeaponsPage.tsx
@@ -4,7 +4,11 @@
 import { WEAPONS } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
+
+import type { WeaponType } from '@genshin/game-data';
+import { WEAPON_TYPES } from '@genshin/game-data';
 
 import type { WeaponFilterState } from '@/features/collection/weapons/filtering';
 import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
@@ -25,7 +29,17 @@ export function WeaponsPage() {
     error,
   } = useWeaponCollection();
 
-  const [filters, setFilters] = useState<WeaponFilterState>(initialFilterState);
+  const [searchParams] = useSearchParams();
+
+  const [filters, setFilters] = useState<WeaponFilterState>(() => {
+    const state = initialFilterState();
+    const typeParam = searchParams.get('type');
+    const weaponTypeValues = Object.values(WEAPON_TYPES) as WeaponType[];
+    if (typeParam && weaponTypeValues.includes(typeParam as WeaponType)) {
+      state.weaponTypes = new Set<WeaponType>([typeParam as WeaponType]);
+    }
+    return state;
+  });
   const [selectedWeaponId, setSelectedWeaponId] = useState<string | null>(null);
 
   const effectiveSelectedWeaponId = isAuthenticated ? selectedWeaponId : null;


### PR DESCRIPTION
## Summary

When the teams page shows an empty-state "No {type} weapons in your collection" CTA, clicking "Go to Weapons" now navigates to `/weapons?type=Claymore` (or whichever weapon type is needed) so the weapons page loads with that type pre-filtered.

## Changes

- **`WeaponPool.tsx`** — The `!hasWeaponsOfType` CTA links to `/weapons?type=${weaponType}` instead of plain `/weapons`. The "no weapons at all" CTA continues linking without a filter preset.
- **`WeaponsPage.tsx`** — Reads the `type` query parameter on mount via `useSearchParams` and seeds the initial `WeaponFilterState` with the corresponding weapon type pre-selected. Invalid or missing `type` values fall through to the default unfiltered state.

Closes #666