### PR TITLE
chore(lint): automate import sorting and unused-import removal

### DIFF
--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -1,13 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
-
 import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+
+import importConfig from '../../eslint.config.base.mjs';
 
 export default [
   {
@@ -22,25 +20,5 @@ export default [
       globals: globals.node,
     },
   },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
+  ...importConfig(import.meta.dirname),
 ];

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { readFileSync } from 'node:fs';
+import { STATUS_CODES } from 'node:http';
+
+import type { ProblemDetail } from '@genshin/domain';
+import { GoogleError } from 'google-gax';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { HTTPException } from 'hono/http-exception';
+import { logger } from 'hono/logger';
+
 import type { AuthVariables } from '@/middleware/auth.js';
 import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
 import { firestoreErrorToHttpException } from '@/repositories/firestore-error.js';
@@ -11,14 +21,6 @@ import { root } from '@/routes/root.js';
 import { teams } from '@/routes/teams.js';
 import { userProfile } from '@/routes/user-profile.js';
 import { weapons } from '@/routes/weapons.js';
-import type { ProblemDetail } from '@genshin/domain';
-import { GoogleError } from 'google-gax';
-import { Hono } from 'hono';
-import { cors } from 'hono/cors';
-import { HTTPException } from 'hono/http-exception';
-import { logger } from 'hono/logger';
-import { readFileSync } from 'node:fs';
-import { STATUS_CODES } from 'node:http';
 
 // Read version from package.json to maintain single source of truth
 const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));

--- a/apps/api/src/lib/firebase/auth.ts
+++ b/apps/api/src/lib/firebase/auth.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { app } from '@/lib/firebase/app.js';
 import { type DecodedIdToken, getAuth } from 'firebase-admin/auth';
+
+import { app } from '@/lib/firebase/app.js';
 
 const auth = getAuth(app);
 

--- a/apps/api/src/lib/firebase/firestore.ts
+++ b/apps/api/src/lib/firebase/firestore.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { app } from '@/lib/firebase/app.js';
 import { getFirestore } from 'firebase-admin/firestore';
+
+import { app } from '@/lib/firebase/app.js';
 
 const rawDatabaseId = process.env.FIRESTORE_DATABASE_ID ?? '(default)';
 const databaseId = rawDatabaseId.trim();

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { app } from '@/app.js';
 import { serve } from '@hono/node-server';
