### PR TITLE
chore: allowlist build scripts for pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,12 @@
   "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=20.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "esbuild",
+      "protobufjs"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Allowlists the three transitive deps with postinstall scripts so the pnpm v11 upgrade in #766 stops failing every CI job with `ERR_PNPM_IGNORED_BUILDS`.

pnpm v11 promotes `ERR_PNPM_IGNORED_BUILDS` from a warning to a hard error; `@firebase/util`, `esbuild`, and `protobufjs` legitimately need their postinstall scripts (Firebase init, esbuild platform binary, protobufjs inline-module compile), so the right knob is `pnpm.onlyBuiltDependencies`, not silencing.

The field is recognised by both pnpm 10 and 11, so landing it on develop ahead of #766 is safe and doesn't touch the lockfile.

## Gotchas

Verified with pnpm 10 locally; pnpm 11 verification was blocked by corepack pinning to v10 via `packageManager`. Real validation is the next CI run on #766 once Renovate rebases it onto this commit.

## Verification

- `pnpm install --frozen-lockfile` under pnpm 10.33.4 — postinstall scripts ran for all three packages, no lockfile drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)