### PR TITLE
feat: set up Release Drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,6 +32,12 @@ categories:
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 
+# Keep triage-only pull requests out of the notes.
+exclude-labels:
+  - 'duplicate'
+  - 'invalid'
+  - 'wontfix'
+
 version-resolver:
   major:
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -38,6 +38,12 @@ exclude-labels:
   - 'invalid'
   - 'wontfix'
 
+# Strip the conventional-commit prefix from each bullet; the category heading
+# already conveys the type, so 'feat: add X' reads as 'add X'.
+replacers:
+  - search: '/^(\s*-\s)(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\([^)]*\))?!?:\s+/gim'
+    replace: '$1'
+
 version-resolver:
   major:
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,6 +25,9 @@ categories:
     labels:
       - 'dependencies'
       - 'automated'
+  - title: '🧰 Chores'
+    labels:
+      - 'chore'
 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
@@ -43,6 +46,7 @@ version-resolver:
       - 'documentation'
       - 'dependencies'
       - 'automated'
+      - 'chore'
   default: patch
 
 # Apply category labels from conventional-commit PR titles so the categories
@@ -64,6 +68,10 @@ autolabeler:
   - label: 'dependencies'
     title:
       - '/^(chore|build|fix)\(deps(-dev)?\)/i'
+  - label: 'chore'
+    title:
+      - '/^(chore|build)(?!\(deps)(\(.+\))?:/i'
+      - '/^(ci|style|refactor|test|perf)(\(.+\))?:/i'
   - label: 'breaking-change'
     title:
       - '/^\w+(\(.+\))?!:/'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Collect notes from PRs merged into develop. The tag is retargeted to main at
+# publish time (git flow); see .github/workflows/release-drafter.yml.
+commitish: refs/heads/develop
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Fixes'
+    labels:
+      - 'bug'
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+  - title: '⬆️ Dependencies'
+    labels:
+      - 'dependencies'
+      - 'automated'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'security'
+      - 'documentation'
+      - 'dependencies'
+      - 'automated'
+  default: patch
+
+# Apply category labels from conventional-commit PR titles so the categories
+# above are driven by commit prefixes without manual labeling. A breaking-change
+# marker (type!:) adds the major-bump label on top of the type label.
+autolabeler:
+  - label: 'enhancement'
+    title:
+      - '/^feat(\(.+\))?!?:/i'
+  - label: 'bug'
+    title:
+      - '/^fix(\(.+\))?!?:/i'
+  - label: 'documentation'
+    title:
+      - '/^docs(\(.+\))?:/i'
+  - label: 'security'
+    title:
+      - '/^(feat|fix|chore)\(security\)/i'
+  - label: 'dependencies'
+    title:
+      - '/^(chore|build|fix)\(deps(-dev)?\)/i'
+  - label: 'breaking-change'
+    title:
+      - '/^\w+(\(.+\))?!:/'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Autolabeler
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  autolabel:
+    name: Autolabel Pull Request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# ---------------------------------------------------------------------------
+# Maintenance notes
+# - Rules (label <- PR-title prefix) live in .github/release-drafter.yml under
+#   the autolabeler key.
+# - Labels same-repo PRs only; fork PRs run with a read-only token. Switch the
+#   trigger to pull_request_target to label fork PRs (see the release-drafter
+#   README) once outside contributions arrive.
+# ---------------------------------------------------------------------------

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update_release_draft:
+    name: Update Release Draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
+        with:
+          # Pull-request events autolabel only; push and manual dispatch draft
+          # the release only. Splitting the two avoids drafting on every PR sync
+          # and keeps the draft a single source for develop's merged PRs.
+          disable-autolabeler: ${{ github.event_name != 'pull_request' }}
+          disable-releaser: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# ---------------------------------------------------------------------------
+# Maintenance notes
+# - Configuration (categories, autolabeler, version-resolver) lives in
+#   .github/release-drafter.yml.
+# - Notes are collected from PRs merged into develop (commitish in the config).
+#   At release time, publish the running draft and set its tag target to the
+#   main merge commit so the tag lands on main per git flow.
+# - Autolabeler labels same-repo PRs only; fork PRs run with a read-only token
+#   and are left for manual labeling.
+# ---------------------------------------------------------------------------

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,22 +19,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Draft only, on trusted refs. The releaser needs contents: write, so it never
+  # runs in a pull_request context.
   update_release_draft:
     name: Update Release Draft
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
 
     steps:
       - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
