### PR TITLE
docs: complete README against ddbeck checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: MIT
 
 # Genshin Planner
 
-By [Alex Brandt](https://github.com/alunduil) · [Repository](https://github.com/dungeon-studio/genshin.dungeon.studio)
+By [Alex Brandt](https://github.com/alunduil) · [Repository](https://github.com/dungeon-studio/genshin.dungeon.studio) · [Try it](https://develop.genshin.dungeon.studio)
 
 🔬 **Alpha**: core features work end-to-end; expect rough edges. Contributors welcome.
 
@@ -37,7 +37,7 @@ Anyone who plays Genshin Impact and wants to:
 
 ## Getting started
 
-The quickest way to explore the project or contribute is to use VS Code with DevContainers:
+The quickest way to explore the project or contribute is to use VS Code with DevContainers. You'll need [Docker](https://www.docker.com/get-started/), [VS Code](https://code.visualstudio.com/), and the [DevContainers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed first.
 
 1. **Clone and open** in VS Code
 2. Click **"Reopen in Container"** when prompted
@@ -52,4 +52,6 @@ See the [Manual Setup Guide](./docs/how-tos/manual-setup.md) for Node.js 20+ and
 ## Learn more
 
 - **Contributing**: See [CONTRIBUTING.md](./CONTRIBUTING.md) for development workflow and how to help
+- **Documentation**: Browse [docs/](./docs/) for how-tos, references, and explanations
 - **Planning & Roadmap**: See [GitHub Issues & Milestones](https://github.com/dungeon-studio/genshin.dungeon.studio/milestones) for what's next
+- **License**: [MIT](./LICENSE)


### PR DESCRIPTION
## Summary

Closes #70. The README was already most of the way there, so this finishes it against ddbeck's checklist rather than rewriting it. Adds DevContainer prerequisites (Docker, VS Code, the extension) before the build steps, a `docs/` pointer and a License link to **Learn more**, and a prose **Try it** link to the live app up top.

## Gotchas

- Two points in the issue are stale and intentionally not followed: the issue says the project is "Genshin Dungeon Studio" (rebranded to **Genshin Planner** in #641) and "Pre-alpha" (the maintainer set **Alpha** in #751). The README is correct on both; the issue text predates those changes.
- The README serves two audiences — players (About / Who's it for) and contributors (the DevContainer build). This is a hosted web app, so players use the site, not a local clone. The framing here is **contributor-first**: the build instructions stay as the Use section, and the new top-of-page **Try it** link gives players/evaluators a destination. The alternative (move setup to CONTRIBUTING, make Use "visit the website") was considered and not taken — lower value, higher churn.

## Verification

- `pre-commit run vale --files README.md` passes (an initial "Dev Containers" → "dev" term error was fixed to one-word "DevContainers" to match existing usage).
- All commit hooks pass (markdownlint, reuse, prettier, etc.).
- Verified every referenced link resolves to a real file: `CONTRIBUTING.md`, `docs/how-tos/manual-setup.md`, `docs/`, `LICENSE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)