### PR TITLE
chore: migrate build-script allowlist to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,5 @@
   "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=20.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@firebase/util",
-      "esbuild",
-      "protobufjs"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,11 @@ packages:
   - 'apps/*'
   - 'packages/*'
 
+allowBuilds:
+  '@firebase/util': true
+  esbuild: true
+  protobufjs: true
+
 # Ensure pnpm version compatibility
 engines:
   pnpm: '>=9.15.4'


### PR DESCRIPTION
## Summary

Moves the pnpm build-script allowlist from `package.json:pnpm.onlyBuiltDependencies` (v10 syntax) to `pnpm-workspace.yaml:allowBuilds` (v11 syntax) so #766 (pnpm 10→11) stops failing every CI job with `ERR_PNPM_IGNORED_BUILDS`.

#773 added the v10 field ahead of #766, but pnpm v11 reads the allowlist from `pnpm-workspace.yaml:allowBuilds` and ignores `pnpm.onlyBuiltDependencies` — the renovate branch's CI is still red on the same error. `allowBuilds` is honoured by both v10 and v11, so dropping the package.json field is safe at the current 10.33.4 pin.

The v11 pinned-version verification gap noted in #773 (corepack pinned to v10) is what masked this — reproduced locally by activating pnpm 11.1.2 via corepack and re-running `pnpm install`.

## Gotchas

None — the workspace-yaml field is the upstream-recommended config for v11 and is already what pnpm v11 auto-writes as a stub on first encounter.

## Verification

- `pnpm install --frozen-lockfile` under pnpm 10.33.4 — postinstall scripts ran for `protobufjs` and `esbuild`, no lockfile drift.
- `pnpm install --frozen-lockfile` under pnpm 11.1.2 (via corepack) — postinstall scripts ran for all three packages including `@firebase/util`, no lockfile drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)