### PR TITLE
feat(api): versioned schema migration for all Firestore repositories

### DIFF
--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -48,6 +48,21 @@ formatters
 # Backend and database
 Firebase
 Firestore
+Verzod
+
+# Schema tooling
+backfilled
+deserializer
+jsoncompat
+Memcache
+optionalslop
+Ostrow
+Parseable
+rollouts
+serializer
+SRECon
+superset
+Zod
 Hono
 
 # Environment and deployment

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,9 @@
     "firebase-admin": "13.8.0",
     "google-gax": "5.0.6",
     "hono": "4.12.14",
-    "negotiator": "1.0.0"
+    "negotiator": "1.0.0",
+    "verzod": "0.5.1",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/apps/api/src/repositories/characters/document.test.ts
+++ b/apps/api/src/repositories/characters/document.test.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CURRENT_VERSION,
+  fromDocument,
+  toDocument,
+  type V1Character,
+  type V0Character,
+} from './document.js';
+
+const TIMESTAMP = '2024-01-15T12:00:00.000Z';
+
+function makeV1Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    schemaVersion: 1 as const,
+    constellationLevel: 3,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V1Character;
+  return { ...base, ...overrides };
+}
+
+function makeV0Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    constellationLevel: 0,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V0Character;
+  return { ...base, ...overrides };
+}
+
+describe('fromDocument', () => {
+  it('migrates a v0 document (no schemaVersion)', () => {
+    const char = fromDocument('columbina', makeV0Document());
+    expect(char.constellationLevel).toBe(0);
+  });
+
+  it('throws when domain assertion fails (invalid constellation level)', () => {
+    expect(() => fromDocument('columbina', makeV1Document({ constellationLevel: 7 }))).toThrow(
+      TypeError,
+    );
+  });
+});
+
+describe('toDocument', () => {
+  it('stamps the current schema version', () => {
+    const char = fromDocument('columbina', makeV1Document());
+    const doc = toDocument(char);
+    expect(doc.schemaVersion).toBe(CURRENT_VERSION);
+  });
+
+  it('round-trips a character through toDocument then fromDocument', () => {
+    const char = fromDocument('columbina', makeV1Document());
+    const doc = toDocument(char);
+    const restored = fromDocument('columbina', doc as unknown as Record<string, unknown>);
+    expect(restored).toEqual(char);
+  });
+});

--- a/apps/api/src/repositories/characters/document.ts
+++ b/apps/api/src/repositories/characters/document.ts
@@ -2,24 +2,34 @@
 // SPDX-License-Identifier: MIT
 
 import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
+import { assertCollectionCharacter } from '@genshin/domain';
 
-export interface DocumentData {
-  constellationLevel: number;
-  createdAt: string;
-  updatedAt: string;
-}
+import { entity, CURRENT_VERSION, type V1Character, type V0Character } from './schemas/index.js';
 
