### PR TITLE
feat: label PRs by component via path rules

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -87,6 +87,31 @@ autolabeler:
   - label: 'breaking-change'
     title:
       - '/^\w+(\(.+\))?!:/'
+  # Component labels from the changed file paths, so a PR is tagged by the part
+  # of the monorepo it touches without manual labeling. Matchers are evaluated
+  # independently, so a cross-cutting PR collects every component it touches.
+  - label: 'web'
+    files:
+      - 'apps/web/**'
+  - label: 'api'
+    files:
+      - 'apps/api/**'
+  - label: 'infrastructure'
+    files:
+      - 'infrastructure/**'
+  - label: 'actions'
+    files:
+      - '.github/**'
+  - label: 'documentation'
+    files:
+      - 'docs/**'
+      - '*.md'
+  - label: 'types'
+    files:
+      - 'packages/domain/**'
+  - label: 'game-data'
+    files:
+      - 'packages/game-data/**'
 
 template: |
   ## What's Changed

--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -29,8 +29,8 @@ jobs:
 
 # ---------------------------------------------------------------------------
 # Maintenance notes
-# - Rules (label <- PR-title prefix) live in .github/release-drafter.yml under
-#   the autolabeler key.
+# - Rules live in .github/release-drafter.yml under the autolabeler key: type
+#   labels from the PR-title prefix, component labels from changed file paths.
 # - Labels same-repo PRs only; fork PRs run with a read-only token. Switch the
 #   trigger to pull_request_target to label fork PRs (see the release-drafter
 #   README) once outside contributions arrive.


### PR DESCRIPTION
## Summary

PRs now pick up component labels (`web`, `api`, `infrastructure`,
`actions`, `documentation`, `types`, `game-data`) automatically from
the files they change, so triage no longer needs a manual labeling
pass. Implemented by adding `files:` matchers to Release Drafter's
existing autolabeler (#835) rather than a second labeling tool — that
autolabeler already applies type labels from the conventional-commit
title prefix.

Closes #134

## Gotchas

- #134 also asked to auto-label issues and proposed `actions/labeler`.
  Both `actions/labeler` and Release Drafter's autolabeler are PR-only
  (issues have no diff to match paths against), so issue labeling is
  out of scope here — split out as #849 to evaluate
  `github/issue-labeler` for keyword-on-issue-body labeling.
- The issue named labels/paths that don't exist (`frontend`,
  `backend`, `packages/types/**`); rules map to the real labels
  (`web`, `api`) and package (`packages/domain/**`).
- `.github/**` → `actions` is intentionally broad: a PR touching only
  `.github/copilot-instructions.md` or an issue template also collects
  the `actions` label.

## Verification

- Both YAML files parse; ran pre-commit on the changed files
  (yamllint, check-yaml, reuse lint, prettier) — all pass.