### PR TITLE
fix: replace dynamic secret indexing with explicit references

### DIFF
--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -33,9 +33,8 @@ jobs:
         with:
           terraform_version: '1.9.0'
 
-      # Authenticate to GCP using Workload Identity
-      # Each environment maps to an explicit secret to avoid passing all secrets
-      # to the runner (fixes CodeQL actions/excessive-secrets-exposure).
+      # Each environment maps to an explicit secret to avoid dynamic secret
+      # indexing, which fixes CodeQL actions/excessive-secrets-exposure.
       - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret

--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -10,9 +10,6 @@ on:
       environment:
         required: true
         type: string
-      service_account_secret:
-        required: true
-        type: string
 
 jobs:
   terraform-apply:
@@ -37,10 +34,17 @@ jobs:
           terraform_version: '1.9.0'
 
       # Authenticate to GCP using Workload Identity
+      # Each environment maps to an explicit secret to avoid passing all secrets
+      # to the runner (fixes CodeQL actions/excessive-secrets-exposure).
       - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets[inputs.service_account_secret] }} # pragma: allowlist secret
+          service_account: >-
+            ${{
+              inputs.environment == 'core' && secrets.GCP_RW_CORE_SERVICE_ACCOUNT_EMAIL ||
+              inputs.environment == 'dev' && secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL ||
+              inputs.environment == 'staging' && secrets.GCP_RW_STAGING_SERVICE_ACCOUNT_EMAIL
+            }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -23,7 +23,6 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
-      service_account_secret: GCP_RW_CORE_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
     secrets: inherit # pragma: allowlist secret
 
   dev:
@@ -32,7 +31,6 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: dev
-      service_account_secret: GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
     secrets: inherit # pragma: allowlist secret
 
   staging:
@@ -41,5 +39,4 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: staging
-      service_account_secret: GCP_RW_STAGING_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -25,11 +25,8 @@ jobs:
       matrix:
         include:
           - environment: core
-            service_account_secret: GCP_RO_CORE_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
           - environment: dev
-            service_account_secret: GCP_RO_DEV_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
           - environment: staging
-            service_account_secret: GCP_RO_STAGING_SERVICE_ACCOUNT_EMAIL # pragma: allowlist secret
 
     steps:
       - uses: actions/checkout@v6
@@ -39,10 +36,17 @@ jobs:
           terraform_version: '1.9.0'
 
       # Authenticate to GCP using Workload Identity
+      # Each environment maps to an explicit secret to avoid passing all secrets
+      # to the runner (fixes CodeQL actions/excessive-secrets-exposure).
       - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_RO_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets[matrix.service_account_secret] }} # pragma: allowlist secret
+          service_account: >-
+            ${{
+              matrix.environment == 'core' && secrets.GCP_RO_CORE_SERVICE_ACCOUNT_EMAIL ||
+              matrix.environment == 'dev' && secrets.GCP_RO_DEV_SERVICE_ACCOUNT_EMAIL ||
+              matrix.environment == 'staging' && secrets.GCP_RO_STAGING_SERVICE_ACCOUNT_EMAIL
+            }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -35,9 +35,10 @@ jobs:
         with:
           terraform_version: '1.9.0'
 
-      # Authenticate to GCP using Workload Identity
-      # Each environment maps to an explicit secret to avoid passing all secrets
-      # to the runner (fixes CodeQL actions/excessive-secrets-exposure).
+      # Authenticate to GCP using Workload Identity.
+      # Each environment maps to an explicit secret reference so this step
+      # narrows which secret is passed to the action input and avoids dynamic
+      # secret indexing (fixes CodeQL actions/excessive-secrets-exposure).
       - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_RO_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Replace `secrets[matrix.service_account_secret]` and `secrets[inputs.service_account_secret]` with explicit per-environment conditional expressions so the workflow runner only receives the secrets it actually needs, satisfying least privilege.

## Changes

- **`terraform-plan.yml`**: Remove `service_account_secret` from matrix entries; use `&&`/`||` conditionals to resolve the correct secret by `matrix.environment`.
- **`terraform-apply-reusable.yml`**: Remove the `service_account_secret` input; resolve the secret by `inputs.environment` using the same pattern.
- **`terraform-apply.yml`**: Remove `service_account_secret` from all caller jobs since the reusable workflow no longer requires it.

## Fixes

Resolves CodeQL alerts [#2](https://github.com/dungeon-studio/genshin.dungeon.studio/security/code-scanning/2) and [#8](https://github.com/dungeon-studio/genshin.dungeon.studio/security/code-scanning/8) (`actions/excessive-secrets-exposure`, CWE-312).