-export function fromDocument(characterId: string, data: DocumentData): CollectionCharacter {
-  return {
+export { CURRENT_VERSION, type V1Character, type V0Character };
+
+export function fromDocument(
+  characterId: string,
+  raw: Record<string, unknown>,
+): CollectionCharacter {
+  const result = entity.safeParse(raw);
+  if (result.type !== 'ok') {
+    throw new TypeError(`Invalid character document: ${result.error.type}`);
+  }
+  const data = result.value;
+  const character = {
     characterId,
     constellationLevel: data.constellationLevel,
     createdAt: data.createdAt as ISOTimestamp,
     updatedAt: data.updatedAt as ISOTimestamp,
   };
+  assertCollectionCharacter(character);
+  return character;
 }
 
-export function toDocument(character: CollectionCharacter): DocumentData {
+export function toDocument(character: CollectionCharacter): V1Character {
   return {
+    schemaVersion: CURRENT_VERSION,
     constellationLevel: character.constellationLevel,
     createdAt: character.createdAt,
     updatedAt: character.updatedAt,

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -4,19 +4,19 @@
 import { db } from '@/lib/firebase/firestore.js';
 import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
 
-import { fromDocument, toDocument, type DocumentData } from './document.js';
+import { fromDocument, toDocument } from './document.js';
 
 function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('characters');
 }
 
-export async function listCharacters(userId: string): Promise<CollectionCharacter[]> {
+export async function list(userId: string): Promise<CollectionCharacter[]> {
   const snapshot = await collectionRef(userId).get();
 
-  return snapshot.docs.map((doc) => fromDocument(doc.id, doc.data() as DocumentData));
+  return snapshot.docs.map((doc) => fromDocument(doc.id, doc.data()!));
 }
 
-export async function getCharacter(
+export async function get(
   userId: string,
   characterId: string,
 ): Promise<CollectionCharacter | null> {
@@ -26,19 +26,19 @@ export async function getCharacter(
     return null;
   }
 
-  return fromDocument(characterId, doc.data() as DocumentData);
+  return fromDocument(characterId, doc.data()!);
 }
 
-export interface SaveCharacterResult {
+export interface SaveResult {
   character: CollectionCharacter;
   created: boolean;
 }
 
-export async function saveCharacter(
+export async function save(
   userId: string,
   characterId: string,
   constellationLevel: number,
-): Promise<SaveCharacterResult> {
+): Promise<SaveResult> {
   const docRef = collectionRef(userId).doc(characterId);
   const existing = await docRef.get();
   const now = new Date().toISOString() as ISOTimestamp;
@@ -46,9 +46,7 @@ export async function saveCharacter(
   const character: CollectionCharacter = {
     characterId,
     constellationLevel,
-    createdAt: existing.exists
-      ? ((existing.data() as DocumentData).createdAt as ISOTimestamp)
-      : now,
+    createdAt: existing.exists ? fromDocument(characterId, existing.data()!).createdAt : now,
     updatedAt: now,
   };
 
@@ -57,6 +55,6 @@ export async function saveCharacter(
   return { character, created: !existing.exists };
 }
 
-export async function deleteCharacter(userId: string, characterId: string): Promise<void> {
+export async function remove(userId: string, characterId: string): Promise<void> {
   await collectionRef(userId).doc(characterId).delete();
 }

--- a/apps/api/src/repositories/characters/schemas/index.ts
+++ b/apps/api/src/repositories/characters/schemas/index.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { createVersionedEntity, type InferredEntity } from 'verzod';
+
+import { v0 } from './v0.js';
+import { v1 } from './v1.js';
+
+export { type V0Character } from './v0.js';
+
+export const CURRENT_VERSION = 1 as const;
+
+export const entity = createVersionedEntity({
+  latestVersion: CURRENT_VERSION,
+  versionMap: { 0: v0, 1: v1 },
+  getVersion(data: unknown) {
+    if (typeof data !== 'object' || data === null) return null;
+    const ver = (data as Record<string, unknown>).schemaVersion;
+    return typeof ver === 'number' ? ver : 0;
+  },
+});
+
+export type V1Character = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/characters/schemas/v0.ts
+++ b/apps/api/src/repositories/characters/schemas/v0.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+export const V0CharacterSchema = z.object({
+  constellationLevel: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type V0Character = z.infer<typeof V0CharacterSchema>;
+
+export const v0 = defineVersion({ initial: true, schema: V0CharacterSchema });

--- a/apps/api/src/repositories/characters/schemas/v1.ts
+++ b/apps/api/src/repositories/characters/schemas/v1.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+import { type V0Character } from './v0.js';
+
+export const V1CharacterSchema = z.object({
+  schemaVersion: z.literal(1),
+  constellationLevel: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const v1 = defineVersion({
+  initial: false,
+  schema: V1CharacterSchema,
+  up: (old: V0Character): z.infer<typeof V1CharacterSchema> => ({
+    schemaVersion: 1,
+    constellationLevel: old.constellationLevel,
+    createdAt: old.createdAt,
+    updatedAt: old.updatedAt,
+  }),
+});

--- a/apps/api/src/repositories/profile/document.test.ts
+++ b/apps/api/src/repositories/profile/document.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CURRENT_VERSION,
+  fromDocument,
+  toDocument,
+  type V1Profile,
+  type V0Profile,
+} from './document.js';
+
+const TIMESTAMP = '2024-01-15T12:00:00.000Z';
+
+function makeV1Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    schemaVersion: 1 as const,
+    name: 'Traveler',
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V1Profile;
+  return { ...base, ...overrides };
+}
+
+function makeV0Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    name: 'Old Traveler',
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V0Profile;
+  return { ...base, ...overrides };
+}
+
+describe('fromDocument', () => {
+  it('migrates a v0 document (no schemaVersion)', () => {
+    const profile = fromDocument(makeV0Document());
+    expect(profile.name).toBe('Old Traveler');
+  });
+
+  it('throws when domain assertion fails (invalid timestamp)', () => {
+    expect(() => fromDocument(makeV1Document({ createdAt: 'not-a-date' }))).toThrow(TypeError);
+  });
+});
+
+describe('toDocument', () => {
+  it('stamps the current schema version', () => {
+    const profile = fromDocument(makeV1Document());
+    const doc = toDocument(profile);
+    expect(doc.schemaVersion).toBe(CURRENT_VERSION);
+  });
+
+  it('round-trips a profile through toDocument then fromDocument', () => {
+    const profile = fromDocument(makeV1Document());
+    const doc = toDocument(profile);
+    const restored = fromDocument(doc as unknown as Record<string, unknown>);
+    expect(restored).toEqual(profile);
+  });
+});

--- a/apps/api/src/repositories/profile/document.ts
+++ b/apps/api/src/repositories/profile/document.ts
@@ -2,23 +2,30 @@
 // SPDX-License-Identifier: MIT
 
 import type { ISOTimestamp, UserProfile } from '@genshin/domain';
+import { assertUserProfile } from '@genshin/domain';
 
-export interface DocumentData {
-  name: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import { entity, CURRENT_VERSION, type V1Profile, type V0Profile } from './schemas/index.js';
 
-export function fromDocument(data: DocumentData): UserProfile {
-  return {
+export { CURRENT_VERSION, type V1Profile, type V0Profile };
+
+export function fromDocument(raw: Record<string, unknown>): UserProfile {
+  const result = entity.safeParse(raw);
+  if (result.type !== 'ok') {
+    throw new TypeError(`Invalid profile document: ${result.error.type}`);
+  }
+  const data = result.value;
+  const profile = {
     name: data.name,
     createdAt: data.createdAt as ISOTimestamp,
     updatedAt: data.updatedAt as ISOTimestamp,
   };
+  assertUserProfile(profile);
+  return profile;
 }
 
-export function toDocument(profile: UserProfile): DocumentData {
+export function toDocument(profile: UserProfile): V1Profile {
   return {
+    schemaVersion: CURRENT_VERSION,
     name: profile.name,
     createdAt: profile.createdAt,
     updatedAt: profile.updatedAt,

--- a/apps/api/src/repositories/profile/index.ts
+++ b/apps/api/src/repositories/profile/index.ts
@@ -4,23 +4,23 @@
 import { db } from '@/lib/firebase/firestore.js';
 import type { ISOTimestamp, ProfileUpdate, UserProfile } from '@genshin/domain';
 
-import { fromDocument, toDocument, type DocumentData } from './document.js';
+import { fromDocument, toDocument } from './document.js';
 
 function docRef(userId: string) {
   return db.collection('users').doc(userId);
 }
 
-export async function getProfile(userId: string): Promise<UserProfile | null> {
+export async function get(userId: string): Promise<UserProfile | null> {
   const doc = await docRef(userId).get();
 
   if (!doc.exists) {
     return null;
   }
 
-  return fromDocument(doc.data() as DocumentData);
+  return fromDocument(doc.data()!);
 }
 
-export async function updateProfile(userId: string, fields: ProfileUpdate): Promise<UserProfile> {
+export async function update(userId: string, fields: ProfileUpdate): Promise<UserProfile> {
   const ref = docRef(userId);
   const existing = await ref.get();
   const now = new Date().toISOString() as ISOTimestamp;
@@ -36,7 +36,7 @@ export async function updateProfile(userId: string, fields: ProfileUpdate): Prom
     return profile;
   }
 
-  const current = fromDocument(existing.data() as DocumentData);
+  const current = fromDocument(existing.data()!);
   const updated: UserProfile = {
     ...current,
     ...fields,

--- a/apps/api/src/repositories/profile/schemas/index.ts
+++ b/apps/api/src/repositories/profile/schemas/index.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { createVersionedEntity, type InferredEntity } from 'verzod';
+
+import { v0 } from './v0.js';
+import { v1 } from './v1.js';
+
+export { type V0Profile } from './v0.js';
+
+export const CURRENT_VERSION = 1 as const;
+
+export const entity = createVersionedEntity({
+  latestVersion: CURRENT_VERSION,
+  versionMap: { 0: v0, 1: v1 },
+  getVersion(data: unknown) {
+    if (typeof data !== 'object' || data === null) return null;
+    const ver = (data as Record<string, unknown>).schemaVersion;
+    return typeof ver === 'number' ? ver : 0;
+  },
+});
+
+export type V1Profile = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/profile/schemas/v0.ts
+++ b/apps/api/src/repositories/profile/schemas/v0.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+export const V0ProfileSchema = z.object({
+  name: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type V0Profile = z.infer<typeof V0ProfileSchema>;
+
+export const v0 = defineVersion({ initial: true, schema: V0ProfileSchema });

--- a/apps/api/src/repositories/profile/schemas/v1.ts
+++ b/apps/api/src/repositories/profile/schemas/v1.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+import { type V0Profile } from './v0.js';
+
+export const V1ProfileSchema = z.object({
+  schemaVersion: z.literal(1),
+  name: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const v1 = defineVersion({
+  initial: false,
+  schema: V1ProfileSchema,
+  up: (old: V0Profile): z.infer<typeof V1ProfileSchema> => ({
+    schemaVersion: 1,
+    name: old.name,
+    createdAt: old.createdAt,
+    updatedAt: old.updatedAt,
+  }),
+});

--- a/apps/api/src/repositories/teams/document.test.ts
+++ b/apps/api/src/repositories/teams/document.test.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { CURRENT_VERSION, fromDocument, toDocument, type V1Team, type V0Team } from './document.js';
+
+const TIMESTAMP = '2024-01-15T12:00:00.000Z';
+
+function makeV1Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    schemaVersion: 1 as const,
+    name: 'My Team',
+    members: [{ characterId: 'columbina' }, null, null, null],
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V1Team;
+  return { ...base, ...overrides };
+}
+
+function makeV0Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    name: 'Old Team',
+    members: [null, null, null, null],
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V0Team;
+  return { ...base, ...overrides };
+}
+
+describe('fromDocument', () => {
+  it('migrates a v0 document (no schemaVersion)', () => {
+    const team = fromDocument(2, makeV0Document());
+    expect(team.slot).toBe(2);
+    expect(team.name).toBe('Old Team');
+  });
+
+  it('migrates primaryStats → priorityMinorAffixes in v0 artifact plans', () => {
+    const team = fromDocument(
+      1,
+      makeV0Document({
+        members: [
+          {
+            characterId: 'columbina',
+            artifactPlan: {
+              primaryStats: ['crit-rate', 'crit-damage'],
+              secondaryStats: ['elemental-mastery'],
+            },
+          },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.priorityMinorAffixes).toEqual([
+      'crit-rate',
+      'crit-damage',
+    ]);
+    expect(team.members[0]?.artifactPlan?.secondaryMinorAffixes).toEqual(['elemental-mastery']);
+    expect(team.members[0]?.artifactPlan).not.toHaveProperty('primaryStats');
+    expect(team.members[0]?.artifactPlan).not.toHaveProperty('secondaryStats');
+  });
+
+  it('preserves priorityMinorAffixes in v0 artifact plans that already use new names', () => {
+    const team = fromDocument(
+      1,
+      makeV0Document({
+        name: 'Team',
+        members: [
+          { characterId: 'columbina', artifactPlan: { priorityMinorAffixes: ['crit-rate'] } },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.priorityMinorAffixes).toEqual(['crit-rate']);
+  });
+
+  it('throws for too many members', () => {
+    expect(() =>
+      fromDocument(1, makeV1Document({ members: [null, null, null, null, null] })),
+    ).toThrow(TypeError);
+  });
+
+  it('includes optional description', () => {
+    const team = fromDocument(1, makeV1Document({ description: 'My best team' }));
+    expect(team.description).toBe('My best team');
+  });
+});
+
+describe('toDocument', () => {
+  it('stamps the current schema version', () => {
+    const team = fromDocument(1, makeV1Document());
+    const doc = toDocument(team);
+    expect(doc.schemaVersion).toBe(CURRENT_VERSION);
+  });
+
+  it('round-trips a team through toDocument then fromDocument', () => {
+    const team = fromDocument(1, makeV1Document());
+    const doc = toDocument(team);
+    const restored = fromDocument(1, doc as unknown as Record<string, unknown>);
+    expect(restored).toEqual(team);
+  });
+});

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -8,53 +8,42 @@ import type {
   ISOTimestamp,
   TeamSlot,
 } from '@genshin/domain';
-import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+import { assertCollectionTeam } from '@genshin/domain';
 
-export interface MemberDocumentData {
-  characterId: string;
-  weaponInstanceId?: string;
-  artifactPlan?: {
-    sands?: string;
-    goblet?: string;
-    circlet?: string;
-    sets?: string[];
-    priorityMinorAffixes?: string[];
-    secondaryMinorAffixes?: string[];
-  };
-}
+import {
+  entity,
+  CURRENT_VERSION,
+  type V1Team,
+  type V0Team,
+  type V1Member,
+} from './schemas/index.js';
 
-export interface DocumentData {
-  name: string;
-  members: (MemberDocumentData | null)[];
-  description?: string;
-  createdAt: string;
-  updatedAt: string;
-}
+export { CURRENT_VERSION, type V1Team, type V0Team };
 
-function memberFromDocument(m: MemberDocumentData): CollectionTeamMember {
+function memberFromDocument(m: V1Member): CollectionTeamMember {
   return {
     characterId: m.characterId,
-    ...(m.weaponInstanceId ? { weaponInstanceId: m.weaponInstanceId } : {}),
-    ...(m.artifactPlan ? { artifactPlan: m.artifactPlan } : {}),
+    ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
+    ...(m.artifactPlan !== undefined ? { artifactPlan: m.artifactPlan } : {}),
   } as CollectionTeamMember;
 }
 
-function memberToDocument(m: CollectionTeamMember): MemberDocumentData {
+function memberToDocument(m: CollectionTeamMember): V1Member {
   return {
     characterId: m.characterId,
-    ...(m.weaponInstanceId ? { weaponInstanceId: m.weaponInstanceId } : {}),
-    ...(m.artifactPlan ? { artifactPlan: m.artifactPlan } : {}),
+    ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
+    ...(m.artifactPlan !== undefined ? { artifactPlan: m.artifactPlan } : {}),
   };
 }
 
-export function fromDocument(slot: TeamSlot, data: DocumentData): CollectionTeam {
-  if (data.members.length > MAX_TEAM_MEMBERS) {
-    throw new TypeError(
-      `Document members must have at most ${MAX_TEAM_MEMBERS} entries, got: ${data.members.length}`,
-    );
+export function fromDocument(slot: TeamSlot, raw: Record<string, unknown>): CollectionTeam {
+  const result = entity.safeParse(raw);
+  if (result.type !== 'ok') {
+    throw new TypeError(`Invalid team document: ${result.error.type}`);
   }
+  const data = result.value;
   const mapped = data.members.map((m) => (m === null ? null : memberFromDocument(m)));
-  return {
+  const team = {
     slot,
     name: data.name,
     members: [
@@ -67,10 +56,13 @@ export function fromDocument(slot: TeamSlot, data: DocumentData): CollectionTeam
     createdAt: data.createdAt as ISOTimestamp,
     updatedAt: data.updatedAt as ISOTimestamp,
   };
+  assertCollectionTeam(team);
+  return team;
 }
 
-export function toDocument(team: CollectionTeam): DocumentData {
+export function toDocument(team: CollectionTeam): V1Team {
   return {
+    schemaVersion: CURRENT_VERSION,
     name: team.name,
     members: team.members.map((m) => (m === null ? null : memberToDocument(m))),
     ...(team.description !== undefined ? { description: team.description } : {}),

--- a/apps/api/src/repositories/teams/index.ts
+++ b/apps/api/src/repositories/teams/index.ts
@@ -4,36 +4,36 @@
 import { db } from '@/lib/firebase/firestore.js';
 import type { CollectionTeam, ISOTimestamp, TeamSlot } from '@genshin/domain';
 
-import { fromDocument, toDocument, type DocumentData } from './document.js';
+import { fromDocument, toDocument } from './document.js';
 
 function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('teams');
 }
 
-export async function listTeams(userId: string): Promise<CollectionTeam[]> {
+export async function list(userId: string): Promise<CollectionTeam[]> {
   const snapshot = await collectionRef(userId).get();
 
   return snapshot.docs
     .filter((doc) => /^[1-4]$/.test(doc.id))
-    .map((doc) => fromDocument(Number(doc.id) as TeamSlot, doc.data() as DocumentData));
+    .map((doc) => fromDocument(Number(doc.id) as TeamSlot, doc.data()!));
 }
 
-export async function getTeam(userId: string, slot: TeamSlot): Promise<CollectionTeam | null> {
+export async function get(userId: string, slot: TeamSlot): Promise<CollectionTeam | null> {
   const doc = await collectionRef(userId).doc(String(slot)).get();
 
   if (!doc.exists) {
     return null;
   }
 
-  return fromDocument(slot, doc.data() as DocumentData);
+  return fromDocument(slot, doc.data()!);
 }
 
-export interface SaveTeamResult {
+export interface SaveResult {
   team: CollectionTeam;
   created: boolean;
 }
 
-export async function saveTeam(
+export async function save(
   userId: string,
   slot: TeamSlot,
   updates: {
@@ -41,28 +41,28 @@ export async function saveTeam(
     members?: CollectionTeam['members'];
     description?: string;
   },
-): Promise<SaveTeamResult> {
+): Promise<SaveResult> {
   const docRef = collectionRef(userId).doc(String(slot));
   const existing = await docRef.get();
   const now = new Date().toISOString() as ISOTimestamp;
 
-  const existingData = existing.exists ? (existing.data() as DocumentData) : null;
+  const existingTeam = existing.exists ? fromDocument(slot, existing.data()!) : null;
 
   const team: CollectionTeam = {
     slot,
-    name: updates.name ?? existingData?.name ?? `Team ${slot}`,
+    name: updates.name ?? existingTeam?.name ?? `Team ${slot}`,
     members:
       updates.members !== undefined
         ? updates.members
-        : existingData
-          ? fromDocument(slot, existingData).members
+        : existingTeam
+          ? existingTeam.members
           : [null, null, null, null],
     ...(updates.description !== undefined
       ? { description: updates.description }
-      : existingData?.description !== undefined
-        ? { description: existingData.description }
+      : existingTeam?.description !== undefined
+        ? { description: existingTeam.description }
         : {}),
-    createdAt: existingData ? (existingData.createdAt as ISOTimestamp) : now,
+    createdAt: existingTeam ? existingTeam.createdAt : now,
     updatedAt: now,
   };
 
@@ -71,6 +71,6 @@ export async function saveTeam(
   return { team, created: !existing.exists };
 }
 
-export async function deleteTeam(userId: string, slot: TeamSlot): Promise<void> {
+export async function remove(userId: string, slot: TeamSlot): Promise<void> {
   await collectionRef(userId).doc(String(slot)).delete();
 }

--- a/apps/api/src/repositories/teams/schemas/index.ts
+++ b/apps/api/src/repositories/teams/schemas/index.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { createVersionedEntity, type InferredEntity } from 'verzod';
+
+import { v0 } from './v0.js';
+import { v1 } from './v1.js';
+
+export { type V0Team } from './v0.js';
+export { type V1Member } from './v1.js';
+
+export const CURRENT_VERSION = 1 as const;
+
+export const entity = createVersionedEntity({
+  latestVersion: CURRENT_VERSION,
+  versionMap: { 0: v0, 1: v1 },
+  getVersion(data: unknown) {
+    if (typeof data !== 'object' || data === null) return null;
+    const ver = (data as Record<string, unknown>).schemaVersion;
+    return typeof ver === 'number' ? ver : 0;
+  },
+});
+
+export type V1Team = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/teams/schemas/v0.ts
+++ b/apps/api/src/repositories/teams/schemas/v0.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+export const V0MemberSchema = z.object({
+  characterId: z.string(),
+  weaponInstanceId: z.string().optional(),
+  artifactPlan: z
+    .object({
+      sands: z.string().optional(),
+      goblet: z.string().optional(),
+      circlet: z.string().optional(),
+      sets: z.array(z.string()).optional(),
+      primaryStats: z.array(z.string()).optional(),
+      secondaryStats: z.array(z.string()).optional(),
+      priorityMinorAffixes: z.array(z.string()).optional(),
+      secondaryMinorAffixes: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+export const V0TeamSchema = z.object({
+  name: z.string(),
+  members: z.array(z.union([z.null(), V0MemberSchema])).max(MAX_TEAM_MEMBERS),
+  description: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type V0Team = z.infer<typeof V0TeamSchema>;
+
+export const v0 = defineVersion({ initial: true, schema: V0TeamSchema });

--- a/apps/api/src/repositories/teams/schemas/v1.ts
+++ b/apps/api/src/repositories/teams/schemas/v1.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+import { type V0Team, V0MemberSchema } from './v0.js';
+
+export const V1MemberSchema = z.object({
+  characterId: z.string(),
+  weaponInstanceId: z.string().optional(),
+  artifactPlan: z
+    .object({
+      sands: z.string().optional(),
+      goblet: z.string().optional(),
+      circlet: z.string().optional(),
+      sets: z.array(z.string()).optional(),
+      priorityMinorAffixes: z.array(z.string()).optional(),
+      secondaryMinorAffixes: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+export type V1Member = z.infer<typeof V1MemberSchema>;
+
+export const V1TeamSchema = z.object({
+  schemaVersion: z.literal(1),
+  name: z.string(),
+  members: z.array(z.union([z.null(), V1MemberSchema])).max(MAX_TEAM_MEMBERS),
+  description: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const v1 = defineVersion({
+  initial: false,
+  schema: V1TeamSchema,
+  up: (old: V0Team): z.infer<typeof V1TeamSchema> => ({
+    schemaVersion: 1,
+    name: old.name,
+    members: old.members.map((m): z.infer<typeof V1MemberSchema> | null => {
+      if (m === null) return null;
+      if (!m.artifactPlan) {
+        return {
+          characterId: m.characterId,
+          ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
+        };
+      }
+      const {
+        primaryStats,
+        secondaryStats,
+        sands,
+        goblet,
+        circlet,
+        sets,
+        priorityMinorAffixes,
+        secondaryMinorAffixes,
+      } = m.artifactPlan;
+      return {
+        characterId: m.characterId,
+        ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
+        artifactPlan: {
+          ...(sands !== undefined ? { sands } : {}),
+          ...(goblet !== undefined ? { goblet } : {}),
+          ...(circlet !== undefined ? { circlet } : {}),
+          ...(sets !== undefined ? { sets } : {}),
+          ...(primaryStats !== undefined
+            ? { priorityMinorAffixes: primaryStats }
+            : priorityMinorAffixes !== undefined
+              ? { priorityMinorAffixes }
+              : {}),
+          ...(secondaryStats !== undefined
+            ? { secondaryMinorAffixes: secondaryStats }
+            : secondaryMinorAffixes !== undefined
+              ? { secondaryMinorAffixes }
+              : {}),
+        },
+      };
+    }),
+    ...(old.description !== undefined ? { description: old.description } : {}),
+    createdAt: old.createdAt,
+    updatedAt: old.updatedAt,
+  }),
+});
+
+// V0MemberSchema re-exported so the map callback type is available without
+// reaching into v0 directly from outside the schemas directory.
+export { V0MemberSchema };

--- a/apps/api/src/repositories/weapons/document.test.ts
+++ b/apps/api/src/repositories/weapons/document.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { UUID } from '@genshin/domain';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CURRENT_VERSION,
+  fromDocument,
+  toDocument,
+  type V1Weapon,
+  type V0Weapon,
+} from './document.js';
+
+const TIMESTAMP = '2024-01-15T12:00:00.000Z';
+const WEAPON_INSTANCE_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+
+function makeV1Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    schemaVersion: 1 as const,
+    weaponId: 'mistsplitter-reforged',
+    refinementLevel: 1,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V1Weapon;
+  return { ...base, ...overrides };
+}
+
+function makeV0Document(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    weaponId: 'mistsplitter-reforged',
+    refinementLevel: 2,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  } satisfies V0Weapon;
+  return { ...base, ...overrides };
+}
+
+describe('fromDocument', () => {
+  it('migrates a v0 document (no schemaVersion)', () => {
+    const weapon = fromDocument(WEAPON_INSTANCE_ID, makeV0Document());
+    expect(weapon.refinementLevel).toBe(2);
+  });
+
+  it('throws when domain assertion fails (invalid refinement level)', () => {
+    expect(() => fromDocument(WEAPON_INSTANCE_ID, makeV1Document({ refinementLevel: 6 }))).toThrow(
+      TypeError,
+    );
+  });
+});
+
+describe('toDocument', () => {
+  it('stamps the current schema version', () => {
+    const weapon = fromDocument(WEAPON_INSTANCE_ID, makeV1Document());
+    const doc = toDocument(weapon);
+    expect(doc.schemaVersion).toBe(CURRENT_VERSION);
+  });
+
+  it('round-trips a weapon through toDocument then fromDocument', () => {
+    const weapon = fromDocument(WEAPON_INSTANCE_ID, makeV1Document());
+    const doc = toDocument(weapon);
+    const restored = fromDocument(WEAPON_INSTANCE_ID, doc as unknown as Record<string, unknown>);
+    expect(restored).toEqual(weapon);
+  });
+});

--- a/apps/api/src/repositories/weapons/document.ts
+++ b/apps/api/src/repositories/weapons/document.ts
@@ -2,26 +2,35 @@
 // SPDX-License-Identifier: MIT
 
 import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/domain';
+import { assertCollectionWeapon } from '@genshin/domain';
 
-export interface DocumentData {
-  weaponId: string;
-  refinementLevel: number;
-  createdAt: string;
-  updatedAt: string;
-}
+import { entity, CURRENT_VERSION, type V1Weapon, type V0Weapon } from './schemas/index.js';
 
-export function fromDocument(weaponInstanceId: UUID, data: DocumentData): CollectionWeapon {
-  return {
+export { CURRENT_VERSION, type V1Weapon, type V0Weapon };
+
+export function fromDocument(
+  weaponInstanceId: UUID,
+  raw: Record<string, unknown>,
+): CollectionWeapon {
+  const result = entity.safeParse(raw);
+  if (result.type !== 'ok') {
+    throw new TypeError(`Invalid weapon document: ${result.error.type}`);
+  }
+  const data = result.value;
+  const weapon = {
     weaponInstanceId,
     weaponId: data.weaponId,
     refinementLevel: data.refinementLevel,
     createdAt: data.createdAt as ISOTimestamp,
     updatedAt: data.updatedAt as ISOTimestamp,
   };
+  assertCollectionWeapon(weapon);
+  return weapon;
 }
 
-export function toDocument(weapon: CollectionWeapon): DocumentData {
+export function toDocument(weapon: CollectionWeapon): V1Weapon {
   return {
+    schemaVersion: CURRENT_VERSION,
     weaponId: weapon.weaponId,
     refinementLevel: weapon.refinementLevel,
     createdAt: weapon.createdAt,

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -5,22 +5,22 @@ import { db } from '@/lib/firebase/firestore.js';
 import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/domain';
 import { randomUUID } from 'node:crypto';
 
-import { fromDocument, toDocument, type DocumentData } from './document.js';
+import { fromDocument, toDocument } from './document.js';
 
 function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('weapons');
 }
 
-export async function listWeapons(userId: string, weaponId?: string): Promise<CollectionWeapon[]> {
+export async function list(userId: string, weaponId?: string): Promise<CollectionWeapon[]> {
   const ref = weaponId
     ? collectionRef(userId).where('weaponId', '==', weaponId)
     : collectionRef(userId);
   const snapshot = await ref.get();
 
-  return snapshot.docs.map((doc) => fromDocument(doc.id as UUID, doc.data() as DocumentData));
+  return snapshot.docs.map((doc) => fromDocument(doc.id as UUID, doc.data()!));
 }
 
-export async function getWeapon(
+export async function get(
   userId: string,
   weaponInstanceId: UUID,
 ): Promise<CollectionWeapon | null> {
@@ -30,10 +30,10 @@ export async function getWeapon(
     return null;
   }
 
-  return fromDocument(weaponInstanceId, doc.data() as DocumentData);
+  return fromDocument(weaponInstanceId, doc.data()!);
 }
 
-export async function createWeapon(
+export async function create(
   userId: string,
   weaponId: string,
   refinementLevel: number,
@@ -54,7 +54,7 @@ export async function createWeapon(
   return weapon;
 }
 
-export async function updateWeapon(
+export async function update(
   userId: string,
   weaponInstanceId: UUID,
   refinementLevel: number,
@@ -66,14 +66,14 @@ export async function updateWeapon(
     return null;
   }
 
-  const existingData = existing.data() as DocumentData;
+  const existingWeapon = fromDocument(weaponInstanceId, existing.data()!);
   const now = new Date().toISOString() as ISOTimestamp;
 
   const weapon: CollectionWeapon = {
     weaponInstanceId,
-    weaponId: existingData.weaponId,
+    weaponId: existingWeapon.weaponId,
     refinementLevel,
-    createdAt: existingData.createdAt as ISOTimestamp,
+    createdAt: existingWeapon.createdAt,
     updatedAt: now,
   };
 
@@ -82,6 +82,6 @@ export async function updateWeapon(
   return weapon;
 }
 
-export async function deleteWeapon(userId: string, weaponInstanceId: UUID): Promise<void> {
+export async function remove(userId: string, weaponInstanceId: UUID): Promise<void> {
   await collectionRef(userId).doc(weaponInstanceId).delete();
 }

--- a/apps/api/src/repositories/weapons/schemas/index.ts
+++ b/apps/api/src/repositories/weapons/schemas/index.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { createVersionedEntity, type InferredEntity } from 'verzod';
+
+import { v0 } from './v0.js';
+import { v1 } from './v1.js';
+
+export { type V0Weapon } from './v0.js';
+
+export const CURRENT_VERSION = 1 as const;
+
+export const entity = createVersionedEntity({
+  latestVersion: CURRENT_VERSION,
+  versionMap: { 0: v0, 1: v1 },
+  getVersion(data: unknown) {
+    if (typeof data !== 'object' || data === null) return null;
+    const ver = (data as Record<string, unknown>).schemaVersion;
+    return typeof ver === 'number' ? ver : 0;
+  },
+});
+
+export type V1Weapon = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/weapons/schemas/v0.ts
+++ b/apps/api/src/repositories/weapons/schemas/v0.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+export const V0WeaponSchema = z.object({
+  weaponId: z.string(),
+  refinementLevel: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type V0Weapon = z.infer<typeof V0WeaponSchema>;
+
+export const v0 = defineVersion({ initial: true, schema: V0WeaponSchema });

--- a/apps/api/src/repositories/weapons/schemas/v1.ts
+++ b/apps/api/src/repositories/weapons/schemas/v1.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+import { type V0Weapon } from './v0.js';
+
+export const V1WeaponSchema = z.object({
+  schemaVersion: z.literal(1),
+  weaponId: z.string(),
+  refinementLevel: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const v1 = defineVersion({
+  initial: false,
+  schema: V1WeaponSchema,
+  up: (old: V0Weapon): z.infer<typeof V1WeaponSchema> => ({
+    schemaVersion: 1,
+    weaponId: old.weaponId,
+    refinementLevel: old.refinementLevel,
+    createdAt: old.createdAt,
+    updatedAt: old.updatedAt,
+  }),
+});

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -9,10 +9,10 @@ vi.mock('@/lib/firebase/auth.js', () => ({
 }));
 
 vi.mock('@/repositories/characters/index.js', () => ({
-  listCharacters: vi.fn(),
-  getCharacter: vi.fn(),
-  saveCharacter: vi.fn(),
-  deleteCharacter: vi.fn(),
+  list: vi.fn(),
+  get: vi.fn(),
+  save: vi.fn(),
+  remove: vi.fn(),
 }));
 
 vi.mock('@genshin/game-data', () => ({
@@ -23,12 +23,7 @@ import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
 import { toMediaTypeString } from '@/middleware/negotiate-content.js';
 import { characterItemV1 } from '@/profiles/alps/character/item-v1.js';
-import {
-  deleteCharacter,
-  getCharacter,
-  listCharacters,
-  saveCharacter,
-} from '@/repositories/characters/index.js';
+import * as Characters from '@/repositories/characters/index.js';
 import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
@@ -86,7 +81,7 @@ describe('Character routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(listCharacters).mockResolvedValue([FAKE_CHARACTER]);
+      vi.mocked(Characters.list).mockResolvedValue([FAKE_CHARACTER]);
       res = await app.request(authedRequest('GET', '/api/characters'));
       body = (await res.json()) as CollectionDocument;
     });
@@ -113,7 +108,7 @@ describe('Character routes', () => {
     });
 
     it('returns empty items when no characters exist', async () => {
-      vi.mocked(listCharacters).mockResolvedValue([]);
+      vi.mocked(Characters.list).mockResolvedValue([]);
 
       const res = await app.request(authedRequest('GET', '/api/characters'));
 
@@ -122,7 +117,7 @@ describe('Character routes', () => {
     });
 
     it('returns 500 when repository throws', async () => {
-      vi.mocked(listCharacters).mockRejectedValue(new Error('Firestore unavailable'));
+      vi.mocked(Characters.list).mockRejectedValue(new Error('Firestore unavailable'));
 
       const res = await app.request(authedRequest('GET', '/api/characters'));
 
@@ -137,7 +132,7 @@ describe('Character routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(getCharacter).mockResolvedValue(FAKE_CHARACTER);
+      vi.mocked(Characters.get).mockResolvedValue(FAKE_CHARACTER);
       res = await app.request(authedRequest('GET', '/api/characters/albedo'));
       body = (await res.json()) as CollectionDocument;
     });
@@ -164,7 +159,7 @@ describe('Character routes', () => {
     });
 
     it('returns 404 when character not in collection', async () => {
-      vi.mocked(getCharacter).mockResolvedValue(null);
+      vi.mocked(Characters.get).mockResolvedValue(null);
 
       const res = await app.request(authedRequest('GET', '/api/characters/albedo'));
 
@@ -186,7 +181,7 @@ describe('Character routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(saveCharacter).mockResolvedValue({
+      vi.mocked(Characters.save).mockResolvedValue({
         character: FAKE_CHARACTER,
         created: true,
       });
@@ -218,7 +213,7 @@ describe('Character routes', () => {
     });
 
     it('returns 200 when character is updated', async () => {
-      vi.mocked(saveCharacter).mockResolvedValue({
+      vi.mocked(Characters.save).mockResolvedValue({
         character: FAKE_CHARACTER,
         created: false,
       });
@@ -305,7 +300,7 @@ describe('Character routes', () => {
     });
 
     it('accepts constellationLevel at minimum boundary', async () => {
-      vi.mocked(saveCharacter).mockResolvedValue({
+      vi.mocked(Characters.save).mockResolvedValue({
         character: { ...FAKE_CHARACTER, constellationLevel: MIN_CONSTELLATION_LEVEL },
         created: true,
       });
@@ -320,7 +315,7 @@ describe('Character routes', () => {
     });
 
     it('accepts constellationLevel at maximum boundary', async () => {
-      vi.mocked(saveCharacter).mockResolvedValue({
+      vi.mocked(Characters.save).mockResolvedValue({
         character: { ...FAKE_CHARACTER, constellationLevel: MAX_CONSTELLATION_LEVEL },
         created: true,
       });
@@ -337,7 +332,7 @@ describe('Character routes', () => {
 
   describe('DELETE /api/characters/:characterId', () => {
     it('returns 204 with no body', async () => {
-      vi.mocked(deleteCharacter).mockResolvedValue();
+      vi.mocked(Characters.remove).mockResolvedValue();
 
       const res = await app.request(authedRequest('DELETE', '/api/characters/albedo'));
 
@@ -346,7 +341,7 @@ describe('Character routes', () => {
     });
 
     it('returns 204 when character does not exist', async () => {
-      vi.mocked(deleteCharacter).mockResolvedValue();
+      vi.mocked(Characters.remove).mockResolvedValue();
 
       const res = await app.request(authedRequest('DELETE', '/api/characters/nonexistent'));
 

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -11,12 +11,7 @@ import type { ValidatedRequestBodyVariables } from '@/middleware/validate-reques
 import { validateRequestBody } from '@/middleware/validate-request-body.js';
 import { characterItemV1 } from '@/profiles/alps/character/item-v1.js';
 import { characterPutRequestV1 } from '@/profiles/json-schema/characters/put-request-v1.js';
-import {
-  deleteCharacter,
-  getCharacter,
-  listCharacters,
-  saveCharacter,
-} from '@/repositories/characters/index.js';
+import * as Characters from '@/repositories/characters/index.js';
 import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
 import { characterItemHref, characterRepresentation, serialiseCharacter } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
@@ -41,7 +36,7 @@ interface SaveCharacterBody {
 // GET /api/characters — List user's character collection
 characters.get('/', async (c) => {
   const userId = c.get('user').uid;
-  const items = await listCharacters(userId);
+  const items = await Characters.list(userId);
   const baseUrl = new URL(c.req.url).origin;
 
   return c.body(
@@ -63,7 +58,7 @@ characters.get('/:characterId', async (c) => {
   const userId = c.get('user').uid;
   const { characterId } = c.req.param();
 
-  const character = await getCharacter(userId, characterId);
+  const character = await Characters.get(userId, characterId);
 
   if (!character) {
     throw new HTTPException(404, { message: 'Character not found in collection' });
@@ -97,7 +92,7 @@ characters.put(
     }
 
     const { constellationLevel } = c.get('validatedBody') as SaveCharacterBody;
-    const { character, created } = await saveCharacter(userId, characterId, constellationLevel);
+    const { character, created } = await Characters.save(userId, characterId, constellationLevel);
     const baseUrl = new URL(c.req.url).origin;
 
     return c.body(
@@ -119,7 +114,7 @@ characters.delete('/:characterId', async (c) => {
   const userId = c.get('user').uid;
   const { characterId } = c.req.param();
 
-  await deleteCharacter(userId, characterId);
+  await Characters.remove(userId, characterId);
 
   return c.body(null, 204);
 });

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -9,25 +9,25 @@ vi.mock('@/lib/firebase/auth.js', () => ({
 }));
 
 vi.mock('@/repositories/teams/index.js', () => ({
-  listTeams: vi.fn(),
-  getTeam: vi.fn(),
-  saveTeam: vi.fn(),
-  deleteTeam: vi.fn(),
+  list: vi.fn(),
+  get: vi.fn(),
+  save: vi.fn(),
+  remove: vi.fn(),
 }));
 
 vi.mock('@/repositories/characters/index.js', () => ({
-  getCharacter: vi.fn(),
+  get: vi.fn(),
 }));
 
 vi.mock('@/repositories/weapons/index.js', () => ({
-  getWeapon: vi.fn(),
+  get: vi.fn(),
 }));
 
 import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
-import { getCharacter } from '@/repositories/characters/index.js';
-import { deleteTeam, getTeam, listTeams, saveTeam } from '@/repositories/teams/index.js';
-import { getWeapon } from '@/repositories/weapons/index.js';
+import * as Characters from '@/repositories/characters/index.js';
+import * as Teams from '@/repositories/teams/index.js';
+import * as Weapons from '@/repositories/weapons/index.js';
 import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 
@@ -61,7 +61,7 @@ const EXPECTED_CONTENT_TYPE = toMediaTypeString(
 );
 
 function mockCharacterOwned() {
-  vi.mocked(getCharacter).mockResolvedValue({
+  vi.mocked(Characters.get).mockResolvedValue({
     characterId: 'hu-tao',
     constellationLevel: 0,
     createdAt: '2026-01-01T00:00:00.000Z',
@@ -70,7 +70,7 @@ function mockCharacterOwned() {
 }
 
 function mockWeaponOwned() {
-  vi.mocked(getWeapon).mockResolvedValue({
+  vi.mocked(Weapons.get).mockResolvedValue({
     weaponInstanceId: 'uuid-1' as UUID,
     weaponId: 'staff-of-homa',
     refinementLevel: 1,
@@ -93,7 +93,7 @@ describe('Team routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(listTeams).mockResolvedValue([FAKE_TEAM, FAKE_EMPTY_TEAM]);
+      vi.mocked(Teams.list).mockResolvedValue([FAKE_TEAM, FAKE_EMPTY_TEAM]);
       res = await app.request(authedRequest('GET', '/api/teams'));
       body = (await res.json()) as CollectionDocument;
     });
@@ -120,7 +120,7 @@ describe('Team routes', () => {
     });
 
     it('returns empty items when no teams exist', async () => {
-      vi.mocked(listTeams).mockResolvedValue([]);
+      vi.mocked(Teams.list).mockResolvedValue([]);
 
       const res = await app.request(authedRequest('GET', '/api/teams'));
 
@@ -129,7 +129,7 @@ describe('Team routes', () => {
     });
 
     it('returns 500 when repository throws', async () => {
-      vi.mocked(listTeams).mockRejectedValue(new Error('Firestore unavailable'));
+      vi.mocked(Teams.list).mockRejectedValue(new Error('Firestore unavailable'));
 
       const res = await app.request(authedRequest('GET', '/api/teams'));
 
@@ -144,7 +144,7 @@ describe('Team routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(getTeam).mockResolvedValue(FAKE_TEAM);
+      vi.mocked(Teams.get).mockResolvedValue(FAKE_TEAM);
       res = await app.request(authedRequest('GET', '/api/teams/1'));
       body = (await res.json()) as CollectionDocument;
     });
@@ -171,7 +171,7 @@ describe('Team routes', () => {
     });
 
     it('returns 404 when team not found', async () => {
-      vi.mocked(getTeam).mockResolvedValue(null);
+      vi.mocked(Teams.get).mockResolvedValue(null);
 
       const res = await app.request(authedRequest('GET', '/api/teams/1'));
 
@@ -211,14 +211,14 @@ describe('Team routes', () => {
     beforeEach(() => {
       mockCharacterOwned();
       mockWeaponOwned();
-      vi.mocked(listTeams).mockResolvedValue([]);
+      vi.mocked(Teams.list).mockResolvedValue([]);
     });
 
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(saveTeam).mockResolvedValue({
+      vi.mocked(Teams.save).mockResolvedValue({
         team: FAKE_TEAM,
         created: true,
       });
@@ -253,7 +253,7 @@ describe('Team routes', () => {
     });
 
     it('returns 200 when team is updated', async () => {
-      vi.mocked(saveTeam).mockResolvedValue({
+      vi.mocked(Teams.save).mockResolvedValue({
         team: FAKE_TEAM,
         created: false,
       });
@@ -276,7 +276,7 @@ describe('Team routes', () => {
     });
 
     it('allows name-only update', async () => {
-      vi.mocked(saveTeam).mockResolvedValue({
+      vi.mocked(Teams.save).mockResolvedValue({
         team: { ...FAKE_TEAM, name: 'Renamed' },
         created: false,
       });
@@ -287,7 +287,7 @@ describe('Team routes', () => {
     });
 
     it('allows clearing all members', async () => {
-      vi.mocked(saveTeam).mockResolvedValue({
+      vi.mocked(Teams.save).mockResolvedValue({
         team: FAKE_EMPTY_TEAM,
         created: false,
       });
@@ -300,7 +300,7 @@ describe('Team routes', () => {
     });
 
     it('allows partial team with null placeholders', async () => {
-      vi.mocked(saveTeam).mockResolvedValue({
+      vi.mocked(Teams.save).mockResolvedValue({
         team: {
           ...FAKE_TEAM,
           members: [
@@ -323,7 +323,7 @@ describe('Team routes', () => {
     });
 
     it('allows member without weapon (optimizer placeholder)', async () => {
-      vi.mocked(saveTeam).mockResolvedValue({
+      vi.mocked(Teams.save).mockResolvedValue({
         team: {
           ...FAKE_TEAM,
           members: [{ characterId: 'hu-tao' }, null, null, null],
@@ -405,7 +405,7 @@ describe('Team routes', () => {
       });
 
       it('returns 400 when character not in collection', async () => {
-        vi.mocked(getCharacter).mockResolvedValue(null);
+        vi.mocked(Characters.get).mockResolvedValue(null);
 
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
@@ -424,7 +424,7 @@ describe('Team routes', () => {
       });
 
       it('returns 400 when weapon instance not in collection', async () => {
-        vi.mocked(getWeapon).mockResolvedValue(null);
+        vi.mocked(Weapons.get).mockResolvedValue(null);
 
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
@@ -460,7 +460,7 @@ describe('Team routes', () => {
       });
 
       it('returns 400 when weapon equipped by different character in another team', async () => {
-        vi.mocked(listTeams).mockResolvedValue([
+        vi.mocked(Teams.list).mockResolvedValue([
           {
             ...FAKE_TEAM,
             slot: 2,
@@ -485,7 +485,7 @@ describe('Team routes', () => {
       });
 
       it('allows same character to carry same weapon across teams', async () => {
-        vi.mocked(listTeams).mockResolvedValue([
+        vi.mocked(Teams.list).mockResolvedValue([
           {
             ...FAKE_TEAM,
             slot: 2,
@@ -497,7 +497,7 @@ describe('Team routes', () => {
             ],
           },
         ]);
-        vi.mocked(saveTeam).mockResolvedValue({
+        vi.mocked(Teams.save).mockResolvedValue({
           team: {
             ...FAKE_TEAM,
             members: [
@@ -576,7 +576,7 @@ describe('Team routes', () => {
       });
 
       it('accepts valid artifact plan', async () => {
-        vi.mocked(saveTeam).mockResolvedValue({
+        vi.mocked(Teams.save).mockResolvedValue({
           team: FAKE_TEAM,
           created: true,
         });
@@ -607,7 +607,7 @@ describe('Team routes', () => {
       });
 
       it('accepts partial artifact plan with only main stats', async () => {
-        vi.mocked(saveTeam).mockResolvedValue({
+        vi.mocked(Teams.save).mockResolvedValue({
           team: FAKE_TEAM,
           created: true,
         });
@@ -635,7 +635,7 @@ describe('Team routes', () => {
       });
 
       it('accepts partial artifact plan with only sets', async () => {
-        vi.mocked(saveTeam).mockResolvedValue({
+        vi.mocked(Teams.save).mockResolvedValue({
           team: FAKE_TEAM,
           created: true,
         });
@@ -661,7 +661,7 @@ describe('Team routes', () => {
       });
 
       it('accepts empty artifact plan', async () => {
-        vi.mocked(saveTeam).mockResolvedValue({
+        vi.mocked(Teams.save).mockResolvedValue({
           team: FAKE_TEAM,
           created: true,
         });
@@ -688,7 +688,7 @@ describe('Team routes', () => {
 
   describe('DELETE /api/teams/:slot', () => {
     it('returns 204 with no body', async () => {
-      vi.mocked(deleteTeam).mockResolvedValue();
+      vi.mocked(Teams.remove).mockResolvedValue();
 
       const res = await app.request(authedRequest('DELETE', '/api/teams/1'));
 
@@ -697,7 +697,7 @@ describe('Team routes', () => {
     });
 
     it('returns 204 when team does not exist', async () => {
-      vi.mocked(deleteTeam).mockResolvedValue();
+      vi.mocked(Teams.remove).mockResolvedValue();
 
       const res = await app.request(authedRequest('DELETE', '/api/teams/4'));
 

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -11,9 +11,9 @@ import type { ValidatedRequestBodyVariables } from '@/middleware/validate-reques
 import { validateRequestBody } from '@/middleware/validate-request-body.js';
 import { teamItemV1 } from '@/profiles/alps/team/item-v1.js';
 import { teamPutRequestV1 } from '@/profiles/json-schema/teams/put-request-v1.js';
-import { getCharacter } from '@/repositories/characters/index.js';
-import { deleteTeam, getTeam, listTeams, saveTeam } from '@/repositories/teams/index.js';
-import { getWeapon } from '@/repositories/weapons/index.js';
+import * as Characters from '@/repositories/characters/index.js';
+import * as Teams from '@/repositories/teams/index.js';
+import * as Weapons from '@/repositories/weapons/index.js';
 import { COLLECTION_JSON } from '@genshin/collection-json';
 import type { CollectionTeamMember, CollectionTeamMembers, TeamSlot, UUID } from '@genshin/domain';
 import {
@@ -56,7 +56,7 @@ function parseSlot(param: string): TeamSlot {
 // GET /api/teams — List user's teams
 teams.get('/', async (c) => {
   const userId = c.get('user').uid;
-  const items = await listTeams(userId);
+  const items = await Teams.list(userId);
   const baseUrl = new URL(c.req.url).origin;
 
   return c.body(JSON.stringify(teamListDocument(items, baseUrl)), {
@@ -69,7 +69,7 @@ teams.get('/:slot', async (c) => {
   const userId = c.get('user').uid;
   const slot = parseSlot(c.req.param('slot'));
 
-  const team = await getTeam(userId, slot);
+  const team = await Teams.get(userId, slot);
 
   if (!team) {
     throw new HTTPException(404, { message: 'Team not found' });
@@ -99,7 +99,7 @@ teams.put(
 
         // Cross-team weapon uniqueness: a weapon instance can only be equipped
         // by one character at a time across all teams (#635).
-        const allTeams = await listTeams(userId);
+        const allTeams = await Teams.list(userId);
         const crossTeamIssues = validateTeams(slot, body.members, allTeams);
         if (crossTeamIssues.length > 0) {
           throw new HTTPException(400, { message: crossTeamIssues[0].message });
@@ -107,7 +107,7 @@ teams.put(
       }
     }
 
-    const { team, created } = await saveTeam(userId, slot, {
+    const { team, created } = await Teams.save(userId, slot, {
       name: body.name,
       members: body.members,
       description: body.description,
@@ -127,7 +127,7 @@ teams.delete('/:slot', async (c) => {
   const userId = c.get('user').uid;
   const slot = parseSlot(c.req.param('slot'));
 
-  await deleteTeam(userId, slot);
+  await Teams.remove(userId, slot);
 
   return c.body(null, 204);
 });
@@ -148,7 +148,7 @@ async function validateMembers(userId: string, members: CollectionTeamMember[]):
   await Promise.all(
     members.map(async (member) => {
       // Character must be in user's collection
-      const character = await getCharacter(userId, member.characterId);
+      const character = await Characters.get(userId, member.characterId);
       if (!character) {
         throw new HTTPException(400, {
           message: `Character not in collection: ${member.characterId}`,
@@ -157,7 +157,7 @@ async function validateMembers(userId: string, members: CollectionTeamMember[]):
 
       // Weapon instance must be in user's collection (if provided)
       if (member.weaponInstanceId) {
-        const weapon = await getWeapon(userId, member.weaponInstanceId as UUID);
+        const weapon = await Weapons.get(userId, member.weaponInstanceId as UUID);
         if (!weapon) {
           throw new HTTPException(400, {
             message: `Weapon instance not in collection: ${member.weaponInstanceId}`,

--- a/apps/api/src/routes/userProfile.test.ts
+++ b/apps/api/src/routes/userProfile.test.ts
@@ -11,13 +11,13 @@ vi.mock('@/lib/firebase/auth.js', () => ({
 }));
 
 vi.mock('@/repositories/profile/index.js', () => ({
-  getProfile: vi.fn(),
-  updateProfile: vi.fn(),
+  get: vi.fn(),
+  update: vi.fn(),
 }));
 
 import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
-import { getProfile, updateProfile } from '@/repositories/profile/index.js';
+import * as Profile from '@/repositories/profile/index.js';
 import { FAKE_UID, authedRequest } from '@/test/auth-requests.js';
 
 const ajv = new Ajv2020();
@@ -85,7 +85,7 @@ describe('Profile routes', () => {
 
   describe('GET /api/profile', () => {
     it('returns 200 with a response matching the profile schema', async () => {
-      vi.mocked(getProfile).mockResolvedValue(FAKE_PROFILE);
+      vi.mocked(Profile.get).mockResolvedValue(FAKE_PROFILE);
 
       const res = await app.request(authedRequest('GET', '/api/profile'));
 
@@ -97,7 +97,7 @@ describe('Profile routes', () => {
     });
 
     it('returns 404 when profile does not exist', async () => {
-      vi.mocked(getProfile).mockResolvedValue(null);
+      vi.mocked(Profile.get).mockResolvedValue(null);
 
       const res = await app.request(authedRequest('GET', '/api/profile'));
 
@@ -107,7 +107,7 @@ describe('Profile routes', () => {
     });
 
     it('returns 500 when repository throws', async () => {
-      vi.mocked(getProfile).mockRejectedValue(new Error('Firestore unavailable'));
+      vi.mocked(Profile.get).mockRejectedValue(new Error('Firestore unavailable'));
 
       const res = await app.request(authedRequest('GET', '/api/profile'));
 
@@ -120,7 +120,7 @@ describe('Profile routes', () => {
   describe('PATCH /api/profile', () => {
     it('returns 200 with a response matching the profile schema', async () => {
       const updated = { ...FAKE_PROFILE, name: 'Aether' };
-      vi.mocked(updateProfile).mockResolvedValue(updated);
+      vi.mocked(Profile.update).mockResolvedValue(updated);
 
       const res = await app.request(authedRequest('PATCH', '/api/profile', { name: 'Aether' }));
 

--- a/apps/api/src/routes/userProfile.ts
+++ b/apps/api/src/routes/userProfile.ts
@@ -11,7 +11,7 @@ import type { ValidatedRequestBodyVariables } from '@/middleware/validate-reques
 import { validateRequestBody } from '@/middleware/validate-request-body.js';
 import { profileGetResponseV1 } from '@/profiles/json-schema/profile/get-response-v1.js';
 import { profilePatchRequestV1 } from '@/profiles/json-schema/profile/patch-request-v1.js';
-import { getProfile, updateProfile } from '@/repositories/profile/index.js';
+import * as Profile from '@/repositories/profile/index.js';
 import { serialiseProfile, type AuthIdentity, type ProfileUpdate } from '@genshin/domain';
 import type { DecodedIdToken } from 'firebase-admin/auth';
 import { Hono } from 'hono';
@@ -44,7 +44,7 @@ userProfile.use(
 // GET /api/profile — Return the authenticated user's composite profile
 userProfile.get('/', async (c) => {
   const decoded = c.get('user');
-  const profile = await getProfile(decoded.uid);
+  const profile = await Profile.get(decoded.uid);
 
   if (!profile) {
     throw new HTTPException(404, { message: 'Profile not found' });
@@ -63,7 +63,7 @@ userProfile.patch(
   async (c) => {
     const decoded = c.get('user');
     const body = c.get('validatedBody') as ProfileUpdate;
-    const updated = await updateProfile(decoded.uid, body);
+    const updated = await Profile.update(decoded.uid, body);
 
     return c.json(serialiseProfile(toAuthIdentity(decoded), updated), 200, {
       'Content-Type': c.get('negotiatedMediaType'),

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -9,11 +9,11 @@ vi.mock('@/lib/firebase/auth.js', () => ({
 }));
 
 vi.mock('@/repositories/weapons/index.js', () => ({
-  listWeapons: vi.fn(),
-  getWeapon: vi.fn(),
-  createWeapon: vi.fn(),
-  updateWeapon: vi.fn(),
-  deleteWeapon: vi.fn(),
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
 }));
 
 vi.mock('@genshin/game-data', () => ({
@@ -24,13 +24,7 @@ import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
 import { toMediaTypeString } from '@/middleware/negotiate-content.js';
 import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
-import {
-  createWeapon,
-  deleteWeapon,
-  getWeapon,
-  listWeapons,
-  updateWeapon,
-} from '@/repositories/weapons/index.js';
+import * as Weapons from '@/repositories/weapons/index.js';
 import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
@@ -71,7 +65,7 @@ describe('Weapon routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(listWeapons).mockResolvedValue([FAKE_WEAPON]);
+      vi.mocked(Weapons.list).mockResolvedValue([FAKE_WEAPON]);
       res = await app.request(authedRequest('GET', '/api/weapons'));
       body = (await res.json()) as CollectionDocument;
     });
@@ -102,7 +96,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns empty items when no weapons exist', async () => {
-      vi.mocked(listWeapons).mockResolvedValue([]);
+      vi.mocked(Weapons.list).mockResolvedValue([]);
 
       const res = await app.request(authedRequest('GET', '/api/weapons'));
 
@@ -111,7 +105,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns 500 when repository throws', async () => {
-      vi.mocked(listWeapons).mockRejectedValue(new Error('Firestore unavailable'));
+      vi.mocked(Weapons.list).mockRejectedValue(new Error('Firestore unavailable'));
 
       const res = await app.request(authedRequest('GET', '/api/weapons'));
 
@@ -130,7 +124,7 @@ describe('Weapon routes', () => {
         id: 'mistsplitter-reforged',
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
-      vi.mocked(listWeapons).mockResolvedValue([FAKE_WEAPON]);
+      vi.mocked(Weapons.list).mockResolvedValue([FAKE_WEAPON]);
       res = await app.request(authedRequest('GET', '/api/weapons?weaponId=mistsplitter-reforged'));
       body = (await res.json()) as CollectionDocument;
     });
@@ -163,7 +157,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns empty items when no instances exist', async () => {
-      vi.mocked(listWeapons).mockResolvedValue([]);
+      vi.mocked(Weapons.list).mockResolvedValue([]);
 
       const res = await app.request(
         authedRequest('GET', '/api/weapons?weaponId=mistsplitter-reforged'),
@@ -201,7 +195,7 @@ describe('Weapon routes', () => {
         id: 'mistsplitter-reforged',
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
-      vi.mocked(createWeapon).mockResolvedValue(FAKE_WEAPON);
+      vi.mocked(Weapons.create).mockResolvedValue(FAKE_WEAPON);
       res = await app.request(
         authedRequest('POST', '/api/weapons', {
           weaponId: 'mistsplitter-reforged',
@@ -335,7 +329,7 @@ describe('Weapon routes', () => {
     });
 
     it('accepts refinementLevel at minimum boundary', async () => {
-      vi.mocked(createWeapon).mockResolvedValue({
+      vi.mocked(Weapons.create).mockResolvedValue({
         ...FAKE_WEAPON,
         refinementLevel: MIN_REFINEMENT_LEVEL,
       });
@@ -351,7 +345,7 @@ describe('Weapon routes', () => {
     });
 
     it('accepts refinementLevel at maximum boundary', async () => {
-      vi.mocked(createWeapon).mockResolvedValue({
+      vi.mocked(Weapons.create).mockResolvedValue({
         ...FAKE_WEAPON,
         refinementLevel: MAX_REFINEMENT_LEVEL,
       });
@@ -372,7 +366,7 @@ describe('Weapon routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(getWeapon).mockResolvedValue(FAKE_WEAPON);
+      vi.mocked(Weapons.get).mockResolvedValue(FAKE_WEAPON);
       res = await app.request(authedRequest('GET', '/api/weapons/instance-uuid-1'));
       body = (await res.json()) as CollectionDocument;
     });
@@ -394,7 +388,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns 404 when weapon instance not found', async () => {
-      vi.mocked(getWeapon).mockResolvedValue(null);
+      vi.mocked(Weapons.get).mockResolvedValue(null);
 
       const res = await app.request(authedRequest('GET', '/api/weapons/nonexistent'));
 
@@ -409,7 +403,7 @@ describe('Weapon routes', () => {
     let body: CollectionDocument;
 
     beforeEach(async () => {
-      vi.mocked(updateWeapon).mockResolvedValue(FAKE_WEAPON);
+      vi.mocked(Weapons.update).mockResolvedValue(FAKE_WEAPON);
       res = await app.request(
         authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
           refinementLevel: 1,
@@ -435,7 +429,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns 404 when weapon instance not found', async () => {
-      vi.mocked(updateWeapon).mockResolvedValue(null);
+      vi.mocked(Weapons.update).mockResolvedValue(null);
 
       const res = await app.request(
         authedRequest('PATCH', '/api/weapons/nonexistent', {
@@ -482,7 +476,7 @@ describe('Weapon routes', () => {
     });
 
     it('updates refinementLevel', async () => {
-      vi.mocked(updateWeapon).mockResolvedValue({
+      vi.mocked(Weapons.update).mockResolvedValue({
         ...FAKE_WEAPON,
         refinementLevel: 3,
       });
@@ -499,7 +493,7 @@ describe('Weapon routes', () => {
 
   describe('DELETE /api/weapons/:weaponInstanceId', () => {
     it('returns 204 with no body', async () => {
-      vi.mocked(deleteWeapon).mockResolvedValue();
+      vi.mocked(Weapons.remove).mockResolvedValue();
 
       const res = await app.request(authedRequest('DELETE', '/api/weapons/instance-uuid-1'));
 

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -12,13 +12,7 @@ import { validateRequestBody } from '@/middleware/validate-request-body.js';
 import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
 import { weaponPatchRequestV1 } from '@/profiles/json-schema/weapons/patch-request-v1.js';
 import { weaponPostRequestV1 } from '@/profiles/json-schema/weapons/post-request-v1.js';
-import {
-  createWeapon,
-  deleteWeapon,
-  getWeapon,
-  listWeapons,
-  updateWeapon,
-} from '@/repositories/weapons/index.js';
+import * as Weapons from '@/repositories/weapons/index.js';
 import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
 import type { UUID } from '@genshin/domain';
 import { serialiseWeapon, weaponItemHref, weaponRepresentation } from '@genshin/domain';
@@ -61,7 +55,7 @@ weapons.get('/', async (c) => {
       throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
     }
 
-    const instances = await listWeapons(userId, weaponId);
+    const instances = await Weapons.list(userId, weaponId);
 
     return c.body(
       JSON.stringify(
@@ -77,7 +71,7 @@ weapons.get('/', async (c) => {
     );
   }
 
-  const items = await listWeapons(userId);
+  const items = await Weapons.list(userId);
 
   return c.body(
     JSON.stringify(
@@ -106,7 +100,7 @@ weapons.post(
       throw new HTTPException(400, { message: `Unknown weapon: ${weaponId}` });
     }
 
-    const weapon = await createWeapon(userId, weaponId, refinementLevel);
+    const weapon = await Weapons.create(userId, weaponId, refinementLevel);
     const baseUrl = new URL(c.req.url).origin;
 
     return c.body(
@@ -131,7 +125,7 @@ weapons.get('/:weaponInstanceId', async (c) => {
   const userId = c.get('user').uid;
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
 
-  const weapon = await getWeapon(userId, weaponInstanceId);
+  const weapon = await Weapons.get(userId, weaponInstanceId);
 
   if (!weapon) {
     throw new HTTPException(404, { message: 'Weapon instance not found' });
@@ -162,7 +156,7 @@ weapons.patch(
 
     const { refinementLevel } = c.get('validatedBody') as UpdateWeaponBody;
 
-    const weapon = await updateWeapon(userId, weaponInstanceId, refinementLevel);
+    const weapon = await Weapons.update(userId, weaponInstanceId, refinementLevel);
 
     if (!weapon) {
       throw new HTTPException(404, { message: 'Weapon instance not found' });
@@ -188,7 +182,7 @@ weapons.delete('/:weaponInstanceId', async (c) => {
   const userId = c.get('user').uid;
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
 
-  await deleteWeapon(userId, weaponInstanceId);
+  await Weapons.remove(userId, weaponInstanceId);
 
   return c.body(null, 204);
 });

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -4,6 +4,5 @@
 export default {
   plugins: {
     '@tailwindcss/postcss': {},
-    autoprefixer: {},
   },
 };

--- a/docs/reference/schema-versioning.md
+++ b/docs/reference/schema-versioning.md
@@ -1,0 +1,150 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Schema versioning conventions
+
+Any shared serialisation boundary is a version skew hazard: deployments are
+never instantaneous, caches outlive the pods that filled them, and rollback
+returns old readers to a store already touched by new writers. **Parseable is
+not the same as compatible.** This applies to Firestore documents, REST bodies,
+queue payloads, cache entries, and any future wire format.
+
+---
+
+## The two-role model
+
+**Writers are strict.** Emit only the current schema version. Never emit a
+superset shaped by historical compatibility. Every payload carries a version
+stamp; if the shape changes, the stamp changes.
+
+**Readers accept the union of all supported writers.** Detect the stamped
+version, validate against that version's schema, and migrate to the current
+shape. Old payloads stay readable without weakening the write type.
+
+The strict write type and the union read type are distinct—don't share them.
+
+---
+
+## Boundary taxonomy
+
+| Boundary            | Shared medium          | Skew window                           |
+| ------------------- | ---------------------- | ------------------------------------- |
+| Firestore documents | Database collection    | Until all documents are backfilled    |
+| REST API            | HTTP                   | Until all clients are updated         |
+| Queue / event bus   | Message broker         | Until all consumers drain the queue   |
+| Cache               | Redis / Memcache / CDN | Until TTL expires or cache is flushed |
+
+The skew window determines how many old writer versions the reader must tolerate.
+
+---
+
+## Implementation: Firestore (current)
+
+Firestore repositories in `apps/api/src/repositories/` use Verzod.
+
+```text
+schemas/
+  v0.ts          V0ConceptSchema, V0Concept, v0 descriptor
+  v1.ts          V1ConceptSchema, V1Concept, v1 descriptor, up() migration
+  index.ts       entity, CURRENT_VERSION, re-exports of versioned types
+document.ts      fromDocument(), toDocument() — the public boundary
+```
+
+`toDocument()` is the strict writer; `fromDocument()` delegates to
+`entity.safeParse()`, which detects the version, validates, and walks the
+`up()` chain to the current shape.
+
+### Naming
+
+| Tier              | Pattern                         | Example                      |
+| ----------------- | ------------------------------- | ---------------------------- |
+| Zod schema object | `V{n}ConceptSchema`             | `V1CharacterSchema`          |
+| TypeScript type   | `V{n}Concept` for every version | `V0Character`, `V1Character` |
+| Verzod descriptor | `v{n}`                          | `v0`, `v1`                   |
+| Verzod entity     | `entity`                        | `entity`                     |
+| Version constant  | `CURRENT_VERSION`               | `CURRENT_VERSION`            |
+
+Version numbers appear on every exported type—there's no unversioned
+`Character` because "latest" changes meaning silently when a new version ships.
+
+---
+
+## Implementation: Other boundaries
+
+REST bodies, queue payloads, and cache entries don't yet use this pattern.
+When those boundaries are introduced: stamp every payload with a `version`
+field, keep one `schemas/v{n}.ts` file per version, write a strict serializer
+and a union deserializer, use the same `V{n}ConceptSchema` / `V{n}Concept`
+naming convention.
+
+---
+
+## Adding a new schema version
+
+1. Create `schemas/v{n}.ts`. Define `V{n}ConceptSchema`, export `type V{n}Concept`
+   and the `v{n}` descriptor. Import `V{n-1}Concept` and write `up()`.
+
+2. Update `schemas/index.ts`. Add `v{n}` to `versionMap`, bump `CURRENT_VERSION`,
+   re-export `type V{n}Concept`.
+
+3. Update the boundary file. Update imports and re-exports. Update the
+   serializer's return type to `V{n}Concept`; emit only the current stamp and
+   the new shape.
+
+4. Update the test file. Add a `makeV{n}Payload()` fixture. Verify migration
+   from every prior version and that the serializer stamps `CURRENT_VERSION`.
+
+The deserializer doesn't change; Verzod handles the new version automatically
+once `versionMap` includes it.
+
+---
+
+## What not to do
+
+**Don't add optional fields to an existing version for compatibility.**
+The type weakens over time, stops expressing the real domain model, and lets
+impossible states become routine. Every new shape gets its own version.
+
+**Don't remove a schema version while payloads at that version still live in
+the shared medium.** Dropping a version makes those payloads unreadable at the
+next deployment. See _Retiring old versions_.
+
+**Don't widen the serializer's return type to cover older shapes.** The writer
+must be as strict as the current schema, not a superset of all historical ones.
+
+---
+
+## Retiring old versions
+
+A version is safe to retire when no payload in the shared medium carries its
+stamp. Lifecycle:
+
+1. Ship the new version. Writers emit it immediately; readers accept both.
+2. Measure reads from the old-version branch.
+3. Rewrite or wait for the medium to drain.
+4. When the old-version read count reaches zero, delete `v{n-1}.ts`, remove it
+   from `versionMap`, and remove the re-export.
+
+---
+
+## Missing CI checks
+
+- **Subsumption check.** No automated check verifies read-direction compatibility
+  (`V{n-1}Schema` values still accepted after migration to `V{n}Schema`). A
+  one-keyword tightening—`maximum` → `exclusiveMaximum`—silently breaks old
+  payloads. Tool: `jsoncompat` (Ostrow, SRECon Americas 2026).
+
+- **Old-version read metrics.** No instrumentation counts traversals of `up()`
+  paths, so retiring a version safely requires a manual audit of the medium.
+
+- **Breaking-change detection in CI.** Nothing blocks a PR that narrows a Zod
+  schema in a way that rejects previously valid payloads.
+
+---
+
+## Further reading
+
+Robbie Ostrow (OpenAI), [Escaping Version Skew: Formalizing compatibility in a
+world of partial rollouts](https://www.usenix.org/conference/srecon26americas/presentation/ostrow),
+SRECon Americas 2026. Source for the two-role model, the optionalslop
+anti-pattern, the subsumption checker approach, and the `jsoncompat` tool.

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -65,5 +65,5 @@ export {
 } from './representations/json/profile.js';
 
 export { validateTeam, validateTeams, type TeamValidationContext } from './teamValidation.js';
-export { type ProfileUpdate, type UserProfile } from './userProfile.js';
+export { assertUserProfile, type ProfileUpdate, type UserProfile } from './userProfile.js';
 export type { UUID } from './uuid.js';

--- a/packages/domain/src/userProfile.ts
+++ b/packages/domain/src/userProfile.ts
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: MIT */
 
 import type { ISOTimestamp } from './isoTimestamp.js';
+import { isISOTimestamp } from './isoTimestamp.js';
 
 /**
  * User-controlled fields stored in Firestore.
@@ -17,3 +18,23 @@ export interface UserProfile {
 
 /** The shape accepted by PATCH /api/profile. */
 export type ProfileUpdate = Partial<Pick<UserProfile, 'name'>>;
+
+export function assertUserProfile(value: unknown): asserts value is UserProfile {
+  if (typeof value !== 'object' || value === null) {
+    throw new TypeError(`UserProfile must be a non-null object, got: ${JSON.stringify(value)}`);
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.name !== 'string') {
+    throw new TypeError(`UserProfile.name must be a string, got: ${JSON.stringify(obj.name)}`);
+  }
+  if (!isISOTimestamp(obj.createdAt)) {
+    throw new TypeError(
+      `UserProfile.createdAt must be an ISO 8601 timestamp, got: ${JSON.stringify(obj.createdAt)}`,
+    );
+  }
+  if (!isISOTimestamp(obj.updatedAt)) {
+    throw new TypeError(
+      `UserProfile.updatedAt must be an ISO 8601 timestamp, got: ${JSON.stringify(obj.updatedAt)}`,
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,12 @@ importers:
       negotiator:
         specifier: 1.0.0
         version: 1.0.0
+      verzod:
+        specifier: 0.5.1
+        version: 0.5.1(zod@3.25.76)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -3591,6 +3597,12 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  verzod@0.5.1:
+    resolution: {integrity: sha512-zWjmFU/NSrGZA/O0WufiHxusNLkTeXqZlO+AT0QLIu5upS/cxxtMyXYKpBYWbjB9OtJgoAaUO5B7EdBMykIZzA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      zod: ^3.22.0
+
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3779,6 +3791,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -7130,6 +7145,10 @@ snapshots:
   uuid@9.0.1:
     optional: true
 
+  verzod@0.5.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -7271,6 +7290,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Summary

Closes #587.

Adds Verzod-backed versioned schema migration to all four Firestore repositories (characters, weapons, teams, profile), following the strict writer / union reader pattern from Ostrow's [Escaping Version Skew](https://www.usenix.org/conference/srecon26americas/presentation/ostrow) (SRECon Americas 2026).

- **Strict writer**: `toDocument()` always stamps `schemaVersion: CURRENT_VERSION` and emits only the current shape
- **Union reader**: `fromDocument()` delegates to Verzod — detects version via `getVersion`, validates against the versioned schema, and walks the `up()` chain to the current shape
- **Domain assertions** (`assertCollectionCharacter`, `assertCollectionTeam`, `assertCollectionWeapon`, `assertUserProfile`) run on the read path so domain invariants are enforced at the Firestore boundary
- **Teams v1 migration** resolves the silent breakage from #565: `primaryStats` → `priorityMinorAffixes` and `secondaryStats` → `secondaryMinorAffixes` are applied to any document written before that rename

## Naming deviation from issue description

The issue referred loosely to `V0DocumentData` / `DocumentData` style names. We landed on fully semantic, version-explicit names (`V0Character`, `V1Character`, `V0Team`, `V1Team`, etc.) — no unversioned type exists because "latest" changes meaning silently when a new version ships. This is a deliberate improvement, not an oversight.

## Additional changes

- Route modules use namespace imports (`import * as Characters`) — removes function name stutter (`Characters.get` not `Characters.getCharacter`) and prevents generic type name collisions across modules
- `document.test.ts` added for all four repositories covering V0→V1 migration, domain assertion rejection, and round-trip
- `docs/reference/schema-versioning.md` documents the pattern, boundary taxonomy (Firestore, REST, queue, cache), retirement lifecycle, and current tooling gaps — scoped to all serde boundaries, not just Firestore

## Test plan

- [ ] `pnpm --filter api test` — all document and route tests pass
- [ ] `pnpm --filter api typecheck` — no type errors
- [ ] Review `teams/schemas/v1.ts` `up()` function covers `primaryStats`/`secondaryStats` → new names
- [ ] Review `docs/reference/schema-versioning.md` is coherent as a contributor reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)