### PR TITLE
fix(terraform): mark firebase_web_app_config output sensitive

### DIFF
--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -41,5 +41,5 @@ output "firebase_web_app_config" {
     messaging_sender_id = data.google_firebase_web_app_config.web.messaging_sender_id
     app_id              = google_firebase_web_app.web.app_id
   }
-  sensitive = false
+  sensitive = true
 }


### PR DESCRIPTION
## What

Mark the `firebase_web_app_config` Terraform output as `sensitive = true` in the dev environment.

## Why

The terraform-plan workflow posts full plan output to PR comments. The `firebase_web_app_config` output included the Firebase API key in cleartext, which triggered [GitHub secret scanning alert #1](https://github.com/dungeon-studio/genshin.dungeon.studio/security/secret-scanning/1).

While Firebase client API keys are public by design (they're embedded in the frontend bundle), there's no reason to expose them in plan comments. Marking the output sensitive causes Terraform to redact the values in plan/apply console output.

## Impact

- **Plan comments**: will show `(sensitive value)` instead of the raw config values.
- **Deploy workflow**: unaffected — `terraform output -json` still returns actual values for sensitive outputs.

## Remaining follow-up

- Resolve secret scanning alert #1 (the existing PR comment still contains the key).