### PR TITLE
feat(web): add user profile page consuming /api/profile

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -6,7 +6,7 @@ import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 
 import { Layout } from './components/layout';
 import { Toaster } from './components/ui/sonner';
-import { AuthProvider } from './features/auth';
+import { AuthProvider, ProfilePage, ProtectedRoute } from './features/auth';
 import { CharactersPage } from './pages/characters-page';
 import { NotFoundPage } from './pages/not-found-page';
 import { TeamsPage } from './pages/teams-page';
@@ -24,6 +24,9 @@ export function App() {
               <Route path="/" element={<TeamsPage />} />
               <Route path="/characters" element={<CharactersPage />} />
               <Route path="/weapons" element={<WeaponsPage />} />
+              <Route element={<ProtectedRoute />}>
+                <Route path="/profile" element={<ProfilePage />} />
+              </Route>
               <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -46,16 +46,21 @@ export function Header() {
 function UserMenu({ user }: { user: { displayName: string | null; photoURL: string | null } }) {
   return (
     <div className="flex items-center gap-3">
-      {user.photoURL ? (
-        <img
-          src={user.photoURL}
-          alt=""
-          aria-hidden="true"
-          className="h-8 w-8 rounded-full"
-          referrerPolicy="no-referrer"
-        />
-      ) : null}
-      <span className="text-sm font-medium text-foreground">{user.displayName ?? 'User'}</span>
+      <Link
+        to="/profile"
+        className="flex items-center gap-3 text-foreground hover:text-foreground/80"
+      >
+        {user.photoURL ? (
+          <img
+            src={user.photoURL}
+            alt=""
+            aria-hidden="true"
+            className="h-8 w-8 rounded-full"
+            referrerPolicy="no-referrer"
+          />
+        ) : null}
+        <span className="text-sm font-medium">{user.displayName ?? 'User'}</span>
+      </Link>
       <LogoutButton />
     </div>
   );

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -4,5 +4,6 @@
 export { AuthProvider } from './auth-provider';
 export { LoginButton } from './login-button';
 export { LogoutButton } from './logout-button';
+export { ProfilePage } from './profile-page';
 export { ProtectedRoute } from './protected-route';
 export { useAuth } from './use-auth';

--- a/apps/web/src/features/auth/profile-page.test.tsx
+++ b/apps/web/src/features/auth/profile-page.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProfilePage } from './profile-page';
+import { useProfileQuery, useUpdateProfileMutation } from './use-profile';
+
+vi.mock('@/lib/firebase', () => ({ auth: {} }));
+vi.mock('./use-profile');
+
+const mockedUseProfileQuery = vi.mocked(useProfileQuery);
+const mockedUseUpdateProfileMutation = vi.mocked(useUpdateProfileMutation);
+
+const PROFILE = {
+  uid: 'user-123',
+  email: 'traveler@example.com',
+  emailVerified: true,
+  picture: 'https://example.com/avatar.png',
+  name: 'Traveler',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+};
+
+function mockQuery(value: { data?: typeof PROFILE; isLoading?: boolean; error?: Error | null }) {
+  mockedUseProfileQuery.mockReturnValue({
+    data: value.data,
+    isLoading: value.isLoading ?? false,
+    error: value.error ?? null,
+  } as unknown as ReturnType<typeof useProfileQuery>);
+}
+
+function mockMutation(value: { mutate?: () => void; isPending?: boolean; isError?: boolean }) {
+  const mutate = value.mutate ?? vi.fn();
+  mockedUseUpdateProfileMutation.mockReturnValue({
+    mutate,
+    isPending: value.isPending ?? false,
+    isError: value.isError ?? false,
+  } as unknown as ReturnType<typeof useUpdateProfileMutation>);
+  return mutate;
+}
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutation({});
+  });
+
+  it('shows a loading indicator while the profile loads', () => {
+    mockQuery({ isLoading: true });
+
+    render(<ProfilePage />);
+
+    expect(screen.getByText('Loading profile')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the profile fails to load', () => {
+    mockQuery({ error: new Error('boom') });
+
+    render(<ProfilePage />);
+
+    expect(screen.getByText(/failed to load your profile/i)).toBeInTheDocument();
+  });
+
+  it('renders the name, email, verification state, and avatar', () => {
+    mockQuery({ data: PROFILE });
+
+    const { container } = render(<ProfilePage />);
+
+    expect(screen.getByRole('heading', { name: 'Profile' })).toBeInTheDocument();
+    expect(screen.getByText('Traveler')).toBeInTheDocument();
+    expect(screen.getByText(/traveler@example\.com/)).toBeInTheDocument();
+    expect(screen.getByText(/Verified/)).toBeInTheDocument();
+    expect(container.querySelector('img')).toHaveAttribute('src', PROFILE.picture);
+  });
+
+  it('disables Save until the display name changes', async () => {
+    mockQuery({ data: PROFILE });
+
+    render(<ProfilePage />);
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText('Display name'), '!');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('submits the trimmed display name via the update mutation', async () => {
+    const mutate = mockMutation({});
+    mockQuery({ data: PROFILE });
+
+    render(<ProfilePage />);
+
+    const input = screen.getByLabelText('Display name');
+    await userEvent.clear(input);
+    await userEvent.type(input, '  Paimon  ');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mutate).toHaveBeenCalledWith({ name: 'Paimon' });
+  });
+});