+
+import { app } from '@/app.js';
 
 const port = parseInt(process.env.PORT || '8080', 10);
 console.log(`Server running at http://localhost:${port}`);

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { DecodedIdToken } from '@/lib/firebase/auth.js';
-import { verifyToken } from '@/lib/firebase/auth.js';
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
+
+import type { DecodedIdToken } from '@/lib/firebase/auth.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
 
 export type AuthVariables = {
   user: DecodedIdToken;

--- a/apps/api/src/middleware/negotiate-content.ts
+++ b/apps/api/src/middleware/negotiate-content.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { ProfileLink } from '@/middleware/profile-link.js';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import Negotiator from 'negotiator';
+
+import type { ProfileLink } from '@/middleware/profile-link.js';
 
 export type { ProfileLink } from '@/middleware/profile-link.js';
 

--- a/apps/api/src/middleware/negotiate-request-schema.test.ts
+++ b/apps/api/src/middleware/negotiate-request-schema.test.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { ProfileLink } from '@/middleware/profile-link.js';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
+
+import type { ProfileLink } from '@/middleware/profile-link.js';
 
 import type { NegotiatedRequestSchemaVariables } from './negotiate-request-schema.js';
 import { negotiateRequestSchema } from './negotiate-request-schema.js';

--- a/apps/api/src/middleware/negotiate-request-schema.ts
+++ b/apps/api/src/middleware/negotiate-request-schema.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { ProfileLink } from '@/middleware/profile-link.js';
 import contentType from 'content-type';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+
+import type { ProfileLink } from '@/middleware/profile-link.js';
 
 /**
  * Extract the pathname from a profile URL or path.

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
-import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
+
+import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
+import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 
 import type { ValidatedRequestBodyVariables } from './validate-request-body.js';
 import { validateRequestBody } from './validate-request-body.js';

--- a/apps/api/src/middleware/validate-request-body.ts
+++ b/apps/api/src/middleware/validate-request-body.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 import type { ErrorObject, SchemaObject } from 'ajv/dist/2020.js';
 import { Ajv2020 } from 'ajv/dist/2020.js';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+
+import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 
 const ajv = new Ajv2020({ allErrors: true });
 

--- a/apps/api/src/profiles/alps/registry.test.ts
+++ b/apps/api/src/profiles/alps/registry.test.ts
@@ -5,9 +5,10 @@ import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { describe, expect, it } from 'vitest';
+
 import type { AlpsProfile } from '@/profiles/alps/profile.js';
 import { alpsRegistry } from '@/profiles/alps/registry.js';
-import { describe, expect, it } from 'vitest';
 
 const profilesDir = fileURLToPath(new URL('.', import.meta.url));
 const infraFiles = new Set(['registry.ts', 'registry.test.ts', 'profile.ts']);

--- a/apps/api/src/profiles/json-schema/registry.test.ts
+++ b/apps/api/src/profiles/json-schema/registry.test.ts
@@ -5,9 +5,10 @@ import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { describe, expect, it } from 'vitest';
+
 import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 import { jsonSchemaRegistry } from '@/profiles/json-schema/registry.js';
-import { describe, expect, it } from 'vitest';
 
 const schemasDir = fileURLToPath(new URL('.', import.meta.url));
 const infraFiles = new Set(['registry.ts', 'registry.test.ts', 'json-schema-profile.ts']);

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { db } from '@/lib/firebase/firestore.js';
 import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
+
+import { db } from '@/lib/firebase/firestore.js';
 
 import { fromDocument, toDocument } from './document.js';
 

--- a/apps/api/src/repositories/profile/index.ts
+++ b/apps/api/src/repositories/profile/index.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { db } from '@/lib/firebase/firestore.js';
 import type { ISOTimestamp, ProfileUpdate, UserProfile } from '@genshin/domain';
+
+import { db } from '@/lib/firebase/firestore.js';
 
 import { fromDocument, toDocument } from './document.js';
 

--- a/apps/api/src/repositories/teams/index.ts
+++ b/apps/api/src/repositories/teams/index.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { db } from '@/lib/firebase/firestore.js';
 import type { CollectionTeam, ISOTimestamp, TeamSlot } from '@genshin/domain';
+
+import { db } from '@/lib/firebase/firestore.js';
 
 import { fromDocument, toDocument } from './document.js';
 

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { db } from '@/lib/firebase/firestore.js';
-import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/domain';
 import { randomUUID } from 'node:crypto';
+
+import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/domain';
+
+import { db } from '@/lib/firebase/firestore.js';
 
 import { fromDocument, toDocument } from './document.js';
 

--- a/apps/api/src/routes/alps-profiles.test.ts
+++ b/apps/api/src/routes/alps-profiles.test.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { app } from '@/app.js';
 import { alpsRegistry } from '@/profiles/alps/registry.js';
-import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('Profile serving routes', () => {
   describe('GET known profile', () => {

--- a/apps/api/src/routes/alps-profiles.ts
+++ b/apps/api/src/routes/alps-profiles.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { alpsRegistry } from '@/profiles/alps/registry.js';
 import { Hono } from 'hono';
+
+import { alpsRegistry } from '@/profiles/alps/registry.js';
 
 export const alpsProfiles = new Hono();
 

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -1,8 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 import type { CollectionCharacter } from '@genshin/domain';
+import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import { getCharacterById } from '@genshin/game-data';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { app } from '@/app.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
+import { toMediaTypeString } from '@/middleware/negotiate-content.js';
+import { characterItemV1 } from '@/profiles/alps/character/item-v1.js';
+import * as Characters from '@/repositories/characters/index.js';
+import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 
 vi.mock('@/lib/firebase/auth.js', () => ({
   verifyToken: vi.fn(),
@@ -18,16 +28,6 @@ vi.mock('@/repositories/characters/index.js', () => ({
 vi.mock('@genshin/game-data', () => ({
   getCharacterById: vi.fn(),
 }));
-
-import { app } from '@/app.js';
-import { verifyToken } from '@/lib/firebase/auth.js';
-import { toMediaTypeString } from '@/middleware/negotiate-content.js';
-import { characterItemV1 } from '@/profiles/alps/character/item-v1.js';
-import * as Characters from '@/repositories/characters/index.js';
-import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
-import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
-import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
-import { getCharacterById } from '@genshin/game-data';
 
 const FAKE_CHARACTER: CollectionCharacter = {
   characterId: 'albedo',

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
+import { characterItemHref, characterRepresentation, serialiseCharacter } from '@genshin/domain';
+import { getCharacterById } from '@genshin/game-data';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
 import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
@@ -12,11 +18,6 @@ import { validateRequestBody } from '@/middleware/validate-request-body.js';
 import { characterItemV1 } from '@/profiles/alps/character/item-v1.js';
 import { characterPutRequestV1 } from '@/profiles/json-schema/characters/put-request-v1.js';
 import * as Characters from '@/repositories/characters/index.js';
-import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
-import { characterItemHref, characterRepresentation, serialiseCharacter } from '@genshin/domain';
-import { getCharacterById } from '@genshin/game-data';
-import { Hono } from 'hono';
-import { HTTPException } from 'hono/http-exception';
 
 export const characters = new Hono<{
   Variables: AuthVariables &

--- a/apps/api/src/routes/json-schema-profiles.test.ts
+++ b/apps/api/src/routes/json-schema-profiles.test.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { app } from '@/app.js';
 import { jsonSchemaRegistry } from '@/profiles/json-schema/registry.js';
-import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('Schema serving routes', () => {
   describe('GET known schema', () => {

--- a/apps/api/src/routes/json-schema-profiles.ts
+++ b/apps/api/src/routes/json-schema-profiles.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { jsonSchemaRegistry } from '@/profiles/json-schema/registry.js';
 import { Hono } from 'hono';
+
+import { jsonSchemaRegistry } from '@/profiles/json-schema/registry.js';
 
 export const jsonSchemaProfiles = new Hono();
 

--- a/apps/api/src/routes/root.test.ts
+++ b/apps/api/src/routes/root.test.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { app } from '@/app.js';
-import { rootGetResponseV1 } from '@/profiles/json-schema/root/get-response-v1.js';
 import { Ajv2020 } from 'ajv/dist/2020.js';
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import { app } from '@/app.js';
+import { rootGetResponseV1 } from '@/profiles/json-schema/root/get-response-v1.js';
 
 const ajv = new Ajv2020();
 const validateGetSchema = ajv.compile(rootGetResponseV1.schema);

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
-import { negotiateContent } from '@/middleware/negotiate-content.js';
-import { rootGetResponseV1 } from '@/profiles/json-schema/root/get-response-v1.js';
 import type { Env, Hono as HonoApp } from 'hono';
 import { Hono } from 'hono';
 import { findTargetHandler, isMiddleware } from 'hono/utils/handler';
+
+import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import { negotiateContent } from '@/middleware/negotiate-content.js';
+import { rootGetResponseV1 } from '@/profiles/json-schema/root/get-response-v1.js';
 
 /**
  * Discover top-level resource paths from the app's registered routes.

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -1,8 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 import type { CollectionCharacter, CollectionTeam, CollectionWeapon, UUID } from '@genshin/domain';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { app } from '@/app.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
+import { toMediaTypeString } from '@/middleware/negotiate-content.js';
+import { teamItemV1 } from '@/profiles/alps/team/item-v1.js';
+import * as Characters from '@/repositories/characters/index.js';
+import * as Teams from '@/repositories/teams/index.js';
+import * as Weapons from '@/repositories/weapons/index.js';
+import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 
 vi.mock('@/lib/firebase/auth.js', () => ({
   verifyToken: vi.fn(),
@@ -22,17 +32,6 @@ vi.mock('@/repositories/characters/index.js', () => ({
 vi.mock('@/repositories/weapons/index.js', () => ({
   get: vi.fn(),
 }));
-
-import { app } from '@/app.js';
-import { verifyToken } from '@/lib/firebase/auth.js';
-import * as Characters from '@/repositories/characters/index.js';
-import * as Teams from '@/repositories/teams/index.js';
-import * as Weapons from '@/repositories/weapons/index.js';
-import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
-import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
-
-import { toMediaTypeString } from '@/middleware/negotiate-content.js';
-import { teamItemV1 } from '@/profiles/alps/team/item-v1.js';
 
 const FAKE_TEAM: CollectionTeam = {
   slot: 1,

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -1,6 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { COLLECTION_JSON } from '@genshin/collection-json';
+import type { CollectionTeamMember, CollectionTeamMembers, TeamSlot, UUID } from '@genshin/domain';
+import {
+  isValidTeamSlot,
+  teamItemDocument,
+  teamListDocument,
+  validateArtifactPlan,
+  validateTeams,
+} from '@genshin/domain';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
 import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
@@ -14,17 +26,6 @@ import { teamPutRequestV1 } from '@/profiles/json-schema/teams/put-request-v1.js
 import * as Characters from '@/repositories/characters/index.js';
 import * as Teams from '@/repositories/teams/index.js';
 import * as Weapons from '@/repositories/weapons/index.js';
-import { COLLECTION_JSON } from '@genshin/collection-json';
-import type { CollectionTeamMember, CollectionTeamMembers, TeamSlot, UUID } from '@genshin/domain';
-import {
-  isValidTeamSlot,
-  teamItemDocument,
-  teamListDocument,
-  validateArtifactPlan,
-  validateTeams,
-} from '@genshin/domain';
-import { Hono } from 'hono';
-import { HTTPException } from 'hono/http-exception';
 
 export const teams = new Hono<{
   Variables: AuthVariables &

--- a/apps/api/src/routes/user-profile.test.ts
+++ b/apps/api/src/routes/user-profile.test.ts
@@ -1,10 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { profileGetResponseV1 } from '@/profiles/json-schema/profile/get-response-v1.js';
 import type { UserProfile } from '@genshin/domain';
 import { Ajv2020 } from 'ajv/dist/2020.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { app } from '@/app.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
+import { profileGetResponseV1 } from '@/profiles/json-schema/profile/get-response-v1.js';
+import * as Profile from '@/repositories/profile/index.js';
+import { FAKE_UID, authedRequest } from '@/test/auth-requests.js';
 
 vi.mock('@/lib/firebase/auth.js', () => ({
   verifyToken: vi.fn(),
@@ -14,11 +19,6 @@ vi.mock('@/repositories/profile/index.js', () => ({
   get: vi.fn(),
   update: vi.fn(),
 }));
-
-import { app } from '@/app.js';
-import { verifyToken } from '@/lib/firebase/auth.js';
-import * as Profile from '@/repositories/profile/index.js';
-import { FAKE_UID, authedRequest } from '@/test/auth-requests.js';
 
 const ajv = new Ajv2020();
 const validateGetSchema = ajv.compile(profileGetResponseV1.schema);

--- a/apps/api/src/routes/user-profile.ts
+++ b/apps/api/src/routes/user-profile.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { serialiseProfile, type AuthIdentity, type ProfileUpdate } from '@genshin/domain';
+import type { DecodedIdToken } from 'firebase-admin/auth';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
 import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
@@ -12,10 +17,6 @@ import { validateRequestBody } from '@/middleware/validate-request-body.js';
 import { profileGetResponseV1 } from '@/profiles/json-schema/profile/get-response-v1.js';
 import { profilePatchRequestV1 } from '@/profiles/json-schema/profile/patch-request-v1.js';
 import * as Profile from '@/repositories/profile/index.js';
-import { serialiseProfile, type AuthIdentity, type ProfileUpdate } from '@genshin/domain';
-import type { DecodedIdToken } from 'firebase-admin/auth';
-import { Hono } from 'hono';
-import { HTTPException } from 'hono/http-exception';
 
 function toAuthIdentity({ uid, email, email_verified, picture }: DecodedIdToken): AuthIdentity {
   return { uid, email, emailVerified: email_verified, picture };

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -1,8 +1,18 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
 import type { CollectionWeapon, UUID } from '@genshin/domain';
+import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
+import { getWeaponById } from '@genshin/game-data';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { app } from '@/app.js';
+import { verifyToken } from '@/lib/firebase/auth.js';
+import { toMediaTypeString } from '@/middleware/negotiate-content.js';
+import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
+import * as Weapons from '@/repositories/weapons/index.js';
+import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 
 vi.mock('@/lib/firebase/auth.js', () => ({
   verifyToken: vi.fn(),
@@ -19,16 +29,6 @@ vi.mock('@/repositories/weapons/index.js', () => ({
 vi.mock('@genshin/game-data', () => ({
   getWeaponById: vi.fn(),
 }));
-
-import { app } from '@/app.js';
-import { verifyToken } from '@/lib/firebase/auth.js';
-import { toMediaTypeString } from '@/middleware/negotiate-content.js';
-import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
-import * as Weapons from '@/repositories/weapons/index.js';
-import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
-import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
-import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
-import { getWeaponById } from '@genshin/game-data';
 
 const FAKE_WEAPON: CollectionWeapon = {
   weaponInstanceId: 'instance-uuid-1' as UUID,

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
+import type { UUID } from '@genshin/domain';
+import { serialiseWeapon, weaponItemHref, weaponRepresentation } from '@genshin/domain';
+import { getWeaponById } from '@genshin/game-data';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
 import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
@@ -13,12 +20,6 @@ import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
 import { weaponPatchRequestV1 } from '@/profiles/json-schema/weapons/patch-request-v1.js';
 import { weaponPostRequestV1 } from '@/profiles/json-schema/weapons/post-request-v1.js';
 import * as Weapons from '@/repositories/weapons/index.js';
-import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
-import type { UUID } from '@genshin/domain';
-import { serialiseWeapon, weaponItemHref, weaponRepresentation } from '@genshin/domain';
-import { getWeaponById } from '@genshin/game-data';
-import { Hono } from 'hono';
-import { HTTPException } from 'hono/http-exception';
 
 export const weapons = new Hono<{
   Variables: AuthVariables &

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,16 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
-
 import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+
+import importConfig from '../../eslint.config.base.mjs';
 
 export default [
   {
@@ -54,25 +52,5 @@ export default [
       'react/function-component-definition': 'off',
     },
   },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
+  ...importConfig(import.meta.dirname),
 ];

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -3,7 +3,6 @@
 
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
-
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { useCallback, useEffect, useRef } from 'react';
-import { toast } from 'sonner';
-
 import type { CharacterId, CollectionCharacter } from '@genshin/domain';
 import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import { useCallback, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
 
 import { useAuth } from '@/features/auth/use-auth';
 

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.ts
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
+import { isValidRefinementLevel } from '@genshin/domain';
 import type { Weapon } from '@genshin/game-data';
 import { useCallback, useEffect } from 'react';
 import { toast } from 'sonner';
-
-import { isValidRefinementLevel } from '@genshin/domain';
 
 import { useAuth } from '@/features/auth/use-auth';
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { auth } from '@/lib/firebase';
 import type { ProblemDetail } from '@genshin/domain';
+
+import { auth } from '@/lib/firebase';
 
 export type { ProblemDetail };
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+
 import { App } from './app.tsx';
 import './index.css';
 

--- a/apps/web/src/pages/teams-page.tsx
+++ b/apps/web/src/pages/teams-page.tsx
@@ -13,8 +13,8 @@ import { useWeaponCollection } from '@/features/collection/weapons/use-weapon-co
 import { CharacterPool } from '@/features/teams/character-pool';
 import { TeamPlanner } from '@/features/teams/team-planner';
 import { TeamStrip } from '@/features/teams/team-strip';
-import { WeaponPool } from '@/features/teams/weapon-pool';
 import { useTeams } from '@/features/teams/use-teams';
+import { WeaponPool } from '@/features/teams/weapon-pool';
 
 type SheetTab = 'characters' | 'weapons';
 

--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { WeaponType } from '@genshin/game-data';
 import { WEAPONS } from '@genshin/game-data';
+import { WEAPON_TYPES } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
-
-import type { WeaponType } from '@genshin/game-data';
-import { WEAPON_TYPES } from '@genshin/game-data';
 
 import { Container } from '@/components/container';
 import type { WeaponFilterState } from '@/features/collection/weapons/filtering';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import react from '@vitejs/plugin-react';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 const requiredEnvVars: readonly string[] = [

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/eslint.config.base.mjs
+++ b/eslint.config.base.mjs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { resolve } from 'node:path';
+
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
+import importX from 'eslint-plugin-import-x';
+import unusedImports from 'eslint-plugin-unused-imports';
+
+/**
+ * Shared import-management config for every workspace package.
+ *
+ * Holds the import rules that must stay identical across packages: dependency
+ * hygiene, deterministic ordering, and unused-import removal. Spread the result
+ * into a package's flat config after `js`/`typescript-eslint` recommended sets
+ * so these rules win on conflict (`unused-imports` supersedes the recommended
+ * `no-unused-vars`).
+ *
+ * @param {string} packageDir - the consuming package's `import.meta.dirname`,
+ *   used to resolve its own and the workspace-root `package.json` for the
+ *   extraneous-dependencies check.
+ * @returns {import('eslint').Linter.Config[]}
+ */
+export default function importConfig(packageDir) {
+  return [
+    {
+      files: ['**/*.{ts,tsx,js,mjs,cjs}'],
+      plugins: { 'import-x': importX, 'unused-imports': unusedImports },
+      settings: {
+        'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
+      },
+      rules: {
+        'import-x/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: [
+              '**/*.{test,spec}.{ts,tsx}',
+              '**/test/**',
+              'eslint.config.js',
+              '*.config.{ts,js,mjs,cjs}',
+            ],
+            packageDir: [packageDir, resolve(packageDir, '../..')],
+          },
+        ],
+        'import-x/order': [
+          'error',
+          {
+            groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
+            'newlines-between': 'always',
+            alphabetize: { order: 'asc', caseInsensitive: true },
+          },
+        ],
+        // `unused-imports` owns unused-symbol reporting so removals are
+        // autofixable; the recommended `no-unused-vars` rules are disabled to
+        // avoid double-reporting.
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+        'unused-imports/no-unused-imports': 'error',
+        'unused-imports/no-unused-vars': [
+          'error',
+          { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
+        ],
+      },
+    },
+  ];
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint": "10.4.0",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import-x": "4.16.2",
+    "eslint-plugin-unused-imports": "4.4.1",
     "knip": "6.16.1",
     "prettier": "3.8.3",
     "stylelint": "17.12.0",

