### PR TITLE
feat(ci): add pnpm validate orchestrator and devcontainer-validate workflow

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -45,7 +45,7 @@ pre-commit install
 # ---------------------------------------------------------------------------
 step "Installing reuse-tool"
 
-pipx install reuse==6.2.0
+"${SCRIPT_DIR}/../scripts/install-reuse.sh"
 
 # ---------------------------------------------------------------------------
 # 6. Playwright browsers (for Playwright MCP server)

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 # shellcheck source=lib.sh
 source "${SCRIPT_DIR}/lib.sh"
 
@@ -45,7 +46,7 @@ pre-commit install
 # ---------------------------------------------------------------------------
 step "Installing reuse-tool"
 
-"${SCRIPT_DIR}/../scripts/install-reuse.sh"
+"${REPO_ROOT}/scripts/install-reuse.sh"
 
 # ---------------------------------------------------------------------------
 # 6. Playwright browsers (for Playwright MCP server)

--- a/.github/workflows/devcontainer-validate.yml
+++ b/.github/workflows/devcontainer-validate.yml
@@ -1,0 +1,49 @@
+---
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: devcontainer-validate
+
+on:
+  pull_request:
+    paths:
+      - '.devcontainer/**'
+      - '.vscode/extensions.json'
+      - 'scripts/install-reuse.sh'
+      - 'scripts/validate-workspace.ts'
+      - '.github/workflows/devcontainer-validate.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate inside devcontainer
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build devcontainer and run pnpm validate
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: genshin-planner-devcontainer
+          push: never
+          runCmd: pnpm validate
+
+# ---------------------------------------------------------------------------
+# Maintenance notes
+# - Cold devcontainer build (no cache) is the slow path. The job ceiling
+#   leaves headroom for first-time builds without retries.
+# - Runs pnpm validate (lint + typecheck + reuse + workspace consistency)
+#   inside the built image so devcontainer drift surfaces here, not in
+#   contributor terminals.
+# ---------------------------------------------------------------------------

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-name: devcontainer-validate
+name: devcontainer
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
       - '.vscode/extensions.json'
       - 'scripts/install-reuse.sh'
       - 'scripts/validate-workspace.ts'
-      - '.github/workflows/devcontainer-validate.yml'
+      - '.github/workflows/devcontainer.yml'
       - 'package.json'
       - 'pnpm-lock.yaml'
   push:
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   validate:
-    name: Validate inside devcontainer
+    name: Validate
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",
-    "reuse:check": "reuse lint"
+    "reuse:check": "reuse lint",
+    "validate:workspace": "tsx scripts/validate-workspace.ts",
+    "validate": "pnpm lint && pnpm typecheck && pnpm reuse:check && pnpm validate:workspace"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
@@ -39,6 +41,7 @@
     "stylelint": "17.11.1",
     "stylelint-config-standard": "40.0.0",
     "concurrently": "9.2.1",
+    "tsx": "4.22.0",
     "turbo": "2.9.14",
     "typescript": "6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       stylelint-config-standard:
         specifier: 40.0.0
         version: 40.0.0(stylelint@17.11.1(typescript@6.0.3))
+      tsx:
+        specifier: 4.22.0
+        version: 4.22.0
       turbo:
         specifier: 2.9.14
         version: 2.9.14

--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,24 @@
       "groupName": "pre-commit hooks",
       "groupSlug": "pre-commit",
       "addLabels": ["pre-commit"]
+    },
+    {
+      "description": "Bump fsfe/reuse-tool in lockstep across pre-commit and install-reuse.sh",
+      "matchDepNames": ["fsfe/reuse-tool"],
+      "groupName": "pre-commit hooks",
+      "groupSlug": "pre-commit",
+      "addLabels": ["pre-commit"]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track REUSE_VERSION in scripts/install-reuse.sh against fsfe/reuse-tool releases",
+      "managerFilePatterns": ["/^scripts/install-reuse\\.sh$/"],
+      "matchStrings": ["REUSE_VERSION=\"\\$\\{REUSE_VERSION:-(?<currentValue>[^}]+)\\}\""],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "fsfe/reuse-tool",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ]
 }

