### PR TITLE
docs: align project descriptions for 0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ SPDX-License-Identifier: MIT
 
 By [Alex Brandt](https://github.com/alunduil) · [Repository](https://github.com/dungeon-studio/genshin.dungeon.studio)
 
-🚧 **Pre-Alpha**: not yet ready for general use, but contributors are welcome.
+🔬 **Alpha**: core features work end-to-end; expect rough edges. Contributors welcome.
 
 ## About
 
-Experiment with team compositions without the spreadsheets. Genshin Planner is an early stage project that aims to let you describe your character collection to an AI assistant and, when implemented, get personalized team recommendations. Whether you're optimizing for Abyss clears or just want to try new playstyles, the goal is to provide suggestions tailored to _your_ roster.
+Build Genshin Impact teams without the spreadsheets. Genshin Planner lets you track your character and weapon collection, assemble team compositions, and plan your roster. AI-powered team recommendations are planned for a future release.
 
 ## Who's it for
 
 Anyone who plays Genshin Impact and wants to:
 
-- Discover team compositions that work for _your_ characters, not tier lists
-- Experiment with different team combinations
-- Get AI-powered suggestions based on your actual roster
-- Explore synergies without manual research
+- Track their character and weapon collection in one place
+- Experiment with different team compositions
+- Plan builds and artifact sets for each team member
+- Explore synergies across their actual roster
 
 ## Getting started
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "genshin-dungeon-studio",
   "version": "0.1.0",
   "private": true,
-  "description": "AI-powered team building companion for Genshin Impact",
+  "description": "Team building companion for Genshin Impact",
   "keywords": [
     "genshin-impact",
     "team-builder",


### PR DESCRIPTION
## Summary

- Updated README status from "Pre-Alpha" to "Alpha" and rewrote the About section and feature list to reflect the delivered 0.1.0 feature set (collection management, team building, roster planning) instead of promising unimplemented AI features
- Removed "AI-powered" from the root `package.json` description
- Updated the GitHub repository description to remove "chat interface" and "personalized recommendations"
- `index.html` meta/title, Footer, and Terraform display name were reviewed and required no changes
- `HomePage.tsx` from the original checklist no longer exists (home route is now `TeamsPage`); no status badge to update

Closes #581

## Test plan

- [x] Vale passes with no errors on README.md
- [x] All pre-commit hooks pass
- [x] GitHub repo description verified via `gh api`