### PR TITLE
docs: document Dependabot configuration gotchas

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,14 @@
 - Use `pnpm why <package>` to detect duplicate transitive versions and pin when needed.
 - ESLint uses flat config via workspace-local `eslint.config.js` files; configure ignore patterns with `ignores`, not `.eslintignore`.
 
+## Dependabot maintenance
+
+- YAML anchors and aliases aren't supported in `dependabot.yml`. All configuration must be explicit.
+- A package-ecosystem and directory pair must be unique. Don't create separate entries for the same combo (for example, one for weekly updates and another for daily security). Security updates are automatic and independent of the version update schedule.
+- Omit default values like `open-pull-requests-limit: 5` and `allow: [{dependency-type: "all"}]`. They clutter the config without changing behavior.
+- Use the specific directory where the manifest lives. For the `devcontainers` ecosystem, use `/.devcontainer`, the directory containing `devcontainer.json`, not `/`.
+- The `prefix-scope` commit-message option doesn't exist in Dependabot's schema. Valid options are `prefix`, `prefix-development`, and `include`.
+
 ## Documentation rules
 
 - Put information in the right place, in this priority order:


### PR DESCRIPTION
## Summary

- Adds a "Dependabot maintenance" section to `.github/copilot-instructions.md` documenting configuration gotchas discovered during PR #103
- Covers YAML anchor limitations, unique ecosystem+directory constraint, default value omission, directory specificity, and valid commit-message options

Closes #109

## Test plan

- [x] Vale passes with no new errors
- [x] All pre-commit hooks pass
- [x] markdownlint passes