--- a/scripts/install-reuse.sh
+++ b/scripts/install-reuse.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Install reuse-tool via pipx.
+#
+# Used by both the DevContainer post-create script and the
+# devcontainer-validate workflow so the installed version stays in lockstep.
+# Idempotent: skips when the requested version is already on PATH.
+
+set -euo pipefail
+
+REUSE_VERSION="${REUSE_VERSION:-6.2.0}"
+
+if command -v reuse > /dev/null 2>&1; then
+  installed="$(reuse --version 2>/dev/null | awk '{print $NF}')"
+  if [[ "${installed}" == "${REUSE_VERSION}" ]]; then
+    echo "reuse ${REUSE_VERSION} already installed; skipping."
+    exit 0
+  fi
+  echo "reuse ${installed} present; replacing with ${REUSE_VERSION}."
+  pipx uninstall reuse > /dev/null
+fi
+
+pipx install "reuse==${REUSE_VERSION}"

--- a/scripts/validate-workspace.ts
+++ b/scripts/validate-workspace.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Workspace Configuration Validator.
+//
+// Asserts that VS Code extension recommendations in .vscode/extensions.json
+// stay in lockstep with the extensions installed by .devcontainer/devcontainer.json.
+// Both files carry a MAINTENANCE comment pointing at the other; this check
+// enforces it.
+//
+// Usage: pnpm tsx scripts/validate-workspace.ts
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface ExtensionsJson {
+  recommendations?: string[];
+}
+
+interface DevContainerJson {
+  customizations?: {
+    vscode?: {
+      extensions?: string[];
+    };
+  };
+}
+
+function stripJsonc(content: string): string {
+  return content
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/,(\s*[}\]])/g, '$1');
+}
+
+function readJsonc<T>(path: string): T {
+  return JSON.parse(stripJsonc(readFileSync(path, 'utf-8'))) as T;
+}
+
+const root = process.cwd();
+const extensionsPath = join(root, '.vscode', 'extensions.json');
+const devcontainerPath = join(root, '.devcontainer', 'devcontainer.json');
+
+const recommended = readJsonc<ExtensionsJson>(extensionsPath).recommendations ?? [];
+const installed =
+  readJsonc<DevContainerJson>(devcontainerPath).customizations?.vscode?.extensions ?? [];
+
+const recommendedSet = new Set(recommended);
+const installedSet = new Set(installed);
+
+const onlyRecommended = [...recommendedSet].filter((ext) => !installedSet.has(ext)).sort();
+const onlyInstalled = [...installedSet].filter((ext) => !recommendedSet.has(ext)).sort();
+
+if (onlyRecommended.length === 0 && onlyInstalled.length === 0) {
+  console.log(`workspace: ${recommended.length} extensions in sync.`);
+  process.exit(0);
+}
+
+console.error(
+  'workspace: extensions out of sync between .vscode/extensions.json and .devcontainer/devcontainer.json',
+);
+if (onlyRecommended.length > 0) {
+  console.error(`  only in .vscode/extensions.json: ${onlyRecommended.join(', ')}`);
+}
+if (onlyInstalled.length > 0) {
+  console.error(`  only in .devcontainer/devcontainer.json: ${onlyInstalled.join(', ')}`);
+}
+process.exit(1);


### PR DESCRIPTION
## Summary

`pnpm validate` now runs lint, typecheck, reuse, and a workspace-consistency check in one shot, and a new `devcontainer / Validate` CI job runs it inside the built devcontainer so drift surfaces in CI rather than on contributor laptops. Closes #186.

## Gotchas

- `pnpm validate` deliberately chains the existing scripts rather than re-implementing them. If you add a new project-wide check, wire it into `validate` so the devcontainer job picks it up automatically.
- Cold devcontainer builds are the slow path — local timing unknown, hence the 30 min job ceiling. First run will tell us what to tighten to.
- Required-check candidate for the develop ruleset (#2): `devcontainer / Validate`. Worth wiring up once it's green at least once.
- Renovate covers the new `REUSE_VERSION` pin in `scripts/install-reuse.sh` via a custom regex manager against `fsfe/reuse-tool` releases, grouped into the existing "pre-commit hooks" PR so the devcontainer install and the pre-commit hook bump together.
- Didn't introduce `uv` — only Python tool in play is reuse-tool, which is a CLI, so pipx is the right fit.

## Verification

- `pnpm tsx scripts/validate-workspace.ts` — passes, 13 extensions in sync.
- `pre-commit run renovate-config-validator --files renovate.json` — passes with the new custom manager.
- `pre-commit run --files` over the other new files — all hooks pass.
- Devcontainer build itself not exercised locally; the new workflow is the verification path.