--- a/packages/collection-json/eslint.config.js
+++ b/packages/collection-json/eslint.config.js
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
-
 import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
 import tseslint from 'typescript-eslint';
+
+import importConfig from '../../eslint.config.base.mjs';
 
 export default [
   { ignores: ['dist', 'node_modules'] },
@@ -19,25 +17,5 @@ export default [
       '@typescript-eslint/explicit-function-return-type': 'warn',
     },
   },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
+  ...importConfig(import.meta.dirname),
 ];

--- a/packages/domain/eslint.config.js
+++ b/packages/domain/eslint.config.js
@@ -1,36 +1,14 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
-import { resolve } from 'node:path';
-
 import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
 import tseslint from 'typescript-eslint';
+
+import importConfig from '../../eslint.config.base.mjs';
 
 export default [
   { ignores: ['dist', 'node_modules'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
+  ...importConfig(import.meta.dirname),
 ];

--- a/packages/domain/src/artifact-plan-validation.test.ts
+++ b/packages/domain/src/artifact-plan-validation.test.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it } from 'vitest';
-
 import { isValid } from '@genshin/validation';
+import { describe, expect, it } from 'vitest';
 
 import { validateArtifactPlan } from './artifact-plan-validation.js';
 

--- a/packages/domain/src/artifact-plan-validation.ts
+++ b/packages/domain/src/artifact-plan-validation.ts
@@ -15,7 +15,6 @@ import {
   GOBLET_MAIN_AFFIXES,
   SANDS_MAIN_AFFIXES,
 } from '@genshin/game-data';
-
 import type { ValidationIssue } from '@genshin/validation';
 import { issue } from '@genshin/validation';
 

--- a/packages/domain/src/collection-character.test.ts
+++ b/packages/domain/src/collection-character.test.ts
@@ -68,7 +68,6 @@ describe('assertCollectionCharacter', () => {
   });
 
   it('throws for missing characterId', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { characterId: _, ...rest } = VALID_CHARACTER;
     expect(() => assertCollectionCharacter(rest)).toThrow(/characterId/);
   });

