### PR TITLE
feat: check documentation links via lychee

### DIFF
--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -52,6 +52,7 @@ run_verification() {
   verify "pre-commit"           pre-commit --version
   verify "reuse"                reuse --version
   verify "hadolint"             hadolint --version
+  verify "lychee"               lychee --version
   verify "firebase"             firebase --version
   verify "playwright-cli"       npx --yes playwright --version
   verify "playwright-browsers"  npx --yes playwright install --list
@@ -74,6 +75,7 @@ run_version_summary() {
   print_version "pre-commit" pre-commit --version
   print_version "reuse"      reuse --version
   print_version "hadolint"   hadolint --version
+  print_version "lychee"     lychee --version
   print_version "firebase"   firebase --version
   print_version "playwright" npx --yes playwright --version
   eval "${_xtrace}"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -67,7 +67,7 @@ step "Installing lychee"
 LYCHEE_VERSION="lychee-v0.24.2"
 curl -fsSL \
   "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
-  | sudo tar -xz -C /usr/local/bin lychee
+  | sudo tar -xz -C /usr/local/bin --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
 sudo chmod +x /usr/local/bin/lychee
 
 # ---------------------------------------------------------------------------

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -60,7 +60,18 @@ sudo curl -fsSL \
 sudo chmod +x /usr/local/bin/hadolint
 
 # ---------------------------------------------------------------------------
-# 7. Playwright browsers (for Playwright MCP server)
+# 7. Link checker
+# ---------------------------------------------------------------------------
+step "Installing lychee"
+
+LYCHEE_VERSION="lychee-v0.24.2"
+curl -fsSL \
+  "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+  | sudo tar -xz -C /usr/local/bin lychee
+sudo chmod +x /usr/local/bin/lychee
+
+# ---------------------------------------------------------------------------
+# 8. Playwright browsers (for Playwright MCP server)
 # ---------------------------------------------------------------------------
 step "Installing Playwright Chromium and Chrome"
 

--- a/.github/copilot/new-page.prompt.md
+++ b/.github/copilot/new-page.prompt.md
@@ -11,7 +11,7 @@ Follow the conventions in [code-generation.instructions.md](code-generation.inst
 
 Create a new page component at `apps/web/src/pages/${input:pageName}Page.tsx`.
 
-Use [CharactersPage.tsx](../../apps/web/src/pages/CharactersPage.tsx) as a reference for
+Use [characters-page.tsx](../../apps/web/src/pages/characters-page.tsx) as a reference for
 structure and style.
 
 ## Requirements
@@ -26,7 +26,7 @@ structure and style.
 2. Use a named function export: `export function ${input:pageName}Page()`.
 3. Use semantic HTML with a `<div className="mx-auto max-w-7xl px-4 py-12">` wrapper.
 4. Include an `<h1>` heading as the first visible content.
-5. Add the route to [App.tsx](../../apps/web/src/App.tsx) inside the
+5. Add the route to [app.tsx](../../apps/web/src/app.tsx) inside the
    `<Route element={<Layout />}>` group.
 6. Import the page: `import { ${input:pageName}Page } from './pages/${input:pageName}Page';`.
 7. Run `pnpm typecheck` to verify the new route compiles.

--- a/.github/workflows/external-link-check.yml
+++ b/.github/workflows/external-link-check.yml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: External Link Check
+
+on:
+  schedule:
+    # Fridays at 18:00 Europe/London. The timezone field (GitHub Actions
+    # support added March 2026) handles BST/GMT automatically.
+    - cron: '0 18 * * 5'
+      timezone: Europe/London
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  # External URLs rot independently of our changes, so checking them per-PR
+  # produces flaky failures. Verify them weekly and open an issue when
+  # something breaks rather than blocking a PR. Never blocks.
+  external:
+    name: External Links
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check all links
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --no-progress "**/*.md"
+          fail: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Reuse the open report if one exists so repeated breakage updates a
+      # single issue instead of filing a new one every week.
+      - name: Find existing report issue
+        if: steps.lychee.outputs.exit_code != 0
+        id: report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          number=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search 'Link Checker Report in:title' --json number --jq '.[0].number // empty')
+          echo "number=${number}" >> "${GITHUB_OUTPUT}"
+
+      - name: Open or update issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          issue-number: ${{ steps.report.outputs.number }}
+          labels: documentation

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Link Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Internal cross-references must resolve on disk. Runs on every pull request
+  # (no path filter, so it always reports a status and is safe to require) and
+  # blocks merge on failure. --offline skips all network requests.
+  internal:
+    name: Internal Links
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check internal links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --offline --no-progress "**/*.md"
+          fail: true
+
+  # External URLs rot independently of our changes, so checking them per-PR
+  # produces flaky failures. Instead, verify them weekly and open an issue when
+  # something breaks. Never blocks.
+  external:
+    name: External Links
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check all links
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --no-progress "**/*.md"
+          fail: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: documentation

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,8 +10,10 @@ on:
       - develop
       - main
   schedule:
-    # Mondays at 06:00 UTC.
-    - cron: '0 6 * * 1'
+    # Fridays at 18:00 Europe/London. GitHub cron is UTC-only with no DST,
+    # so this is pinned to 17:00 UTC (18:00 BST); during GMT/winter it fires
+    # at 17:00 London.
+    - cron: '0 17 * * 5'
   workflow_dispatch:
 
 permissions:
@@ -65,10 +67,23 @@ jobs:
           fail: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Open issue on broken links
+      # Reuse the open report if one exists so repeated breakage updates a
+      # single issue instead of filing a new one every week.
+      - name: Find existing report issue
+        if: steps.lychee.outputs.exit_code != 0
+        id: report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          number=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search 'Link Checker Report in:title' --json number --jq '.[0].number // empty')
+          echo "number=${number}" >> "${GITHUB_OUTPUT}"
+
+      - name: Open or update issue on broken links
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
+          issue-number: ${{ steps.report.outputs.number }}
           labels: documentation

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,10 +10,10 @@ on:
       - develop
       - main
   schedule:
-    # Fridays at 18:00 Europe/London. GitHub cron is UTC-only with no DST,
-    # so this is pinned to 17:00 UTC (18:00 BST); during GMT/winter it fires
-    # at 17:00 London.
-    - cron: '0 17 * * 5'
+    # Fridays at 18:00 Europe/London. The timezone field (GitHub Actions
+    # support added March 2026) handles BST/GMT automatically.
+    - cron: '0 18 * * 5'
+      timezone: Europe/London
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,12 +9,6 @@ on:
     branches:
       - develop
       - main
-  schedule:
-    # Fridays at 18:00 Europe/London. The timezone field (GitHub Actions
-    # support added March 2026) handles BST/GMT automatically.
-    - cron: '0 18 * * 5'
-      timezone: Europe/London
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -26,10 +20,10 @@ concurrency:
 jobs:
   # Internal cross-references must resolve on disk. Runs on every pull request
   # (no path filter, so it always reports a status and is safe to require) and
-  # blocks merge on failure. --offline skips all network requests.
+  # blocks merge on failure. --offline skips all network requests, so external
+  # rot — checked weekly in external-link-check.yml — never blocks a PR.
   internal:
     name: Internal Links
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -42,48 +36,3 @@ jobs:
         with:
           args: --offline --no-progress "**/*.md"
           fail: true
-
-  # External URLs rot independently of our changes, so checking them per-PR
-  # produces flaky failures. Instead, verify them weekly and open an issue when
-  # something breaks. Never blocks.
-  external:
-    name: External Links
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      issues: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Check all links
-        id: lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
-        with:
-          args: --no-progress "**/*.md"
-          fail: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Reuse the open report if one exists so repeated breakage updates a
-      # single issue instead of filing a new one every week.
-      - name: Find existing report issue
-        if: steps.lychee.outputs.exit_code != 0
-        id: report
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          number=$(gh issue list --repo "${{ github.repository }}" --state open \
-            --search 'Link Checker Report in:title' --json number --jq '.[0].number // empty')
-          echo "number=${number}" >> "${GITHUB_OUTPUT}"
-
-      - name: Open or update issue on broken links
-        if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
-        with:
-          title: Link Checker Report
-          content-filepath: ./lychee/out.md
-          issue-number: ${{ steps.report.outputs.number }}
-          labels: documentation

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pids
 # Linter/formatter cache
 .eslintcache
 .stylelintcache
+.lycheecache
 
 # npm/pnpm specific
 .npm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,9 @@ ci:
     - renovate-config-validator
     - hadolint
     - ls-lint
+    # lychee is a binary not installable in pre-commit.ci; its CI coverage
+    # lives in link-check.yml, not pre-commit.yml.
+    - lychee
 
 repos:
   # Basic file checks
@@ -156,6 +159,12 @@ repos:
         entry: hadolint
         language: system
         types: [dockerfile]
+
+      - id: lychee
+        name: lychee (internal links)
+        entry: lychee --offline --no-progress
+        language: system
+        types: [markdown]
 
       - id: ls-lint
         name: file naming conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Pre-commit enforces formatting, linting, documentation, secrets, and hygiene che
 - pre-commit.ci is the authoritative runner for hooks that it can run in its environment.
 - [.github/workflows/pre-commit.yml](.github/workflows/pre-commit.yml) runs only hooks that can't run in pre-commit.ci.
 - [.github/workflows/ci.yml](.github/workflows/ci.yml) runs build and type check jobs for apps and packages.
-- [.github/workflows/link-check.yml](.github/workflows/link-check.yml) verifies documentation links with [lychee](https://lychee.cli.rs): internal cross-references block pull requests, while external URLs are checked weekly and reported via a GitHub issue.
+- [.github/workflows/link-check.yml](.github/workflows/link-check.yml) blocks pull requests on broken internal documentation links ([lychee](https://lychee.cli.rs), offline); [.github/workflows/external-link-check.yml](.github/workflows/external-link-check.yml) checks external URLs weekly and reports breakage via a GitHub issue.
 - Feature work adds tests and enforces them when it introduces testable behavior.
 
 **Commit types**. Use these prefixes in your commit messages:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ Pre-commit enforces formatting, linting, documentation, secrets, and hygiene che
 - pre-commit.ci is the authoritative runner for hooks that it can run in its environment.
 - [.github/workflows/pre-commit.yml](.github/workflows/pre-commit.yml) runs only hooks that can't run in pre-commit.ci.
 - [.github/workflows/ci.yml](.github/workflows/ci.yml) runs build and type check jobs for apps and packages.
+- [.github/workflows/link-check.yml](.github/workflows/link-check.yml) verifies documentation links with [lychee](https://lychee.cli.rs): internal cross-references block pull requests, while external URLs are checked weekly and reported via a GitHub issue.
 - Feature work adds tests and enforces them when it introduces testable behavior.
 
 **Commit types**. Use these prefixes in your commit messages:

--- a/docs/explanation/dsgep-002-web-deployment-automation.md
+++ b/docs/explanation/dsgep-002-web-deployment-automation.md
@@ -240,7 +240,3 @@ Verify deployment via:
 - [Cache Control Headers (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
 - [Cloud Storage Static Website Hosting](https://cloud.google.com/storage/docs/hosting-static-website)
 - [SPA Routing in Static Hosting](https://firebase.google.com/docs/hosting/redirect-behavior#spa)
-
-## See also
-
-- How-to: [Manually Redeploy the Web App](../how-tos/deploy-web-to-cloud-storage.md)

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# lychee link checker configuration.
+#
+# Internal links (on-disk file paths) are verified on every pull request and
+# block merge. External URLs are verified on a weekly schedule and reported via
+# a GitHub issue rather than blocking, since transient outages and rate limits
+# make per-PR external checks flaky. See .github/workflows/link-check.yml.
+
+# Skip vendored dependencies and build output; only project docs are ours to
+# keep healthy. A "**/*.md" glob expands into these otherwise.
+exclude_path = [
+  "node_modules",
+  ".pnpm-store",
+  "dist",
+  "build",
+  ".turbo",
+  ".styles",
+]
+
+# Cache results so the weekly external run doesn't re-request every URL.
+cache = true
+max_cache_age = "2d"
+
+# Local dev servers referenced in docs (e.g. http://localhost:8080) aren't
+# reachable from CI; treat loopback addresses as valid.
+exclude_loopback = true
+
+# Accept rate-limited and auth-gated responses as live rather than broken.
+accept = ["200..=299", "403", "429"]

--- a/lychee.toml
+++ b/lychee.toml
@@ -9,19 +9,17 @@
 # make per-PR external checks flaky. See .github/workflows/link-check.yml.
 
 # Skip vendored dependencies and build output; only project docs are ours to
-# keep healthy. A "**/*.md" glob expands into these otherwise.
+# keep healthy. A "**/*.md" glob expands into these otherwise. Entries are
+# regex anchored to a path segment so they can't match a legitimate file such
+# as docs/how-to-build.md.
 exclude_path = [
-  "node_modules",
-  ".pnpm-store",
-  "dist",
-  "build",
-  ".turbo",
-  ".styles",
+  "(^|/)node_modules/",
+  "(^|/)\\.pnpm-store/",
+  "(^|/)dist/",
+  "(^|/)build/",
+  "(^|/)\\.turbo/",
+  "(^|/)\\.styles/",
 ]
-
-# Cache results so the weekly external run doesn't re-request every URL.
-cache = true
-max_cache_age = "2d"
 
 # Local dev servers referenced in docs (e.g. http://localhost:8080) aren't
 # reachable from CI; treat loopback addresses as valid.


### PR DESCRIPTION
## Summary

Broken documentation links now fail fast instead of rotting unnoticed. lychee verifies links across two workflows, split by failure mode: internal cross-references are deterministic, so `link-check.yml` checks them with `--offline` on every pull request and blocks merge; external URLs fail transiently, so a separate weekly workflow (`external-link-check.yml`, Fridays 18:00 Europe/London) checks those and opens or updates an issue on breakage rather than blocking PRs. A matching offline pre-commit hook gives the same internal check locally. Setting this up also surfaced real internal rot, fixed here (see Verification).

Closes #128

## Gotchas

- **No path filter on the internal job — deliberate.** It runs on every PR (the issue scoped it to markdown-touching PRs). A required check gated by `paths:` never reports a status on PRs that skip it and deadlocks the ruleset; the offline check is sub-second, so always-on keeps it safe to require.
- **Depends on an org Actions allowlist change (done).** The repo enforces `allowed_actions: selected` at the *org* level, so `lycheeverse/lychee-action` and `peter-evans/create-issue-from-file` had to be added to the org allowlist or the workflow `startup_failure`s before any job runs. Already applied; noted here for whoever copies this workflow.
- **Making the check required is tracked separately in #847.** The develop ruleset currently requires only `pre-commit.ci - pr`, so until #847 lands the link check is advisory. (Ruleset isn't Terraform-managed yet — see #781/#830.)
- **6 pre-existing broken *external* links are not fixed here.** Tracked in #836; the weekly job will also surface them. Out of scope to keep this PR about the tooling.
- **lychee is a binary,** so like hadolint it's installed in the devcontainer and skipped on pre-commit.ci; the `link-check.yml` / `external-link-check.yml` workflows are its CI home, not pre-commit.ci.

## Verification

- **CI green:** the `Internal Links` job runs and passes; `devcontainer` passes after fixing a bug where the lychee install pulled the binary from the wrong tarball path (it nests under `lychee-x86_64-unknown-linux-gnu/`), which had failed the build.
- **Real rot fixed:** `lychee --offline` (including hidden dirs, matching CI) is 0 errors after fixing two genuine broken internal links — a `dsgep-002` "See also" pointing at a how-to the Firebase Hosting migration (`3515f2d`) deleted, and `new-page.prompt.md` references to `App.tsx`/`CharactersPage.tsx` that should be kebab-case (`app.tsx`/`characters-page.tsx`). The prompt's broader PascalCase-vs-kebab instruction mismatch is tracked separately in #846.
- **`pre-commit run`** over the diff passes, including the new `lychee` hook and `reuse lint` (SPDX on new files).
- **Not verified:** the weekly external path (scheduled job, report-issue dedup, and the `timezone:` schedule firing) hasn't executed — it only runs on `schedule`/`workflow_dispatch`. External *detection* is confirmed locally (the 6 findings in #836).