--- a/apps/web/src/features/auth/profile-page.tsx
+++ b/apps/web/src/features/auth/profile-page.tsx
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { ProfileResponse } from '@genshin/domain';
+import { Loader2 } from 'lucide-react';
+import { useState, type FormEvent } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+
+import { LogoutButton } from './logout-button';
+import { useProfileQuery, useUpdateProfileMutation } from './use-profile';
+
+export function ProfilePage() {
+  const { data: profile, isLoading, error } = useProfileQuery();
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-12">
+        <h1 className="sr-only">Profile</h1>
+        <div className="flex items-center justify-center py-24">
+          <Loader2
+            className="h-8 w-8 animate-spin text-muted-foreground"
+            aria-hidden="true"
+            focusable={false}
+          />
+          <span className="sr-only">Loading profile</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !profile) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-12">
+        <h1 className="text-2xl font-bold text-foreground">Profile</h1>
+        <p className="mt-4 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          Failed to load your profile. Please try again later.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-12">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-foreground">Profile</h1>
+        <LogoutButton />
+      </div>
+
+      <Card>
+        <CardHeader className="flex-row items-center gap-4 space-y-0">
+          {profile.picture ? (
+            <img
+              src={profile.picture}
+              alt=""
+              aria-hidden="true"
+              className="h-16 w-16 rounded-full"
+              referrerPolicy="no-referrer"
+            />
+          ) : null}
+          <div>
+            <CardTitle className="text-xl">{profile.name}</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {profile.email ?? 'No email on file'}
+              {profile.email ? (
+                <span className="ml-2">
+                  {profile.emailVerified ? '· Verified' : '· Unverified'}
+                </span>
+              ) : null}
+            </p>
+          </div>
+        </CardHeader>
+
+        <CardContent>
+          {/* Re-mount on the persisted name so the editable field re-seeds after
+              a successful save without syncing state from props in an effect. */}
+          <DisplayNameForm key={profile.name} profile={profile} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DisplayNameForm({ profile }: { profile: ProfileResponse }) {
+  const updateProfile = useUpdateProfileMutation();
+  const [name, setName] = useState(profile.name);
+
+  const trimmed = name.trim();
+  const unchanged = trimmed.length === 0 || trimmed === profile.name;
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (unchanged) return;
+    updateProfile.mutate({ name: trimmed });
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="flex-1">
+          <label htmlFor="profile-name" className="mb-1.5 block text-sm font-medium">
+            Display name
+          </label>
+          <Input
+            id="profile-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            disabled={updateProfile.isPending}
+            autoComplete="name"
+          />
+        </div>
+        <Button type="submit" disabled={unchanged || updateProfile.isPending}>
+          {updateProfile.isPending ? 'Saving…' : 'Save'}
+        </Button>
+      </form>
+      {updateProfile.isError ? (
+        <p role="alert" className="mt-2 text-sm text-destructive">
+          Could not save your changes. Please try again.
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/features/auth/use-profile.test.ts
+++ b/apps/web/src/features/auth/use-profile.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { assertProfileResponse } from './use-profile';
+
+// The module imports @/lib/api, which initialises Firebase from env vars that
+// are absent in the test environment. The guard under test needs none of it.
+vi.mock('@/lib/firebase', () => ({ auth: {} }));
+
+const VALID = {
+  uid: 'user-123',
+  email: 'traveler@example.com',
+  emailVerified: true,
+  picture: 'https://example.com/avatar.png',
+  name: 'Traveler',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+};
+
+describe('assertProfileResponse', () => {
+  it('accepts a fully populated composite profile', () => {
+    expect(() => assertProfileResponse(VALID)).not.toThrow();
+  });
+
+  it('accepts a null email and an absent picture', () => {
+    expect(() =>
+      assertProfileResponse({
+        uid: VALID.uid,
+        email: null,
+        emailVerified: VALID.emailVerified,
+        name: VALID.name,
+        createdAt: VALID.createdAt,
+        updatedAt: VALID.updatedAt,
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => assertProfileResponse(null)).toThrow(TypeError);
+    expect(() => assertProfileResponse('profile')).toThrow(TypeError);
+  });
+
+  it('rejects a missing mutable name', () => {
+    expect(() =>
+      assertProfileResponse({
+        uid: VALID.uid,
+        email: VALID.email,
+        emailVerified: VALID.emailVerified,
+        picture: VALID.picture,
+        createdAt: VALID.createdAt,
+        updatedAt: VALID.updatedAt,
+      }),
+    ).toThrow(TypeError);
+  });
+
+  it('rejects a non-boolean emailVerified', () => {
+    expect(() => assertProfileResponse({ ...VALID, emailVerified: 'yes' })).toThrow(TypeError);
+  });
+
+  it('rejects a non-timestamp updatedAt', () => {
+    expect(() => assertProfileResponse({ ...VALID, updatedAt: 'last week' })).toThrow(TypeError);
+  });
+});

--- a/apps/web/src/features/auth/use-profile.ts
+++ b/apps/web/src/features/auth/use-profile.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { assertUserProfile, type ProfileResponse, type ProfileUpdate } from '@genshin/domain';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { apiGet, apiPatch } from '@/lib/api';
+
+import { useAuth } from './use-auth';
+
+export function profileKey(userId: string): readonly [string, string] {
+  return ['profile', userId] as const;
+}
+
+/**
+ * Validate an unknown value against the composite GET /api/profile contract.
+ *
+ * The auth-owned half is checked field by field; the profile-owned half
+ * (name and timestamps) reuses the shared `assertUserProfile` guard so the
+ * validation stays in lockstep with the domain definition.
+ */
+export function assertProfileResponse(value: unknown): asserts value is ProfileResponse {
+  if (typeof value !== 'object' || value === null) {
+    throw new TypeError(`ProfileResponse must be a non-null object, got: ${JSON.stringify(value)}`);
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.uid !== 'string') {
+    throw new TypeError(`ProfileResponse.uid must be a string, got: ${JSON.stringify(obj.uid)}`);
+  }
+  if (obj.email !== null && typeof obj.email !== 'string') {
+    throw new TypeError(
+      `ProfileResponse.email must be a string or null, got: ${JSON.stringify(obj.email)}`,
+    );
+  }
+  if (typeof obj.emailVerified !== 'boolean') {
+    throw new TypeError(
+      `ProfileResponse.emailVerified must be a boolean, got: ${JSON.stringify(obj.emailVerified)}`,
+    );
+  }
+  if (obj.picture != null && typeof obj.picture !== 'string') {
+    throw new TypeError(
+      `ProfileResponse.picture must be a string, null, or absent, got: ${JSON.stringify(obj.picture)}`,
+    );
+  }
+  assertUserProfile({ name: obj.name, createdAt: obj.createdAt, updatedAt: obj.updatedAt });
+}
+
+export function useProfileQuery() {
+  const { user } = useAuth();
+  const uid = user?.uid;
+
+  return useQuery({
+    queryKey: profileKey(uid ?? ''),
+    queryFn: async (): Promise<ProfileResponse> => {
+      const response = await apiGet('/api/profile');
+      assertProfileResponse(response);
+      return response;
+    },
+    enabled: uid !== undefined,
+  });
+}
+
+export function useUpdateProfileMutation() {
+  const { user } = useAuth();
+  const uid = user?.uid;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (update: ProfileUpdate): Promise<ProfileResponse> => {
+      const response = await apiPatch('/api/profile', update);
+      assertProfileResponse(response);
+      return response;
+    },
+    onSuccess: (profile) => {
+      if (uid !== undefined) queryClient.setQueryData(profileKey(uid), profile);
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Deferred — not shipping for 1.0.0. With the editable display name dropped (a single editable field doesn't justify a dedicated protected route), the page's only net-new content over the existing header is the email address — and email-verification is constant under Google-only sign-in, so it conveys nothing today. The page should return when it has real content: account stats (#823) or account deletion.

The implementation commit stays on this branch for reuse if the page is revived. See #39 (deferred out of 1.0.0).