--- a/packages/domain/src/collection-weapon.test.ts
+++ b/packages/domain/src/collection-weapon.test.ts
@@ -70,13 +70,11 @@ describe('assertCollectionWeapon', () => {
   });
 
   it('throws for missing weaponInstanceId', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { weaponInstanceId: _, ...rest } = VALID_WEAPON;
     expect(() => assertCollectionWeapon(rest)).toThrow(/weaponInstanceId/);
   });
 
   it('throws for missing weaponId', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { weaponId: _, ...rest } = VALID_WEAPON;
     expect(() => assertCollectionWeapon(rest)).toThrow(/weaponId/);
   });

--- a/packages/domain/src/representations/collection-json/characters.test.ts
+++ b/packages/domain/src/representations/collection-json/characters.test.ts
@@ -3,9 +3,9 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { deserialiseCharacter, serialiseCharacter } from './characters.js';
 import type { CollectionCharacter } from '../../collection-character.js';
 import type { ISOTimestamp } from '../../iso-timestamp.js';
-import { deserialiseCharacter, serialiseCharacter } from './characters.js';
 
 const BASE_URL = 'http://localhost:8080';
 const VALID_TIMESTAMP = '2024-01-15T12:00:00Z' as ISOTimestamp;

--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -3,10 +3,10 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { deserialiseTeam, serialiseTeam } from './teams.js';
 import type { CollectionTeam, CollectionTeamMembers, TeamSlot } from '../../collection-team.js';
 import type { ISOTimestamp } from '../../iso-timestamp.js';
 import type { UUID } from '../../uuid.js';