-        with:
-          # Pull-request events autolabel only; push and manual dispatch draft
-          # the release only. Splitting the two avoids drafting on every PR sync
-          # and keeps the draft a single source for develop's merged PRs.
-          disable-autolabeler: ${{ github.event_name != 'pull_request' }}
-          disable-releaser: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Label only, on pull requests. The dedicated autolabeler sub-action needs
+  # just pull-requests: write — no contents access.
+  autolabel:
+    name: Autolabel Pull Request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,6 +57,7 @@ jobs:
 # - Notes are collected from PRs merged into develop (commitish in the config).
 #   At release time, publish the running draft and set its tag target to the
 #   main merge commit so the tag lands on main per git flow.
-# - Autolabeler labels same-repo PRs only; fork PRs run with a read-only token
-#   and are left for manual labeling.
+# - Autolabeler labels same-repo PRs only; fork PRs run with a read-only token.
+#   Switch the trigger to pull_request_target to label fork PRs (see the
+#   release-drafter README) once outside contributions arrive.
 # ---------------------------------------------------------------------------

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 permissions:
@@ -19,11 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Draft only, on trusted refs. The releaser needs contents: write, so it never
-  # runs in a pull_request context.
   update_release_draft:
     name: Update Release Draft
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -35,29 +30,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Label only, on pull requests. The dedicated autolabeler sub-action needs
-  # just pull-requests: write — no contents access.
-  autolabel:
-    name: Autolabel Pull Request
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      pull-requests: write
-
-    steps:
-      - uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 # ---------------------------------------------------------------------------
 # Maintenance notes
 # - Configuration (categories, autolabeler, version-resolver) lives in
 #   .github/release-drafter.yml.
+# - PR labeling is a separate concern; see .github/workflows/autolabeler.yml.
 # - Notes are collected from PRs merged into develop (commitish in the config).
 #   At release time, publish the running draft and set its tag target to the
 #   main merge commit so the tag lands on main per git flow.
-# - Autolabeler labels same-repo PRs only; fork PRs run with a read-only token.
-#   Switch the trigger to pull_request_target to label fork PRs (see the
-#   release-drafter README) once outside contributions arrive.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Release notes now draft themselves: every PR merged into `develop` updates a running GitHub Release draft, sorted into Features / Fixes / Security / Documentation / Dependencies / Chores by an autolabeler that reads conventional-commit prefixes off PR titles. Scoped to GitHub Release notes only — the Keep a Changelog `CHANGELOG.md` is #136. Closes #133.

## Gotchas

- **This PR created a `chore` label on the repo** — remote state, not visible in this diff. Other categories reuse existing labels; #844 reviews the full taxonomy and #781 will codify it in Terraform.
- **`commitish: develop`, not `main`** — draws per-PR notes from develop's merges, because only the single `release/*`→`main` PR reaches main (collecting there collapses a release to one bullet). The tag is retargeted to the `main` merge commit at publish. Non-obvious for git flow; #845 owns the full publish/tag flow.
- **Categorization silently no-ops on non-Conventional-Commit titles** — the autolabeler keys off `feat:`/`fix:`/etc. prefixes, and `replacers` strips them from the notes; #159 (PR-title validation) would enforce the convention this depends on.
- **Fork PRs aren't labeled** — `pull_request` hands forks a read-only token; labeling forks needs `pull_request_target`.
- **Labeling pins a sub-action** — `release-drafter/release-drafter/autolabeler@693d20e`, a subpath of the same repo/SHA as the main action (not a typo). No pre-commit schema validation for the config, because release-drafter's published schema omits the `autolabeler` block (and isn't strict), so a hook would skip the riskiest part.

## Verification

- Ran `pre-commit run yamllint`, `reuse`, and `check-yaml` on all files — all pass.
- Pinned both the main action and the `autolabeler` sub-action to the v7.3.1 commit SHA (`693d20e`), confirmed via the GitHub API.
- Reviewed every action input and config option against the v7.3.1 `action.yml` and schema; confirmed `disable-autolabeler`/`disable-releaser` are not real inputs (the cause of the original split-by-input bug).
- Verified the prefix-stripping `replacers` regex against sample bullets with Node (strips `type:`/`type(scope):`/`type!:`, leaves clean titles untouched).