### PR TITLE
fix: resolve CodeQL incompatible-type comparison in team deserialiser

### DIFF
--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -67,7 +67,7 @@ export function teamItemDocument(team: CollectionTeam, baseUrl: string): Collect
 }
 
 function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
-  if (typeof value !== 'object' || value === null) {
+  if (value === null || typeof value !== 'object') {
     throw new TypeError(`artifactPlan must be a non-null object, got: ${JSON.stringify(value)}`);
   }
   const plan = value as Record<string, unknown>;
@@ -89,7 +89,7 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
 }
 
 function deserialiseCollectionTeamMember(value: unknown, index: number): CollectionTeamMember {
-  if (typeof value !== 'object' || value === null) {
+  if (value === null || typeof value !== 'object') {
     throw new TypeError(
       `members[${index}] must be a non-null object, got: ${JSON.stringify(value)}`,
     );


### PR DESCRIPTION
## Summary

Swap `null` check before `typeof` in two deserialise functions to eliminate a tautological comparison flagged by CodeQL's `js/comparison-between-incompatible-types` rule.

## Problem

`typeof value !== 'object' || value === null` narrows `value` to `object` (excluding `null`) after the left operand is false, making the subsequent `value === null` always `false`.

## Fix

Reorder to `value === null || typeof value !== 'object'` so the `null` check runs before type narrowing. Same runtime semantics, no dead branch.

Applies to both `deserialiseArtifactPlan` and `deserialiseCollectionTeamMember` in `packages/domain/src/representations/collection-json/teams.ts`.