-import { deserialiseTeam, serialiseTeam } from './teams.js';
 
 const BASE_URL = 'http://localhost:8080';
 const VALID_TIMESTAMP = '2024-01-15T12:00:00Z' as ISOTimestamp;

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -22,9 +22,9 @@ import {
 } from '@genshin/collection-json';
 
 import type { ArtifactPlan } from '../../artifact-plan.js';
+import type { CollectionTeamMember } from '../../collection-team-member.js';
 import type { CollectionTeam, CollectionTeamMembers } from '../../collection-team.js';
 import { assertCollectionTeam, MAX_TEAM_MEMBERS } from '../../collection-team.js';
-import type { CollectionTeamMember } from '../../collection-team-member.js';
 
 const TEAM_TEMPLATE: Template = {
   data: [

--- a/packages/domain/src/representations/collection-json/weapons.test.ts
+++ b/packages/domain/src/representations/collection-json/weapons.test.ts
@@ -3,10 +3,10 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { deserialiseWeapon, serialiseWeapon } from './weapons.js';
 import type { CollectionWeapon } from '../../collection-weapon.js';
 import type { ISOTimestamp } from '../../iso-timestamp.js';
 import type { UUID } from '../../uuid.js';
-import { deserialiseWeapon, serialiseWeapon } from './weapons.js';
 
 const BASE_URL = 'http://localhost:8080';
 const VALID_TIMESTAMP = '2024-01-15T12:00:00Z' as ISOTimestamp;

--- a/packages/domain/src/representations/json/profile.test.ts
+++ b/packages/domain/src/representations/json/profile.test.ts
@@ -3,10 +3,10 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { deserialiseProfile, serialiseProfile } from './profile.js';
 import type { AuthIdentity } from '../../auth-identity.js';
 import type { ISOTimestamp } from '../../iso-timestamp.js';
 import type { UserProfile } from '../../user-profile.js';
-import { deserialiseProfile, serialiseProfile } from './profile.js';
 
 const VALID_TIMESTAMP = '2024-01-15T12:00:00Z' as ISOTimestamp;
 

--- a/packages/domain/src/team-validation.ts
+++ b/packages/domain/src/team-validation.ts
@@ -14,6 +14,7 @@
 
 import type { ValidationIssue } from '@genshin/validation';
 import { issue, prefixPaths } from '@genshin/validation';
+
 import { validateArtifactPlan } from './artifact-plan-validation.js';
 import type { CollectionTeamMembers, TeamSlot } from './collection-team.js';
 

--- a/packages/game-data/eslint.config.js
+++ b/packages/game-data/eslint.config.js
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
-
 import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
 import tseslint from 'typescript-eslint';
+
+import importConfig from '../../eslint.config.base.mjs';
 
 export default [
   { ignores: ['dist', 'node_modules'] },
@@ -19,25 +17,5 @@ export default [
       '@typescript-eslint/explicit-function-return-type': 'warn',
     },
   },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
+  ...importConfig(import.meta.dirname),
 ];

--- a/packages/validation/eslint.config.js
+++ b/packages/validation/eslint.config.js
@@ -1,36 +1,14 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
-import { resolve } from 'node:path';
-
 import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
 import tseslint from 'typescript-eslint';
+
+import importConfig from '../../eslint.config.base.mjs';
 
 export default [
   { ignores: ['dist', 'node_modules'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
+  ...importConfig(import.meta.dirname),
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       eslint-plugin-import-x:
         specifier: 4.16.2
         version: 4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-unused-imports:
+        specifier: 4.4.1
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))
       knip:
         specifier: 6.16.1
         version: 6.16.1
@@ -2720,6 +2723,15 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-unused-imports@4.4.1:
+    resolution: {integrity: sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^10.0.0 || ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -7059,6 +7071,12 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.4.0(jiti@2.7.0)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
 
   eslint-scope@9.1.2:
     dependencies:

--- a/tools/game-data-codegen/eslint.config.js
+++ b/tools/game-data-codegen/eslint.config.js
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
-
 import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
 import tseslint from 'typescript-eslint';
+
+import importConfig from '../../eslint.config.base.mjs';
 
 export default [
   { ignores: ['dist', 'node_modules'] },
@@ -19,25 +17,5 @@ export default [
       '@typescript-eslint/explicit-function-return-type': 'warn',
     },
   },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
+  ...importConfig(import.meta.dirname),
 ];


### PR DESCRIPTION
## Summary

Imports are now consistently grouped/sorted and unused imports are auto-removed across the codebase, enforced by ESLint. Adds `import-x/order` (using the already-installed `eslint-plugin-import-x`) and `eslint-plugin-unused-imports`, wired through a shared `eslint.config.base.mjs` factory that collapses the import block previously duplicated across all seven per-package configs.

Closes #156

## Gotchas

- The substantive change is `eslint.config.base.mjs` plus the seven now-thin `eslint.config.js` files. The other ~50 changed files are mechanical `eslint --fix` output — imports regrouped as external → internal (`@/` alias) → relative, alphabetized within each group. The enforced grouping flips the prior informal order (which put `@/` before `@genshin/*`), so expect reordered import blocks everywhere.
- Worth a closer look: the four `apps/api/src/routes/*.test.ts` files that interleaved `vi.mock(...)` between imports. Strict ordering can't autofix across those statements, so the imports are consolidated into one sorted block with the mocks after. vitest hoists `vi.mock` above all imports at transform time, so mocks still apply before the modules under test load — the api suite (187 tests) confirms this.
- No new CI status check: this extends the existing `eslint` pre-commit hook (already mirrored in `pre-commit.yml` with `--all-files`), so the develop ruleset needs no update (re: the issue comment).