### PR TITLE
docs: add best practices from package metadata PR to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@
 
 - Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't automatically build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
 - The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. The build config extends `tsconfig.json`, so compiler options stay in sync automatically; only the exclude patterns differ.
-- When `tsconfig.json` uses project references (`references` field with `"files": []`), type-check with build mode: `tsc -b --noEmit`. Plain `tsc --noEmit` won't follow references and type-checks nothing. Example: `apps/web` references `tsconfig.app.json` and `tsconfig.node.json`.
+- When `tsconfig.json` uses project references, type-check with `tsc -b --noEmit`. Plain `tsc --noEmit` won't follow references.
 - Turbo 2.0+ renamed `pipeline` to `tasks` in `turbo.json`. When upgrading Turbo major versions, check the `turbo.json` schema for deprecated fields.
 
 ## State usage
@@ -84,7 +84,7 @@
   - `dependencies`: runtime code shipped to production.
   - `devDependencies`: build tools, plugins, type definitions, and local tooling.
 - Use `pnpm why <package>` to detect duplicate transitive versions and pin when needed.
-- New workspace packages should include these `package.json` fields: `description` (one-line summary, no trailing period), `keywords`, `author` (name and email), `homepage`, `bugs` (link to issue tracker), and `license`. See the root `package.json` as a template.
+- New workspace packages should match the root `package.json` metadata fields (`description`, `keywords`, `author`, `homepage`, `bugs`, `license`).
 - ESLint uses flat config via workspace-local `eslint.config.js` files; configure ignore patterns with `ignores`, not `.eslintignore`.
 
 ## Documentation rules

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,8 @@
 
 - Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't automatically build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
 - The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. The build config extends `tsconfig.json`, so compiler options stay in sync automatically; only the exclude patterns differ.
+- When `tsconfig.json` uses project references (`references` field with `"files": []`), type-check with build mode: `tsc -b --noEmit`. Plain `tsc --noEmit` won't follow references and type-checks nothing. Example: `apps/web` references `tsconfig.app.json` and `tsconfig.node.json`.
+- Turbo 2.0+ renamed `pipeline` to `tasks` in `turbo.json`. When upgrading Turbo major versions, check the `turbo.json` schema for deprecated fields.
 
 ## State usage
 
@@ -82,6 +84,7 @@
   - `dependencies`: runtime code shipped to production.
   - `devDependencies`: build tools, plugins, type definitions, and local tooling.
 - Use `pnpm why <package>` to detect duplicate transitive versions and pin when needed.
+- New workspace packages should include these `package.json` fields: `description` (one-line summary, no trailing period), `keywords`, `author` (name and email), `homepage`, `bugs` (link to issue tracker), and `license`. See the root `package.json` as a template.
 - ESLint uses flat config via workspace-local `eslint.config.js` files; configure ignore patterns with `ignores`, not `.eslintignore`.
 
 ## Documentation rules
@@ -106,6 +109,7 @@
 - Don't modify third-party Vale styles generated under `.styles/`, except `.styles/config/`.
 - Every source file needs SPDX headers. For files without comment syntax, declare them in `.reuse/dep5`; see [How to add SPDX headers to new files](../docs/how-tos/add-spdx-headers.md).
 - Wrap file and directory paths in backticks when they appear in prose (for example, `apps/web`, `packages/game-data/src/index.ts`). Markdown link targets don't need backticks.
+- When adding features, keep these descriptions in sync: `package.json` `description`, `README.md` tagline or summary, and `CONTRIBUTING.md` references to commands or scripts.
 - Documentation principles:
   - Prefer concise, factual, present-tense writing.
   - Keep guidance implementation-oriented, not aspirational.


### PR DESCRIPTION
## Summary

- Add TypeScript project references build mode guidance (`tsc -b --noEmit`) to Build and CI rules
- Add `package.json` metadata checklist for new workspace packages to Dependencies and linting
- Add Turborepo 2.0+ `pipeline` to `tasks` migration note to Build and CI rules
- Add documentation consistency rule (keep `package.json`, `README.md`, and `CONTRIBUTING.md` descriptions in sync) to Documentation rules

Closes #93