### PR TITLE
feat: enforce coverage regression guard via codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,12 @@ coverage:
   status:
     project:
       default:
-        informational: true
+        target: auto
+        threshold: 1%
     patch:
       default:
-        informational: true
+        target: auto
+        threshold: 1%
 
 comment:
   layout: reach,diff,flags,components


### PR DESCRIPTION
## Summary

Coverage can no longer silently regress: both codecov status checks now ratchet against the base commit instead of being purely informational. Rather than the fixed 80%/90% targets #127 originally proposed — arbitrary before we know where each area sits — `project` and `patch` use `target: auto` with a 1% threshold, so overall and new-code coverage may not fall more than 1% below base.

Closes #127

## Gotchas

- This makes the checks *able* to fail, but they are not yet *required* on the `develop` ruleset (only `pre-commit.ci - pr` is). A regression shows red on the PR but won't block merge until the checks are made required — tracked in #830, which also moves the ruleset into Terraform.
- Flags and components stay informational; only the repo-wide `project`/`patch` defaults gate.

## Verification

- Validated the config against `https://codecov.io/validate` — returned `Valid!` with `target: auto`, `threshold: 1.0` on both project and patch.
- `pre-commit run --files codecov.yml` passed (yamllint, reuse, secrets).