### PR TITLE
feat: integrate hadolint for Dockerfile linting

### DIFF
--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -51,6 +51,7 @@ run_verification() {
   verify "gcloud"               gcloud --version
   verify "pre-commit"           pre-commit --version
   verify "reuse"                reuse --version
+  verify "hadolint"             hadolint --version
   verify "firebase"             firebase --version
   verify "playwright-cli"       npx --yes playwright --version
   verify "playwright-browsers"  npx --yes playwright install --list
@@ -72,6 +73,7 @@ run_version_summary() {
   print_version "gcloud"     gcloud --version
   print_version "pre-commit" pre-commit --version
   print_version "reuse"      reuse --version
+  print_version "hadolint"   hadolint --version
   print_version "firebase"   firebase --version
   print_version "playwright" npx --yes playwright --version
   eval "${_xtrace}"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -48,7 +48,18 @@ step "Installing reuse-tool"
 pipx install reuse==6.2.0
 
 # ---------------------------------------------------------------------------
-# 6. Playwright browsers (for Playwright MCP server)
+# 6. Dockerfile linter
+# ---------------------------------------------------------------------------
+step "Installing hadolint"
+
+HADOLINT_VERSION="v2.12.0"
+sudo curl -fsSL \
+  "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+  -o /usr/local/bin/hadolint
+sudo chmod +x /usr/local/bin/hadolint
+
+# ---------------------------------------------------------------------------
+# 7. Playwright browsers (for Playwright MCP server)
 # ---------------------------------------------------------------------------
 step "Installing Playwright Chromium and Chrome"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,3 +61,17 @@ jobs:
           TRIVY_CONFIG: ${{ github.workspace }}/.trivy.yaml
         with:
           extra_args: --all-files terraform_trivy
+
+      - name: Install hadolint
+        run: |
+          set -euo pipefail
+          HADOLINT_VERSION=v2.12.0
+          sudo curl -fsSL \
+            "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+            -o /usr/local/bin/hadolint
+          sudo chmod +x /usr/local/bin/hadolint
+
+      - name: Run hadolint hook
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files hadolint

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -4,4 +4,5 @@
 # hadolint configuration for Dockerfile linting
 # See https://github.com/hadolint/hadolint for documentation
 
-failure-threshold: warning
+trustedRegistries:
+  - docker.io

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+# hadolint configuration for Dockerfile linting
+# See https://github.com/hadolint/hadolint for documentation
+
+failure-threshold: warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ ci:
     - typescript-check
     - terraform_fmt
     - terraform_trivy
+    - hadolint
 
 repos:
   # Basic file checks
@@ -139,3 +140,9 @@ repos:
         types: [ts, tsx]
         pass_filenames: false
         stages: [manual]
+
+      - id: hadolint
+        name: hadolint
+        entry: hadolint
+        language: system
+        types: [dockerfile]

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -34,6 +34,7 @@ ESLint
 Prettier
 Stylelint
 Vitest
+hadolint
 markdownlint
 yamllint
 Colocate

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -30,13 +30,13 @@ COPY packages/validation/package.json ./packages/validation/
 
 RUN pnpm install --frozen-lockfile
 
-# Copy source and build — turbo handles dependency ordering via ^build
+# Copy source, build, then prune to production-only dependencies — turbo
+# handles dependency ordering via ^build, and the build must run before
+# the prune so dev dependencies are still present.
 COPY packages ./packages
 COPY apps/api ./apps/api
-RUN pnpm turbo run build --filter=@genshin/api
-
-# Install production-only dependencies
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm turbo run build --filter=@genshin/api && \
+    pnpm install --prod --frozen-lockfile
 
 # Production stage
 FROM node:25.9.0-slim


### PR DESCRIPTION
## Summary

`apps/api/Dockerfile` (and any future Dockerfile) is now linted against
hadolint's DL-series rules and shellcheck on `RUN` commands at the
default info threshold. The existing Dockerfile's only finding (DL3059,
two consecutive `RUN` after the build step) is fixed by combining the
build and the production-prune into one layer. Trivy continues to
cover security misconfigurations; hadolint covers Dockerfile best
practices.

Closes #200

## Gotchas

- `language: system` rather than the upstream `language: docker_image`
  hook — keeps pre-commit.ci's "no Docker" constraint intact and
  matches the existing local-binary pattern (trivy, gcloud, vale).
  Trade-off is two pinned `v2.12.0` references (devcontainer and
  workflow) that have to move together on upgrade. Once #795 lands
  and pre-commit.ci is gone, the hook can switch to upstream's docker
  hook and collapse to a single pin — follow-up filed as #797.
- `.hadolint.yaml` carries `trustedRegistries: [docker.io]` so the
  config file has at least one recognized key (hadolint warns
  otherwise) while also documenting where base images come from.
- The new CI step needs to be added to the `develop` ruleset's
  required checks once the check name shows up green. Recurring
  manual step tracked at alunduil/alunduil-infrastructure#76, which
  proposes bringing the dungeon-studio org and the develop ruleset's
  required-checks list under terraform so future additions are a
  one-line edit instead of a UI tweak.

## Verification

- Ran `hadolint --config .hadolint.yaml apps/api/Dockerfile` against a
  locally-installed v2.12.0 binary, exit 0, no findings.
- Ran `pre-commit run --files apps/api/Dockerfile .hadolint.yaml` and
  `pre-commit run hadolint --all-files` — both passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)