### PR TITLE
chore(renovate): adopt best-practices preset and supply-chain bake

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,3 +61,8 @@ jobs:
           TRIVY_CONFIG: ${{ github.workspace }}/.trivy.yaml
         with:
           extra_args: --all-files terraform_trivy
+
+      - name: Run Renovate config validator hook
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files renovate-config-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,13 @@ repos:
     hooks:
       - id: detect-secrets
 
+  # Renovate config validation
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.99.1
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict, --no-global]
+
   # ESLint - JavaScript/TypeScript linting
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ ci:
     - typescript-check
     - terraform_fmt
     - terraform_trivy
+    - renovate-config-validator
 
 repos:
   # Basic file checks

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:best-practices"],
   "baseBranchPatterns": ["develop"],
   "schedule": ["before 6pm on friday"],
   "timezone": "Europe/London",
   "labels": ["dependencies", "automated"],
   "reviewers": ["alunduil"],
   "branchPrefix": "renovate/",
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
+  "pre-commit": {
+    "enabled": true
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6pm on friday"]
@@ -46,6 +55,13 @@
       "groupName": "devcontainer dependencies",
       "groupSlug": "devcontainer",
       "addLabels": ["devcontainer"]
+    },
+    {
+      "description": "Group all pre-commit hook updates in a single PR",
+      "matchManagers": ["pre-commit"],
+      "groupName": "pre-commit hooks",
+      "groupSlug": "pre-commit",
+      "addLabels": ["pre-commit"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate now pins GitHub Actions to SHAs and bakes new releases for three days before opening PRs, with a carve-out so CVE fixes still land immediately. The pre-commit manager is enabled so hook revs in `.pre-commit-config.yaml` stay current, and a `renovate-config-validator` pre-commit hook fails commits on schema typos before they surface as Repository Problems.

Closes #214 — that issue asked to extend the Dependabot config for `packages/game-data`, but Dependabot was removed in #412 and Renovate's npm manager auto-discovers every `package.json` in the workspace, so no per-directory entry is needed.

## Gotchas

The new pre-commit grouping rule in `packageRules` is slightly outside the strict "enable the manager" scope, but the existing file groups every other manager into a single PR — leaving pre-commit ungrouped would be the inconsistent choice. Happy to drop it if you'd rather see individual hook-rev PRs.

`internalChecksFilter: "strict"` is load-bearing alongside `minimumReleaseAge` — without it Renovate would open PRs immediately and label them pending, defeating the bake.

The `renovate-config-validator` hook bundles a ~629MiB node image, which exceeds pre-commit.ci's 250MiB tier. It's listed in `ci.skip` and runs via `.github/workflows/pre-commit.yml` (the Local Hooks job) instead, matching the existing pattern for eslint, stylelint, and the terraform hooks.

## Verification

- `pre-commit run renovate-config-validator --all-files` — passed against the new `renovate.json`.
- `pre-commit run yamllint --files .pre-commit-config.yaml .github/workflows/pre-commit.yml` — passed.
- pre-commit.ci first run failed on the renovate-validator bundle size; second push moves it to Local Hooks. CI re-run in flight.