### PR TITLE
feat(web): add focus-visible styling to pool cards in team editor

### DIFF
--- a/apps/web/src/features/teams/CharacterPool.tsx
+++ b/apps/web/src/features/teams/CharacterPool.tsx
@@ -149,7 +149,7 @@ function PoolCharacterCard({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
+        'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
         ELEMENT_BORDER_COLORS[character.element],
         assignedToCurrentSlot && `ring-2 ring-inset ${ELEMENT_SELECTED_RINGS[character.element]}`,
         disabled && 'cursor-not-allowed opacity-40',

--- a/apps/web/src/features/teams/WeaponPool.tsx
+++ b/apps/web/src/features/teams/WeaponPool.tsx
@@ -209,7 +209,7 @@ function PoolWeaponCard({
       onClick={equipped ? undefined : onClick}
       disabled={equipped}
       className={cn(
-        'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors',
+        'flex w-full items-center gap-3 rounded-lg border border-border border-l-4 bg-card p-3 text-left shadow-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
         RARITY_BORDER_COLORS[weapon.rarity] ?? 'border-l-border',
         selected && `ring-2 ring-inset ${RARITY_SELECTED_RINGS[weapon.rarity] ?? 'ring-border'}`,
         equipped ? 'cursor-not-allowed opacity-40' : 'cursor-pointer hover:bg-accent/50',


### PR DESCRIPTION
Add outline-based `focus-visible` indicators to `PoolCharacterCard` and `PoolWeaponCard` buttons. Uses CSS outline (with offset) so keyboard focus is visually distinct from the ring-based selection state.

### Changes
- `PoolCharacterCard`: added `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring`
- `PoolWeaponCard`: added the same focus-visible classes

### Acceptance criteria
- Both card buttons have a visible `focus-visible` indicator that is distinct from the selected-state ring.
- Keyboard-only users can clearly distinguish focused vs. selected cards.

Closes #670