### PR TITLE
feat(web): sticky filter bar on collection pages

### DIFF
--- a/apps/web/src/pages/CharactersPage.tsx
+++ b/apps/web/src/pages/CharactersPage.tsx
@@ -57,47 +57,54 @@ export function CharactersPage() {
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-12">
+    <>
       <h1 className="sr-only">Characters</h1>
 
-      {error && (
-        <p className="mb-4 rounded-md bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
-          Failed to sync collection. Local data is still available.
-        </p>
-      )}
-
-      <CharacterFilters
-        filters={filters}
-        onChange={setFilters}
-        filteredCount={filteredCharacters.length}
-        totalCount={CHARACTERS.length}
-        ownedCount={ownedCount}
-        filteredOwnedCount={filteredOwnedCount}
-      />
-
-      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {filteredCharacters.map((character) => {
-          const owned = isOwned(character.id);
-          const entry = owned ? characters[character.id] : undefined;
-
-          return (
-            <div key={character.id}>
-              <CharacterCard
-                character={character}
-                owned={owned}
-                constellationLevel={entry?.constellationLevel}
-                onAdd={addCharacter}
-                onRemove={removeCharacter}
-                onConstellationChange={handleConstellationChange}
-              />
-            </div>
-          );
-        })}
+      <div className="sticky top-0 z-10 bg-background shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 py-4">
+          {error && (
+            <p className="mb-3 rounded-md bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
+              Failed to sync collection. Local data is still available.
+            </p>
+          )}
+          <CharacterFilters
+            filters={filters}
+            onChange={setFilters}
+            filteredCount={filteredCharacters.length}
+            totalCount={CHARACTERS.length}
+            ownedCount={ownedCount}
+            filteredOwnedCount={filteredOwnedCount}
+          />
+        </div>
       </div>
 
-      {filteredCharacters.length === 0 && (
-        <p className="py-12 text-center text-muted-foreground">No characters match your filters.</p>
-      )}
-    </div>
+      <div className="mx-auto max-w-7xl px-4 pb-12 pt-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filteredCharacters.map((character) => {
+            const owned = isOwned(character.id);
+            const entry = owned ? characters[character.id] : undefined;
+
+            return (
+              <div key={character.id}>
+                <CharacterCard
+                  character={character}
+                  owned={owned}
+                  constellationLevel={entry?.constellationLevel}
+                  onAdd={addCharacter}
+                  onRemove={removeCharacter}
+                  onConstellationChange={handleConstellationChange}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {filteredCharacters.length === 0 && (
+          <p className="py-12 text-center text-muted-foreground">
+            No characters match your filters.
+          </p>
+        )}
+      </div>
+    </>
   );
 }

--- a/apps/web/src/pages/WeaponsPage.tsx
+++ b/apps/web/src/pages/WeaponsPage.tsx
@@ -121,39 +121,44 @@ export function WeaponsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-12">
+    <>
       <h1 className="sr-only">Weapons</h1>
 
-      {error && (
-        <p className="mb-4 rounded-md bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
-          Failed to sync weapon collection.
-        </p>
-      )}
-
-      <WeaponFilters
-        filters={filters}
-        onChange={setFilters}
-        filteredCount={filteredWeapons.length}
-        totalCount={WEAPONS.length}
-        ownedCount={ownedWeaponIds.size}
-        filteredOwnedCount={filteredOwnedCount}
-      />
-
-      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {filteredWeapons.map((weapon) => (
-          <WeaponCard
-            key={weapon.id}
-            weapon={weapon}
-            instanceCount={instanceCounts[weapon.id] ?? 0}
-            selected={effectiveSelectedWeaponId === weapon.id}
-            onClick={handleWeaponClick}
+      <div className="sticky top-0 z-10 bg-background shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 py-4">
+          {error && (
+            <p className="mb-3 rounded-md bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
+              Failed to sync weapon collection.
+            </p>
+          )}
+          <WeaponFilters
+            filters={filters}
+            onChange={setFilters}
+            filteredCount={filteredWeapons.length}
+            totalCount={WEAPONS.length}
+            ownedCount={ownedWeaponIds.size}
+            filteredOwnedCount={filteredOwnedCount}
           />
-        ))}
+        </div>
       </div>
 
-      {filteredWeapons.length === 0 && (
-        <p className="py-12 text-center text-muted-foreground">No weapons match your filters.</p>
-      )}
+      <div className="mx-auto max-w-7xl px-4 pb-12 pt-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filteredWeapons.map((weapon) => (
+            <WeaponCard
+              key={weapon.id}
+              weapon={weapon}
+              instanceCount={instanceCounts[weapon.id] ?? 0}
+              selected={effectiveSelectedWeaponId === weapon.id}
+              onClick={handleWeaponClick}
+            />
+          ))}
+        </div>
+
+        {filteredWeapons.length === 0 && (
+          <p className="py-12 text-center text-muted-foreground">No weapons match your filters.</p>
+        )}
+      </div>
 
       <WeaponInstanceSidebar
         weaponId={effectiveSelectedWeaponId}
@@ -163,6 +168,6 @@ export function WeaponsPage() {
         onRemove={removeWeapon}
         onRefinementChange={setRefinementLevel}
       />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Wraps the filter bar on `CharactersPage` and `WeaponsPage` in a `sticky top-0 z-10` container so it stays visible while scrolling through the card grid
- Full-width `bg-background` and `shadow-sm` prevent card content from visually bleeding through the pinned bar
- Card grid moves into its own scrollable section below; `WeaponInstanceSidebar` is unaffected

Closes #682

## Test plan

- [x] Scroll through 50+ character cards — filter bar remains pinned at top
- [x] Adjust a filter while scrolled down — card grid updates without losing scroll position
- [x] Repeat both checks on the Weapons page
- [x] Confirm the weapon instance sidebar still opens and functions correctly
- [x] Verify no visual bleed-through of card content under the sticky bar (light and dark themes)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)