### PR TITLE
docs: add monorepo dependency management guidelines to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,27 @@
 - `packages/game-data`: Source of truth for static game data; use exported helpers, never hard-code.
 - `packages/domain`: Shared domain model: types, invariants, and wire format representations.
 
+## Dependency management in the monorepo
+
+### Version management strategy
+
+- Root `package.json` is the source of truth for shared tooling versions: TypeScript, ESLint, Prettier, and Stylelint.
+- Pin exact versions without `^` or `~` prefixes for hermetic, reproducible installs.
+- Renovate handles automated dependency updates on a weekly schedule; see `renovate.json` for the configuration.
+- `pnpm-workspace.yaml` declares workspace package globs and engine constraints only; don't use it for version overrides.
+
+### Where dependencies go
+
+- **Root `package.json`**: monorepo-wide tooling shared across all workspaces: turbo, concurrently, TypeScript, ESLint, Prettier, and Stylelint.
+- **Workspace `package.json`**: app-specific and package-specific dependencies. Each workspace declares every direct dependency it imports, even when the same package exists at the root.
+- Explicit declaration ensures each workspace dependency graph is self-describing and survives hoisting changes.
+
+### Best practices
+
+- Declare every direct import in the consuming workspace `package.json`. Relying on hoisting from the root is fragile and breaks when someone removes the root dependency or the hoisting strategy changes.
+- When a shared tool like TypeScript or ESLint appears in both root and workspace `package.json`, keep the versions identical.
+- Don't put version overrides in `pnpm-workspace.yaml`. Version overrides are a last resort for transitive dependency conflicts, not a substitute for pinning in `package.json`.
+
 ## Core coding rules
 
 - Use strict TypeScript and keep components/functions focused.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,24 +27,11 @@
 
 ## Dependency management in the monorepo
 
-### Version management strategy
-
-- Root `package.json` is the source of truth for shared tooling versions: TypeScript, ESLint, Prettier, and Stylelint.
-- Pin exact versions without `^` or `~` prefixes for hermetic, reproducible installs.
-- Renovate handles automated dependency updates on a weekly schedule; see `renovate.json` for the configuration.
+- Pin exact versions without `^` or `~` prefixes; Renovate handles updates weekly.
+- Root `package.json` is the source of truth for shared tooling: turbo, concurrently, TypeScript, ESLint, Prettier, and Stylelint.
+- Workspace `package.json` holds app-specific dependencies. Declare every direct import explicitly, even when the same package exists at the root.
+- When a shared tool appears in both root and workspace `package.json`, keep the versions identical.
 - `pnpm-workspace.yaml` declares workspace package globs and engine constraints only; don't use it for version overrides.
-
-### Where dependencies go
-
-- **Root `package.json`**: monorepo-wide tooling shared across all workspaces: turbo, concurrently, TypeScript, ESLint, Prettier, and Stylelint.
-- **Workspace `package.json`**: app-specific and package-specific dependencies. Each workspace declares every direct dependency it imports, even when the same package exists at the root.
-- Explicit declaration ensures each workspace dependency graph is self-describing and survives hoisting changes.
-
-### Best practices
-
-- Declare every direct import in the consuming workspace `package.json`. Relying on hoisting from the root is fragile and breaks when someone removes the root dependency or the hoisting strategy changes.
-- When a shared tool like TypeScript or ESLint appears in both root and workspace `package.json`, keep the versions identical.
-- Don't put version overrides in `pnpm-workspace.yaml`. Version overrides are a last resort for transitive dependency conflicts, not a substitute for pinning in `package.json`.
 
 ## Core coding rules
 


### PR DESCRIPTION
## Summary

- Adds a new "Dependency management in the monorepo" section to `.github/copilot-instructions.md`, placed after "Repository map" as proposed in #95
- Covers version management strategy, where dependencies go, and best practices for the pnpm + Turborepo monorepo
- Documents the explicit re-declaration principle, exact version pinning, and Renovate workflow

## Test plan

- [x] Vale passes with no new errors
- [x] All pre-commit hooks pass
- [x] Section placement matches issue #95 proposal

Closes #95