### PR TITLE
chore(pre-commit): convert Prettier to local hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           extra_args: --all-files eslint
 
+      - name: Run Prettier hook
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files prettier
+
       - name: Run Stylelint hook
         uses: pre-commit/action@v3.0.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ ci:
   # Keep this list in sync with workflow ownership documented in CONTRIBUTING.md.
   skip:
     - eslint
+    - prettier
     - stylelint
     - typescript-check
     - terraform_fmt
@@ -63,14 +64,6 @@ repos:
       # Git hygiene
       - id: no-commit-to-branch
         args: [--branch, develop, --branch, main]
-
-  # Prettier - Code formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types_or: [javascript, jsx, ts, tsx, json, yaml, markdown, css]
-        args: [--write]
 
   # Markdown linting
   - repo: https://github.com/DavidAnson/markdownlint-cli2
@@ -115,7 +108,9 @@ repos:
     hooks:
       - id: detect-secrets
 
-  # ESLint - JavaScript/TypeScript linting
+  # Local hooks using package.json-managed tools. Kept local (not via
+  # remote pre-commit repos) so versions stay aligned with package.json
+  # and aren't perturbed by pre-commit autoupdate.
   - repo: local
     hooks:
       - id: eslint
@@ -124,6 +119,12 @@ repos:
         language: system
         types: [javascript, jsx, ts, tsx]
         args: [--fix, --max-warnings=0]
+
+      - id: prettier
+        name: prettier
+        entry: pnpm exec prettier --write
+        language: system
+        types_or: [javascript, jsx, ts, tsx, json, yaml, markdown, css]
 
       - id: stylelint
         name: stylelint


### PR DESCRIPTION
## Summary

Prettier now formats via a local pre-commit hook instead of the archived `pre-commit/mirrors-prettier` repo, ending the autoupdate-to-alpha bumps that left us pinned at `v4.0.0-alpha.8`. `pnpm format` and the `prettier@3.8.3` devDep in `package.json` are unchanged; the prettier version source consolidates there.

## Gotchas

- This recreates work from #148, which got squash-merged into the stale `pre-commit-ci-update-config` branch instead of `develop` back in February and was effectively lost. New commit on `develop`, not a cherry-pick of `aa83ef1`.
- The hook landscape was explored before settling: `pre-commit/mirrors-prettier` is archived, `rbubley/mirrors-prettier` is the maintained community fork (single-maintainer, unofficial), and Prettier upstream no longer blesses any pre-commit-corpus hook. Going local matches the ESLint/Stylelint pattern already in this repo and keeps the version source in `package.json`.

## Verification

- `pre-commit run prettier --all-files` — Passed
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/pre-commit.yml` — all hooks Passed
- `pre-commit validate-config` — exit 0

Closes #175