### PR TITLE
docs: document changelog maintenance workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This project hasn't yet cut its first release, so every entry collects under a
+single `### Added` bucket in `[Unreleased]`. Once `0.1.0` ships, later unreleased
+changes split into the standard Added, Changed, Deprecated, Removed, Fixed, and
+Security sections, since they then describe deltas from a shipped release.
 
 ## [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,39 @@ When creating release branches, derive the name from the root `package.json` ver
 
 ---
 
+## Changelog
+
+[CHANGELOG.md](CHANGELOG.md) is hand-curated and follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). It's a separate artifact from the GitHub Release notes that [Release Drafter](.github/release-drafter.yml) aggregates from merged pull requests: the release notes stay pull-request-centric for GitHub readers, while the changelog stays curated for humans.
+
+### When to add an entry
+
+Add a line to the `[Unreleased]` section when your pull request changes something a user of the deployed app would notice: a new or removed feature, a change to existing behavior, a user-facing bug fix, or a security fix. Skip internal refactors, test-only changes, dependency bumps users don't perceive, and documentation fixes—those belong in the commit history, not the changelog.
+
+The test: would a user notice or care? If not, leave the changelog alone.
+
+### Current format
+
+Until `0.1.0` ships, the project has no released version to describe deltas from, so every entry collects under a single `### Added` bucket. Once the first release cuts, later unreleased changes split into the standard sections below.
+
+### Categorizing entries (after the first release)
+
+Classify each kept change by what the user experiences, using your commit type as a guide:
+
+- `feat:` → **Added**
+- `fix:` → **Fixed**
+- `feat(security):` / `fix(security):` → **Security**
+- a breaking removal (`feat!:`, `remove:`) → **Removed**
+- a breaking deprecation (`deprecate:`) → **Deprecated**
+- a user-visible change to existing behavior (`refactor:`, `chore:`, `docs:` only when the change is user-facing) → **Changed**
+
+Most `docs:`, `refactor:`, `chore:`, `style:`, and `test:` commits produce no changelog entry at all, since they aren't user-visible. The map tells you which section to use _if_ the change clears the "would a user notice?" test, not that every commit of that type earns a line.
+
+### At release time
+
+Freeze the `[Unreleased]` section into a versioned section (`## [X.Y.Z] - YYYY-MM-DD`), add its comparison link at the bottom of the file, and start a fresh empty `[Unreleased]`. The Release Drafter output is a useful prompt for what merged since the last release, but copy and curate—don't paste the raw pull-request log.
+
+---
+
 ## Platform compatibility
 
 This project runs on Windows, macOS, and Linux.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,32 +224,7 @@ When creating release branches, derive the name from the root `package.json` ver
 
 [CHANGELOG.md](CHANGELOG.md) is hand-curated and follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). It's a separate artifact from the GitHub Release notes that [Release Drafter](.github/release-drafter.yml) aggregates from merged pull requests: the release notes stay pull-request-centric for GitHub readers, while the changelog stays curated for humans.
 
-### When to add an entry
-
-Add a line to the `[Unreleased]` section when your pull request changes something a user of the deployed app would notice: a new or removed feature, a change to existing behavior, a user-facing bug fix, or a security fix. Skip internal refactors, test-only changes, dependency bumps users don't perceive, and documentation fixes—those belong in the commit history, not the changelog.
-
-The test: would a user notice or care? If not, leave the changelog alone.
-
-### Current format
-
-Until `0.1.0` ships, the project has no released version to describe deltas from, so every entry collects under a single `### Added` bucket. Once the first release cuts, later unreleased changes split into the standard sections below.
-
-### Categorizing entries (after the first release)
-
-Classify each kept change by what the user experiences, using your commit type as a guide:
-
-- `feat:` → **Added**
-- `fix:` → **Fixed**
-- `feat(security):` / `fix(security):` → **Security**
-- a breaking removal (`feat!:`, `remove:`) → **Removed**
-- a breaking deprecation (`deprecate:`) → **Deprecated**
-- a user-visible change to existing behavior (`refactor:`, `chore:`, `docs:` only when the change is user-facing) → **Changed**
-
-Most `docs:`, `refactor:`, `chore:`, `style:`, and `test:` commits produce no changelog entry at all, since they aren't user-visible. The map tells you which section to use _if_ the change clears the "would a user notice?" test, not that every commit of that type earns a line.
-
-### At release time
-
-Freeze the `[Unreleased]` section into a versioned section (`## [X.Y.Z] - YYYY-MM-DD`), add its comparison link at the bottom of the file, and start a fresh empty `[Unreleased]`. The Release Drafter output is a useful prompt for what merged since the last release, but copy and curate—don't paste the raw pull-request log.
+When your pull request changes something a user of the deployed app would notice—a new or removed feature, a change to existing behavior, a user-facing bug fix, or a security fix—add a line under `### Added` in the `[Unreleased]` section. Skip internal refactors, test-only changes, dependency bumps users don't perceive, and documentation fixes. The test is whether a user would notice or care. The [CHANGELOG.md](CHANGELOG.md) header describes the entry layout before and after the first release.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #136. The changelog itself already existed in correct Keep a Changelog pre-first-release shape (PR #668) — what was missing was any record of how to keep it that way, so the issue resolves to documentation rather than code. This names the versioning scheme and the pre-first-release single-`### Added` convention in the CHANGELOG header, and adds a short Changelog section to CONTRIBUTING telling contributors to add a line under `### Added` for user-visible changes. The curated changelog stays a hand-maintained artifact, distinct from Release Drafter's PR-aggregated GitHub Release notes.

## Gotchas

- The issue's Objectives ask to "auto-update on release," but this PR adds no automation. Its own Implementation Notes and the maintainer comment both call for manual curation, with Release Drafter as an assist; this follows the latter.
- The issue lists a fuller conventional-type → section map and a release-time freeze procedure. Those describe a post-`0.1.0` / maintainer workflow that isn't live yet, so they're deferred rather than documented now; CONTRIBUTING carries only the contributor-facing rule.
- No CHANGELOG entry was added for this PR itself — documentation changes aren't user-visible.

## Verification

`pre-commit run --files CHANGELOG.md CONTRIBUTING.md` passes, Vale and internal-link (lychee) checks included.