### PR TITLE
fix: harden pre-commit workflow permissions and reduce duplication

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 ---
-name: Local pre-commit hooks
+name: pre-commit
 
 on:
   pull_request:
@@ -10,9 +10,12 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
-    name: Run local pre-commit hooks
+    name: Local Hooks
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -23,31 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
## Summary

- **Add explicit `permissions: contents: read`** to fix [CodeQL alert #4](https://github.com/dungeon-studio/genshin.dungeon.studio/security/code-scanning/4) (missing workflow permissions).
- **Replace inline Node/pnpm/cache/install steps** with the reusable `.github/actions/setup-node-pnpm` composite action, matching the pattern in `deploy.yml`.
- **Rename workflow and job** for cleaner PR check display: `pre-commit / Local Hooks` (respects pre-commit branding and repo title-case convention).