### PR TITLE
feat(web): add mobile hamburger nav and responsive header

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -4,6 +4,7 @@
 import { Link } from 'react-router-dom';
 
 import { Container } from '@/components/container';
+import { MobileNav } from '@/components/mobile-nav';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { LoginButton, LogoutButton, useAuth } from '@/features/auth';
 
@@ -13,28 +14,31 @@ export function Header() {
   return (
     <header className="border-b border-border bg-background">
       <Container className="flex items-center justify-between py-4">
-        <Link
-          to="/"
-          className="flex items-center gap-2 text-2xl font-bold text-foreground hover:text-foreground/80"
-        >
-          <img
-            src="/favicon-32x32.png"
-            alt=""
-            aria-hidden="true"
-            width={32}
-            height={32}
-            className="dark:hidden"
-          />
-          <img
-            src="/favicon-32x32-dark.png"
-            alt=""
-            aria-hidden="true"
-            width={32}
-            height={32}
-            className="hidden dark:block"
-          />
-          Genshin Planner
-        </Link>
+        <div className="flex items-center gap-2">
+          <MobileNav />
+          <Link
+            to="/"
+            className="flex items-center gap-2 text-2xl font-bold text-foreground hover:text-foreground/80"
+          >
+            <img
+              src="/favicon-32x32.png"
+              alt=""
+              aria-hidden="true"
+              width={32}
+              height={32}
+              className="dark:hidden"
+            />
+            <img
+              src="/favicon-32x32-dark.png"
+              alt=""
+              aria-hidden="true"
+              width={32}
+              height={32}
+              className="hidden dark:block"
+            />
+            <span className="sr-only sm:not-sr-only">Genshin Planner</span>
+          </Link>
+        </div>
         <div className="flex items-center gap-3">
           {!loading && (user ? <UserMenu user={user} /> : <LoginButton />)}
           <ThemeToggle />
@@ -56,7 +60,9 @@ function UserMenu({ user }: { user: { displayName: string | null; photoURL: stri
           referrerPolicy="no-referrer"
         />
       ) : null}
-      <span className="text-sm font-medium text-foreground">{user.displayName ?? 'User'}</span>
+      <span className="hidden text-sm font-medium text-foreground sm:inline">
+        {user.displayName ?? 'User'}
+      </span>
       <LogoutButton />
     </div>
   );

--- a/apps/web/src/components/mobile-nav.test.tsx
+++ b/apps/web/src/components/mobile-nav.test.tsx
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { MobileNav } from './mobile-nav';
+import { NAV_LINKS } from './nav-links';
+
+function renderMobileNav() {
+  return render(
+    <MemoryRouter>
+      <MobileNav />
+    </MemoryRouter>,
+  );
+}
+
+describe('MobileNav', () => {
+  it('reveals every nav link once the menu is opened', async () => {
+    const user = userEvent.setup();
+    renderMobileNav();
+
+    expect(screen.queryByRole('link', { name: 'Teams' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+
+    for (const link of NAV_LINKS) {
+      expect(screen.getByRole('link', { name: link.label })).toBeInTheDocument();
+    }
+  });
+
+  it('closes the menu when a link is selected', async () => {
+    const user = userEvent.setup();
+    renderMobileNav();
+
+    await user.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+    await user.click(screen.getByRole('link', { name: 'Characters' }));
+
+    expect(screen.queryByRole('link', { name: 'Characters' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/mobile-nav.tsx
+++ b/apps/web/src/components/mobile-nav.tsx
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { Menu } from 'lucide-react';
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+
+import { NAV_LINKS } from './nav-links';
+
+export function MobileNav() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" className="sm:hidden" aria-label="Open navigation menu">
+          <Menu className="h-5 w-5" aria-hidden="true" focusable={false} />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="w-64" aria-describedby={undefined}>
+        <SheetTitle>Navigation</SheetTitle>
+        <nav className="mt-6 flex flex-col gap-1" aria-label="Main navigation">
+          {NAV_LINKS.map((link) => (
+            <NavLink
+              key={link.to}
+              to={link.to}
+              end={link.to === '/'}
+              onClick={() => setOpen(false)}
+              className={({ isActive }) =>
+                `rounded-md px-3 py-2 text-base font-medium transition-colors ${
+                  isActive
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                }`
+              }
+            >
+              {link.label}
+            </NavLink>
+          ))}
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/nav-links.ts
+++ b/apps/web/src/components/nav-links.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+export interface NavLinkItem {
+  to: string;
+  label: string;
+}
+
+export const NAV_LINKS: readonly NavLinkItem[] = [
+  { to: '/', label: 'Teams' },
+  { to: '/characters', label: 'Characters' },
+  { to: '/weapons', label: 'Weapons' },
+];

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -4,19 +4,14 @@
 import { NavLink } from 'react-router-dom';
 
 import { Container } from '@/components/container';
+import { NAV_LINKS } from '@/components/nav-links';
 
 export function Nav() {
-  const navLinks = [
-    { to: '/', label: 'Teams' },
-    { to: '/characters', label: 'Characters' },
-    { to: '/weapons', label: 'Weapons' },
-  ];
-
   return (
-    <nav className="border-b border-border bg-muted" aria-label="Main navigation">
+    <nav className="hidden border-b border-border bg-muted sm:block" aria-label="Main navigation">
       <Container>
         <div className="flex gap-8">
-          {navLinks.map((link) => (
+          {NAV_LINKS.map((link) => (
             <NavLink
               key={link.to}
               to={link.to}


### PR DESCRIPTION
## Summary

Small screens now get a hamburger menu and a header that fits. The
three-link nav previously had no mobile affordance, and the header
packed the wordmark, signed-in user name, and action buttons into one
row that overflowed below ~400px. Most of the rest of the app (card
grids, filters, sheets) was already mobile-first; the header and nav
were the remaining gap.

Closes #153

## Gotchas

- The "Genshin Planner" wordmark and the signed-in user's display name
  are now hidden below `sm` — the wordmark stays in the accessibility
  tree (`sr-only sm:not-sr-only`) so the home link keeps its name when
  it collapses to icon-only.
- Nav switches at the `sm` (640px) breakpoint to match the app's
  existing responsive grids, not a new tablet/desktop boundary.
- Not run visually; the layout fix is verified by markup and unit
  tests, not a screenshot at each breakpoint.

## Verification

- `turbo run typecheck lint test build --filter=@genshin/web` all pass.
- Added `mobile-nav.test.tsx`: menu opens to reveal every link and
  closes on selection.