### PR TITLE
feat: enforce strict TypeScript ESLint rules

### DIFF
--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -1,46 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
-
-import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
+import genshinConfig from '@genshin/eslint-config';
 import globals from 'globals';
-import tseslint from 'typescript-eslint';
 
 export default [
-  {
-    ignores: ['dist'],
-  },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...genshinConfig(import.meta.dirname),
   {
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2022,
       globals: globals.node,
-    },
-  },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
     },
   },
 ];

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@eslint/js": "10.0.1",
+    "@genshin/eslint-config": "workspace:*",
     "@types/negotiator": "0.6.4",
     "@types/node": "25.9.1",
     "@vitest/coverage-v8": "4.1.7",
@@ -35,7 +35,6 @@
     "tsc-alias": "1.8.17",
     "tsx": "4.22.3",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"
   }
 }

--- a/apps/api/src/profiles/alps/registry.test.ts
+++ b/apps/api/src/profiles/alps/registry.test.ts
@@ -38,8 +38,11 @@ describe('alpsRegistry', () => {
 
       const relative = file.replace(profilesDir, '');
       expect(entry, `${relative} does not export an AlpsProfile`).toBeDefined();
-      expect(registeredPaths, `${entry!.path} from ${relative} is not in the registry`).toContain(
-        entry!.path,
+      if (entry === undefined) {
+        throw new Error(`${relative} does not export an AlpsProfile`);
+      }
+      expect(registeredPaths, `${entry.path} from ${relative} is not in the registry`).toContain(
+        entry.path,
       );
     }
   });

--- a/apps/api/src/profiles/json-schema/registry.test.ts
+++ b/apps/api/src/profiles/json-schema/registry.test.ts
@@ -38,8 +38,11 @@ describe('jsonSchemaRegistry', () => {
 
       const relative = file.replace(schemasDir, '');
       expect(entry, `${relative} does not export a JsonSchemaProfile`).toBeDefined();
-      expect(registeredPaths, `${entry!.path} from ${relative} is not in the registry`).toContain(
-        entry!.path,
+      if (entry === undefined) {
+        throw new Error(`${relative} does not export a JsonSchemaProfile`);
+      }
+      expect(registeredPaths, `${entry.path} from ${relative} is not in the registry`).toContain(
+        entry.path,
       );
     }
   });

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -13,7 +13,7 @@ function collectionRef(userId: string) {
 export async function list(userId: string): Promise<CollectionCharacter[]> {
   const snapshot = await collectionRef(userId).get();
 
-  return snapshot.docs.map((doc) => fromDocument(doc.id, doc.data()!));
+  return snapshot.docs.map((doc) => fromDocument(doc.id, doc.data()));
 }
 
 export async function get(
@@ -26,7 +26,12 @@ export async function get(
     return null;
   }
 
-  return fromDocument(characterId, doc.data()!);
+  const data = doc.data();
+  if (data === undefined) {
+    return null;
+  }
+
+  return fromDocument(characterId, data);
 }
 
 export interface SaveResult {
@@ -43,10 +48,12 @@ export async function save(
   const existing = await docRef.get();
   const now = new Date().toISOString() as ISOTimestamp;
 
+  const existingData = existing.exists ? existing.data() : undefined;
+
   const character: CollectionCharacter = {
     characterId,
     constellationLevel,
-    createdAt: existing.exists ? fromDocument(characterId, existing.data()!).createdAt : now,
+    createdAt: existingData ? fromDocument(characterId, existingData).createdAt : now,
     updatedAt: now,
   };
 

--- a/apps/api/src/repositories/firestore-error.ts
+++ b/apps/api/src/repositories/firestore-error.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { GoogleError, Status } from 'google-gax';
+import type { GoogleError } from 'google-gax';
+import { Status } from 'google-gax';
 import { HTTPException } from 'hono/http-exception';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 

--- a/apps/api/src/repositories/profile/index.ts
+++ b/apps/api/src/repositories/profile/index.ts
@@ -17,7 +17,12 @@ export async function get(userId: string): Promise<UserProfile | null> {
     return null;
   }
 
-  return fromDocument(doc.data()!);
+  const data = doc.data();
+  if (data === undefined) {
+    return null;
+  }
+
+  return fromDocument(data);
 }
 
 export async function update(userId: string, fields: ProfileUpdate): Promise<UserProfile> {
@@ -36,7 +41,12 @@ export async function update(userId: string, fields: ProfileUpdate): Promise<Use
     return profile;
   }
 
-  const current = fromDocument(existing.data()!);
+  const existingData = existing.data();
+  if (existingData === undefined) {
+    throw new Error('Profile document exists but has no data');
+  }
+
+  const current = fromDocument(existingData);
   const updated: UserProfile = {
     ...current,
     ...fields,

--- a/apps/api/src/repositories/teams/index.ts
+++ b/apps/api/src/repositories/teams/index.ts
@@ -15,7 +15,7 @@ export async function list(userId: string): Promise<CollectionTeam[]> {
 
   return snapshot.docs
     .filter((doc) => /^[1-4]$/.test(doc.id))
-    .map((doc) => fromDocument(Number(doc.id) as TeamSlot, doc.data()!));
+    .map((doc) => fromDocument(Number(doc.id) as TeamSlot, doc.data()));
 }
 
 export async function get(userId: string, slot: TeamSlot): Promise<CollectionTeam | null> {
@@ -25,7 +25,12 @@ export async function get(userId: string, slot: TeamSlot): Promise<CollectionTea
     return null;
   }
 
-  return fromDocument(slot, doc.data()!);
+  const data = doc.data();
+  if (data === undefined) {
+    return null;
+  }
+
+  return fromDocument(slot, data);
 }
 
 export interface SaveResult {
@@ -46,7 +51,8 @@ export async function save(
   const existing = await docRef.get();
   const now = new Date().toISOString() as ISOTimestamp;
 
-  const existingTeam = existing.exists ? fromDocument(slot, existing.data()!) : null;
+  const existingData = existing.exists ? existing.data() : undefined;
+  const existingTeam = existingData ? fromDocument(slot, existingData) : null;
 
   const team: CollectionTeam = {
     slot,

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -17,7 +17,7 @@ export async function list(userId: string, weaponId?: string): Promise<Collectio
     : collectionRef(userId);
   const snapshot = await ref.get();
 
-  return snapshot.docs.map((doc) => fromDocument(doc.id as UUID, doc.data()!));
+  return snapshot.docs.map((doc) => fromDocument(doc.id as UUID, doc.data()));
 }
 
 export async function get(
@@ -30,7 +30,12 @@ export async function get(
     return null;
   }
 
-  return fromDocument(weaponInstanceId, doc.data()!);
+  const data = doc.data();
+  if (data === undefined) {
+    return null;
+  }
+
+  return fromDocument(weaponInstanceId, data);
 }
 
 export async function create(
@@ -66,7 +71,12 @@ export async function update(
     return null;
   }
 
-  const existingWeapon = fromDocument(weaponInstanceId, existing.data()!);
+  const existingData = existing.data();
+  if (existingData === undefined) {
+    return null;
+  }
+
+  const existingWeapon = fromDocument(weaponInstanceId, existingData);
   const now = new Date().toISOString() as ISOTimestamp;
 
   const weapon: CollectionWeapon = {

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -140,7 +140,7 @@ async function validateMembers(userId: string, members: CollectionTeamMember[]):
   }
 
   // No duplicate weapon instance IDs
-  const weaponIds = members.filter((m) => m.weaponInstanceId).map((m) => m.weaponInstanceId!);
+  const weaponIds = members.flatMap((m) => (m.weaponInstanceId ? [m.weaponInstanceId] : []));
   if (new Set(weaponIds).size !== weaponIds.length) {
     throw new HTTPException(400, { message: 'Duplicate weapon instance IDs in team' });
   }

--- a/apps/api/src/test/auth-requests.ts
+++ b/apps/api/src/test/auth-requests.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { verifyToken } from '@/lib/firebase/auth.js';
+import type { verifyToken } from '@/lib/firebase/auth.js';
 
 export const FAKE_UID = 'test-user-123';
 export const FAKE_TOKEN = { uid: FAKE_UID } as Awaited<ReturnType<typeof verifyToken>>;
@@ -16,7 +16,7 @@ export function authedRequest(
   path: string,
   body?: unknown,
   options?: AuthedRequestOptions,
-) {
+): Request {
   const init: RequestInit = {
     method,
     headers: { Authorization: 'Bearer valid-token' },

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,23 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
-
-import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
+import genshinConfig from '@genshin/eslint-config';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
-import tseslint from 'typescript-eslint';
 
 export default [
-  {
-    ignores: ['dist'],
-  },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...genshinConfig(import.meta.dirname),
   {
     files: ['**/*.{ts,tsx}'],
     plugins: {
@@ -52,27 +43,6 @@ export default [
     files: ['src/components/ui/**/*.{ts,tsx}'],
     rules: {
       'react/function-component-definition': 'off',
-    },
-  },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
     },
   },
 ];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,7 +34,7 @@
     "zustand": "5.0.13"
   },
   "devDependencies": {
-    "@eslint/js": "10.0.1",
+    "@genshin/eslint-config": "workspace:*",
     "@tailwindcss/postcss": "4.3.0",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
@@ -57,7 +57,6 @@
     "tailwindcss": "4.3.0",
     "tailwindcss-animate": "1.0.7",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.0",
     "vite": "8.0.14",
     "vitest": "4.1.7"
   }

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { JSX } from 'react';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 
 import { Layout } from './components/layout';
@@ -14,7 +15,7 @@ import { WeaponsPage } from './pages/weapons-page';
 
 const queryClient = new QueryClient();
 
-export function App() {
+export function App(): JSX.Element {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>

--- a/apps/web/src/components/artifact-planner.tsx
+++ b/apps/web/src/components/artifact-planner.tsx
@@ -16,6 +16,7 @@ import {
   type SandsMainAffix,
 } from '@genshin/game-data';
 import { Check, ChevronsUpDown, GripVertical, Minus, Shield } from 'lucide-react';
+import type { JSX } from 'react';
 import { useState } from 'react';
 
 import {
@@ -34,7 +35,7 @@ interface ArtifactPlannerProps {
   onChange?: (plan: ArtifactPlan) => void;
 }
 
-export function ArtifactPlanner({ plan, onChange }: ArtifactPlannerProps) {
+export function ArtifactPlanner({ plan, onChange }: ArtifactPlannerProps): JSX.Element {
   const updatePlan = (fields: ArtifactPlan) => {
     onChange?.({ ...plan, ...fields });
   };
@@ -133,7 +134,8 @@ function SetConfiguration({
   };
 
   const handleSecondChange = (setId: ArtifactSet['id']) => {
-    onChange([sets![0], setId]);
+    if (sets === undefined) return;
+    onChange([sets[0], setId]);
   };
 
   const handleClearSecond = () => {

--- a/apps/web/src/components/character-summary.tsx
+++ b/apps/web/src/components/character-summary.tsx
@@ -3,6 +3,7 @@
 
 import type { Character } from '@genshin/game-data';
 import { CircleHelp } from 'lucide-react';
+import type { JSX } from 'react';
 
 import { getElementIconPath } from '@/lib/elements';
 import { cn } from '@/lib/utils';
@@ -12,7 +13,10 @@ interface CharacterSummaryProps {
   dimmed?: boolean;
 }
 
-export function CharacterSummary({ character, dimmed = false }: CharacterSummaryProps) {
+export function CharacterSummary({
+  character,
+  dimmed = false,
+}: CharacterSummaryProps): JSX.Element {
   if (!character) {
     return (
       <>

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { GAME_DATA_VERSION } from '@genshin/game-data';
+import type { JSX } from 'react';
 
 import { Container } from '@/components/container';
 
 const GITHUB_REPO = 'https://github.com/dungeon-studio/genshin.dungeon.studio';
 
-export function Footer() {
+export function Footer(): JSX.Element {
   return (
     <footer className="border-t border-border bg-muted py-8">
       <Container className="text-center text-sm text-muted-foreground">

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { JSX } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Container } from '@/components/container';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { LoginButton, LogoutButton, useAuth } from '@/features/auth';
 
-export function Header() {
+export function Header(): JSX.Element {
   const { user, loading } = useAuth();
 
   return (

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { JSX } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import { Footer } from '@/components/footer';
 import { Header } from '@/components/header';
 import { Nav } from '@/components/nav';
 
-export function Layout() {
+export function Layout(): JSX.Element {
   return (
     <div className="flex min-h-screen flex-col">
       <Header />

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { JSX } from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { Container } from '@/components/container';
 
-export function Nav() {
+export function Nav(): JSX.Element {
   const navLinks = [
     { to: '/', label: 'Teams' },
     { to: '/characters', label: 'Characters' },

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Monitor, Moon, Sun } from 'lucide-react';
+import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -33,7 +34,7 @@ const LABELS: Record<Theme, string> = {
   system: 'System theme',
 };
 
-export function ThemeToggle() {
+export function ThemeToggle(): JSX.Element {
   const [theme, setTheme] = useState<Theme>(getStoredTheme);
 
   useEffect(() => {

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -4,6 +4,7 @@
 import { type DialogProps } from '@radix-ui/react-dialog';
 import { Command as CommandPrimitive } from 'cmdk';
 import { Search } from 'lucide-react';
+import type { JSX } from 'react';
 import * as React from 'react';
 
 import { Dialog, DialogContent } from '@/components/ui/dialog';
@@ -24,7 +25,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps): JSX.Element => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
@@ -121,7 +122,10 @@ const CommandItem = React.forwardRef<
 
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
-const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>): JSX.Element => {
   return (
     <span
       className={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
+import type { JSX } from 'react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -54,12 +55,18 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>): JSX.Element => (
   <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
 );
 DialogHeader.displayName = 'DialogHeader';
 
-const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>): JSX.Element => (
   <div
     className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
     {...props}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -4,6 +4,7 @@
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { X } from 'lucide-react';
+import type { JSX } from 'react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -72,12 +73,18 @@ const SheetContent = React.forwardRef<
 ));
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>): JSX.Element => (
   <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
 );
 SheetHeader.displayName = 'SheetHeader';
 
-const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>): JSX.Element => (
   <div
     className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
     {...props}

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { ComponentProps } from 'react';
+import type { ComponentProps, JSX } from 'react';
 import { Toaster as Sonner } from 'sonner';
 
 type ToasterProps = ComponentProps<typeof Sonner>;
 
-export function Toaster(props: ToasterProps) {
+export function Toaster(props: ToasterProps): JSX.Element {
   return (
     <Sonner
       className="toaster group"

--- a/apps/web/src/components/weapon-summary.tsx
+++ b/apps/web/src/components/weapon-summary.tsx
@@ -3,6 +3,7 @@
 
 import type { Weapon, WeaponType } from '@genshin/game-data';
 import { CircleHelp } from 'lucide-react';
+import type { JSX } from 'react';
 
 import { cn } from '@/lib/utils';
 import { getWeaponTypeIconPath } from '@/lib/weapon-types';
@@ -19,7 +20,11 @@ interface WeaponSummaryProps {
  * Presentational fragment for weapon type info (name, rarity, weapon type).
  * Instance-level details like refinement are composed by the parent.
  */
-export function WeaponSummary({ weapon, weaponType, dimmed = false }: WeaponSummaryProps) {
+export function WeaponSummary({
+  weapon,
+  weaponType,
+  dimmed = false,
+}: WeaponSummaryProps): JSX.Element {
   const iconType = weapon?.type ?? weaponType;
 
   if (!iconType) {

--- a/apps/web/src/features/auth/auth-provider.tsx
+++ b/apps/web/src/features/auth/auth-provider.tsx
@@ -4,12 +4,13 @@
 import type { User as FirebaseUser } from 'firebase/auth';
 import { onAuthStateChanged } from 'firebase/auth';
 import { useEffect, useState, type ReactNode } from 'react';
+import type { JSX } from 'react';
 
 import { auth } from '@/lib/firebase';
 
 import { AuthContext } from './auth-context';
 
-export function AuthProvider({ children }: { children: ReactNode }) {
+export function AuthProvider({ children }: { children: ReactNode }): JSX.Element {
   const [user, setUser] = useState<FirebaseUser | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/apps/web/src/features/auth/login-button.tsx
+++ b/apps/web/src/features/auth/login-button.tsx
@@ -3,13 +3,14 @@
 
 import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 import { LogIn } from 'lucide-react';
+import type { JSX } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { auth } from '@/lib/firebase';
 
 const googleProvider = new GoogleAuthProvider();
 
-export function LoginButton() {
+export function LoginButton(): JSX.Element {
   async function handleLogin() {
     try {
       await signInWithPopup(auth, googleProvider);

--- a/apps/web/src/features/auth/logout-button.tsx
+++ b/apps/web/src/features/auth/logout-button.tsx
@@ -3,11 +3,12 @@
 
 import { signOut } from 'firebase/auth';
 import { LogOut } from 'lucide-react';
+import type { JSX } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { auth } from '@/lib/firebase';
 
-export function LogoutButton() {
+export function LogoutButton(): JSX.Element {
   async function handleLogout() {
     try {
       await signOut(auth);

--- a/apps/web/src/features/auth/protected-route.tsx
+++ b/apps/web/src/features/auth/protected-route.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { JSX } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
 import { useAuth } from './use-auth';
 
-export function ProtectedRoute() {
+export function ProtectedRoute(): JSX.Element {
   const { user, loading } = useAuth();
 
   if (loading) {

--- a/apps/web/src/features/collection/characters/character-card.tsx
+++ b/apps/web/src/features/collection/characters/character-card.tsx
@@ -5,6 +5,7 @@ import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/domai
 import type { Character } from '@genshin/game-data';
 import { motion } from 'framer-motion';
 import { Trash2 } from 'lucide-react';
+import type { JSX } from 'react';
 import { useState } from 'react';
 
 import { CharacterSummary } from '@/components/character-summary';
@@ -40,7 +41,7 @@ export function CharacterCard({
   onAdd,
   onRemove,
   onConstellationChange,
-}: CharacterCardProps) {
+}: CharacterCardProps): JSX.Element {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
   const borderColors = owned ? ELEMENT_BORDER_COLORS : ELEMENT_BORDER_COLORS_DIM;

--- a/apps/web/src/features/collection/characters/character-filters.tsx
+++ b/apps/web/src/features/collection/characters/character-filters.tsx
@@ -4,6 +4,7 @@
 import type { Element, Rarity } from '@genshin/game-data';
 import { ELEMENTS } from '@genshin/game-data';
 import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search } from 'lucide-react';
+import type { JSX } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -39,7 +40,7 @@ export function CharacterFilters({
   ownedCount,
   filteredOwnedCount,
   showOwnership = true,
-}: CharacterFiltersProps) {
+}: CharacterFiltersProps): JSX.Element {
   function toggleElement(element: Element) {
     const next = new Set(filters.elements);
     if (next.has(element)) {

--- a/apps/web/src/features/collection/characters/use-character-collection-api.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-api.ts
@@ -4,6 +4,7 @@
 import { assertCollectionDocument } from '@genshin/collection-json';
 import type { CharacterId, CollectionCharacter } from '@genshin/domain';
 import { deserialiseCharacter, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiDelete, apiGet, apiPut } from '@/lib/api';
@@ -45,7 +46,9 @@ function parseSingleCharacterResponse(response: unknown): MutationResult {
   };
 }
 
-export function useCharacterCollectionQuery(userId: string | undefined) {
+export function useCharacterCollectionQuery(
+  userId: string | undefined,
+): UseQueryResult<CharacterRecord, Error> {
   return useQuery({
     queryKey: collectionKey(userId ?? ''),
     queryFn: async () => {
@@ -56,7 +59,9 @@ export function useCharacterCollectionQuery(userId: string | undefined) {
   });
 }
 
-export function useAddCharacterMutation(userId: string | undefined) {
+export function useAddCharacterMutation(
+  userId: string | undefined,
+): UseMutationResult<MutationResult, Error, CharacterId> {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -72,7 +77,9 @@ export function useAddCharacterMutation(userId: string | undefined) {
   });
 }
 
-export function useRemoveCharacterMutation(userId: string | undefined) {
+export function useRemoveCharacterMutation(
+  userId: string | undefined,
+): UseMutationResult<void, Error, CharacterId> {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -85,7 +92,9 @@ export function useRemoveCharacterMutation(userId: string | undefined) {
   });
 }
 
-export function useSetConstellationLevelMutation(userId: string | undefined) {
+export function useSetConstellationLevelMutation(
+  userId: string | undefined,
+): UseMutationResult<MutationResult, Error, { characterId: CharacterId; level: number }> {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-api.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-api.ts
@@ -4,6 +4,7 @@
 import { assertCollectionDocument } from '@genshin/collection-json';
 import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
 import { deserialiseWeapon, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiDelete, apiGet, apiPatch, apiPost } from '@/lib/api';
@@ -41,7 +42,9 @@ function parseSingleWeaponResponse(response: unknown): WeaponMutationResult {
   return { weapon };
 }
 
-export function useWeaponCollectionQuery(userId: string | undefined) {
+export function useWeaponCollectionQuery(
+  userId: string | undefined,
+): UseQueryResult<WeaponRecord, Error> {
   return useQuery({
     queryKey: weaponCollectionKey(userId ?? ''),
     queryFn: async () => {
@@ -52,7 +55,9 @@ export function useWeaponCollectionQuery(userId: string | undefined) {
   });
 }
 
-export function useAddWeaponMutation(userId: string | undefined) {
+export function useAddWeaponMutation(
+  userId: string | undefined,
+): UseMutationResult<WeaponMutationResult, Error, string> {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -70,7 +75,9 @@ export function useAddWeaponMutation(userId: string | undefined) {
   });
 }
 
-export function useRemoveWeaponMutation(userId: string | undefined) {
+export function useRemoveWeaponMutation(
+  userId: string | undefined,
+): UseMutationResult<void, Error, CollectionWeaponId> {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -84,7 +91,13 @@ export function useRemoveWeaponMutation(userId: string | undefined) {
   });
 }
 
-export function useSetRefinementLevelMutation(userId: string | undefined) {
+export function useSetRefinementLevelMutation(
+  userId: string | undefined,
+): UseMutationResult<
+  WeaponMutationResult,
+  Error,
+  { collectionWeaponId: CollectionWeaponId; level: number }
+> {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/apps/web/src/features/collection/weapons/weapon-card.tsx
+++ b/apps/web/src/features/collection/weapons/weapon-card.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { Weapon } from '@genshin/game-data';
+import type { JSX } from 'react';
 
 import { WeaponSummary } from '@/components/weapon-summary';
 import { RARITY_BORDER_COLORS } from '@/lib/rarity-styles';
@@ -14,7 +15,12 @@ interface WeaponCardProps {
   onClick?: (weaponId: Weapon['id']) => void;
 }
 
-export function WeaponCard({ weapon, instanceCount, selected = false, onClick }: WeaponCardProps) {
+export function WeaponCard({
+  weapon,
+  instanceCount,
+  selected = false,
+  onClick,
+}: WeaponCardProps): JSX.Element {
   const owned = instanceCount > 0;
 
   return (

--- a/apps/web/src/features/collection/weapons/weapon-filters.tsx
+++ b/apps/web/src/features/collection/weapons/weapon-filters.tsx
@@ -4,6 +4,7 @@
 import type { Rarity, WeaponType } from '@genshin/game-data';
 import { WEAPON_TYPES } from '@genshin/game-data';
 import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search } from 'lucide-react';
+import type { JSX } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -40,7 +41,7 @@ export function WeaponFilters({
   filteredOwnedCount,
   showOwnership = true,
   showWeaponTypes = true,
-}: WeaponFiltersProps) {
+}: WeaponFiltersProps): JSX.Element {
   function toggleWeaponType(type: WeaponType) {
     const next = new Set(filters.weaponTypes);
     if (next.has(type)) {

--- a/apps/web/src/features/collection/weapons/weapon-instance-sidebar.tsx
+++ b/apps/web/src/features/collection/weapons/weapon-instance-sidebar.tsx
@@ -6,6 +6,7 @@ import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
 import type { Weapon } from '@genshin/game-data';
 import { getWeaponById } from '@genshin/game-data';
 import { Plus, Trash2 } from 'lucide-react';
+import type { JSX } from 'react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -38,7 +39,7 @@ export function WeaponInstanceSidebar({
   onAdd,
   onRemove,
   onRefinementChange,
-}: WeaponInstanceSidebarProps) {
+}: WeaponInstanceSidebarProps): JSX.Element {
   const weapon: Weapon | undefined = weaponId ? getWeaponById(weaponId) : undefined;
 
   return (

--- a/apps/web/src/features/teams/character-pool.tsx
+++ b/apps/web/src/features/teams/character-pool.tsx
@@ -5,6 +5,7 @@ import type { CharacterId, CollectionCharacter, TeamSlot } from '@genshin/domain
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { Lock, Users } from 'lucide-react';
+import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -28,7 +29,12 @@ interface CharacterPoolProps {
   onAssign: (characterId: string) => void;
 }
 
-export function CharacterPool({ characters, slot, memberIndex, onAssign }: CharacterPoolProps) {
+export function CharacterPool({
+  characters,
+  slot,
+  memberIndex,
+  onAssign,
+}: CharacterPoolProps): JSX.Element {
   const members = useTeamStore((s) => s.teams[slot].members);
   const currentMemberCharacterId = members[memberIndex]?.characterId;
   const otherMemberIds = useMemo(

--- a/apps/web/src/features/teams/team-member-planner.tsx
+++ b/apps/web/src/features/teams/team-member-planner.tsx
@@ -8,6 +8,7 @@ import type {
   CollectionWeapon,
 } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
+import type { JSX } from 'react';
 
 import { ArtifactPlanner } from '@/components/artifact-planner';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -32,7 +33,7 @@ export function TeamMemberPlanner({
   selected = false,
   onSelect,
   onArtifactPlanChange,
-}: TeamMemberPlannerProps) {
+}: TeamMemberPlannerProps): JSX.Element {
   const character = member ? getCharacterById(member.characterId) : undefined;
 
   const borderClass = elementBorderClass(character?.element);

--- a/apps/web/src/features/teams/team-member-summary.tsx
+++ b/apps/web/src/features/teams/team-member-summary.tsx
@@ -3,6 +3,7 @@
 
 import type { CollectionCharacter, CollectionTeamMember, CollectionWeapon } from '@genshin/domain';
 import { getCharacterById, getWeaponById } from '@genshin/game-data';
+import type { JSX } from 'react';
 
 import { CharacterSummary } from '@/components/character-summary';
 import { WeaponSummary } from '@/components/weapon-summary';
@@ -17,7 +18,7 @@ export function TeamMemberSummary({
   member,
   collectionCharacter,
   collectionWeapon,
-}: TeamMemberSummaryProps) {
+}: TeamMemberSummaryProps): JSX.Element {
   const character = member ? getCharacterById(member.characterId) : undefined;
   const weapon = collectionWeapon ? getWeaponById(collectionWeapon.weaponId) : undefined;
 

--- a/apps/web/src/features/teams/team-planner.tsx
+++ b/apps/web/src/features/teams/team-planner.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { Pencil } from 'lucide-react';
+import type { JSX } from 'react';
 import { useRef, useState } from 'react';
 
 import { Input } from '@/components/ui/input';
@@ -41,7 +42,7 @@ export function TeamPlanner({
   onNameChange,
   onArtifactPlanChange,
   onEdit,
-}: TeamPlannerProps) {
+}: TeamPlannerProps): JSX.Element {
   const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(name);

--- a/apps/web/src/features/teams/team-strip.tsx
+++ b/apps/web/src/features/teams/team-strip.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@genshin/domain';
 import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
+import type { JSX } from 'react';
 
 import { elementBorderClass } from '@/lib/element-styles';
 import { cn } from '@/lib/utils';
@@ -29,7 +30,7 @@ export function TeamStrip({
   onSelect,
   getCharacter,
   getCollectionWeapon,
-}: TeamStripProps) {
+}: TeamStripProps): JSX.Element {
   const slots = Array.from({ length: MAX_TEAM_MEMBERS }, (_, i) => members[i]);
 
   return (

--- a/apps/web/src/features/teams/use-team-api.ts
+++ b/apps/web/src/features/teams/use-team-api.ts
@@ -4,6 +4,7 @@
 import { assertCollectionDocument } from '@genshin/collection-json';
 import type { CollectionTeam, CollectionTeamMembers, TeamSlot } from '@genshin/domain';
 import { deserialiseTeam } from '@genshin/domain';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiDelete, apiGet, apiPut } from '@/lib/api';
@@ -24,7 +25,7 @@ export function parseTeamsResponse(response: unknown): CollectionTeam[] {
   return response.collection.items.map((item) => deserialiseTeam(item));
 }
 
-export function useTeamsQuery(userId: string | undefined) {
+export function useTeamsQuery(userId: string | undefined): UseQueryResult<CollectionTeam[], Error> {
   return useQuery({
     queryKey: teamKey(userId ?? ''),
     queryFn: async () => {
@@ -35,7 +36,9 @@ export function useTeamsQuery(userId: string | undefined) {
   });
 }
 
-export function useSaveTeamMutation(userId: string | undefined) {
+export function useSaveTeamMutation(
+  userId: string | undefined,
+): UseMutationResult<void, Error, SaveTeamPayload> {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -48,7 +51,9 @@ export function useSaveTeamMutation(userId: string | undefined) {
   });
 }
 
-export function useDeleteTeamMutation(userId: string | undefined) {
+export function useDeleteTeamMutation(
+  userId: string | undefined,
+): UseMutationResult<void, Error, TeamSlot> {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/apps/web/src/features/teams/weapon-pool.tsx
+++ b/apps/web/src/features/teams/weapon-pool.tsx
@@ -10,6 +10,7 @@ import type {
 import type { Weapon, WeaponType } from '@genshin/game-data';
 import { getWeaponById, WEAPONS } from '@genshin/game-data';
 import { Lock, Swords } from 'lucide-react';
+import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -58,7 +59,7 @@ export function WeaponPool({
   memberIndex,
   onSelect,
   onClear,
-}: WeaponPoolProps) {
+}: WeaponPoolProps): JSX.Element {
   const teams = useTeamStore((s) => s.teams);
   const currentCharacterId = teams[slot].members[memberIndex]?.characterId;
   const equippedWeapons = useMemo(() => buildEquippedWeapons(teams), [teams]);

--- a/apps/web/src/pages/characters-page.tsx
+++ b/apps/web/src/pages/characters-page.tsx
@@ -4,6 +4,7 @@
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
+import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 
 import { Container } from '@/components/container';
@@ -13,7 +14,7 @@ import type { CharacterFilterState } from '@/features/collection/characters/filt
 import { filterCharacters, initialFilterState } from '@/features/collection/characters/filtering';
 import { useCollection } from '@/features/collection/characters/use-character-collection';
 
-export function CharactersPage() {
+export function CharactersPage(): JSX.Element {
   const {
     characters,
     addCharacter,

--- a/apps/web/src/pages/not-found-page.tsx
+++ b/apps/web/src/pages/not-found-page.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { JSX } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Container } from '@/components/container';
 
-export function NotFoundPage() {
+export function NotFoundPage(): JSX.Element {
   return (
     <Container className="py-12">
       <div className="text-center">

--- a/apps/web/src/pages/teams-page.tsx
+++ b/apps/web/src/pages/teams-page.tsx
@@ -4,6 +4,7 @@
 import type { CollectionWeaponId, TeamSlot } from '@genshin/domain';
 import { TEAM_SLOTS } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
+import type { JSX } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { Container } from '@/components/container';
@@ -18,7 +19,7 @@ import { useTeams } from '@/features/teams/use-teams';
 
 type SheetTab = 'characters' | 'weapons';
 
-export function TeamsPage() {
+export function TeamsPage(): JSX.Element {
   const { characters, getCharacter } = useCollection();
   const { weapons } = useWeaponCollection();
 
@@ -168,7 +169,7 @@ export function TeamsPage() {
                 {activeTab === 'characters' && selectedMemberIndex !== null && (
                   <CharacterPool
                     characters={characters}
-                    slot={selectedSlot!}
+                    slot={selectedSlot}
                     memberIndex={selectedMemberIndex}
                     onAssign={handleToggleCharacter}
                   />
@@ -178,18 +179,21 @@ export function TeamsPage() {
                     Select a team member to choose a character.
                   </p>
                 )}
-                {activeTab === 'weapons' && selectedMember && selectedMemberWeaponType && (
-                  <WeaponPool
-                    key={selectedMemberWeaponType}
-                    collectionWeapons={collectionWeapons}
-                    weaponType={selectedMemberWeaponType}
-                    selectedCollectionWeaponId={selectedMember.weaponInstanceId}
-                    slot={selectedSlot!}
-                    memberIndex={selectedMemberIndex!}
-                    onSelect={handleWeaponSelect}
-                    onClear={handleWeaponClear}
-                  />
-                )}
+                {activeTab === 'weapons' &&
+                  selectedMember &&
+                  selectedMemberWeaponType &&
+                  selectedMemberIndex !== null && (
+                    <WeaponPool
+                      key={selectedMemberWeaponType}
+                      collectionWeapons={collectionWeapons}
+                      weaponType={selectedMemberWeaponType}
+                      selectedCollectionWeaponId={selectedMember.weaponInstanceId}
+                      slot={selectedSlot}
+                      memberIndex={selectedMemberIndex}
+                      onSelect={handleWeaponSelect}
+                      onClear={handleWeaponClear}
+                    />
+                  )}
                 {activeTab === 'weapons' && !selectedMember && (
                   <p className="text-sm text-muted-foreground">
                     Select a team member with an assigned character to choose a weapon.

--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -3,6 +3,7 @@
 
 import { WEAPONS } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
+import type { JSX } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -18,7 +19,7 @@ import { WeaponCard } from '@/features/collection/weapons/weapon-card';
 import { WeaponFilters } from '@/features/collection/weapons/weapon-filters';
 import { WeaponInstanceSidebar } from '@/features/collection/weapons/weapon-instance-sidebar';
 
-export function WeaponsPage() {
+export function WeaponsPage(): JSX.Element {
   const {
     weapons,
     isAuthenticated,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 ---
+# Repository index.ts files are thin Firestore I/O adapters, exercised only
+# through route tests that mock them (`vi.mock('@/repositories/.../index.js')`),
+# so they carry no direct unit coverage by design. document.ts (the
+# fromDocument/toDocument logic) stays covered. teams.save merge logic is
+# tracked for real tests separately.
+ignore:
+  - 'apps/api/src/repositories/*/index.ts'
+
 coverage:
   status:
     project:

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -11,8 +11,10 @@
     ".": {
       // These run at the repo root via pre-commit, which knip can't see:
       // stylelint (`pnpm exec stylelint`; its config and a workspace-local copy
-      // live in apps/web) and syncpack (the syncpack pre-commit hooks).
-      "ignoreDependencies": ["stylelint", "stylelint-config-standard", "syncpack"]
+      // live in apps/web), syncpack (the syncpack pre-commit hooks), and eslint
+      // (`pnpm exec eslint`; the flat configs live in each workspace, so knip's
+      // eslint plugin doesn't activate at the root to claim the dependency).
+      "ignoreDependencies": ["stylelint", "stylelint-config-standard", "syncpack", "eslint"]
     },
     "apps/api": {
       // verify-deployment.ts is a deploy-time entry invoked from deploy.yml,

--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "@types/node": "25.9.1",
     "concurrently": "9.2.1",
     "eslint": "10.4.0",
-    "eslint-import-resolver-typescript": "4.4.4",
-    "eslint-plugin-import-x": "4.16.2",
     "knip": "6.16.1",
     "prettier": "3.8.3",
     "stylelint": "17.12.0",

--- a/packages/collection-json/package.json
+++ b/packages/collection-json/package.json
@@ -19,11 +19,10 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "@eslint/js": "10.0.1",
+    "@genshin/eslint-config": "workspace:*",
     "@vitest/coverage-v8": "4.1.7",
     "eslint": "10.4.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"
   }
 }

--- a/packages/domain/eslint.config.js
+++ b/packages/domain/eslint.config.js
@@ -1,36 +1,6 @@
-/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
-/* SPDX-License-Identifier: MIT */
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
+import genshinConfig from '@genshin/eslint-config';
 
-import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
-import tseslint from 'typescript-eslint';
-
-export default [
-  { ignores: ['dist', 'node_modules'] },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
-];
+export default genshinConfig(import.meta.dirname);

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -27,11 +27,10 @@
     "@genshin/validation": "workspace:*"
   },
   "devDependencies": {
-    "@eslint/js": "10.0.1",
+    "@genshin/eslint-config": "workspace:*",
     "@vitest/coverage-v8": "4.1.7",
     "eslint": "10.4.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"
   }
 }

--- a/packages/domain/src/representations/collection-json/weapons.test.ts
+++ b/packages/domain/src/representations/collection-json/weapons.test.ts
@@ -34,7 +34,11 @@ describe('weapon serialisation round-trip', () => {
   it('includes a collection link for the weapon type', () => {
     const item = serialiseWeapon(VALID_WEAPON, BASE_URL);
     expect(item.links).toBeDefined();
-    expect(item.links![0].rel).toBe('collection');
+    const links = item.links;
+    if (links === undefined) {
+      throw new Error('expected item to have links');
+    }
+    expect(links[0].rel).toBe('collection');
   });
 
   it('preserves refinement level through round-trip', () => {

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import genshinConfig from '@genshin/eslint-config';
+import genshinConfig from './index.js';
 
 export default genshinConfig(import.meta.dirname);

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { resolve } from 'node:path';
+
+import js from '@eslint/js';
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
+import importX from 'eslint-plugin-import-x';
+import tseslint from 'typescript-eslint';
+
+/**
+ * Shared flat-config base for every workspace in the monorepo.
+ *
+ * @param {string} packageDir - the consuming workspace's directory
+ *   (`import.meta.dirname`). Used to resolve
+ *   `import-x/no-extraneous-dependencies` against the workspace and the repo
+ *   root, so it must be the consumer's path, not this package's.
+ * @returns {import('eslint').Linter.Config[]} flat config entries to spread.
+ */
+export default function genshinConfig(packageDir) {
+  return [
+    { ignores: ['dist', 'node_modules'] },
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+      files: ['**/*.{ts,tsx}'],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'error',
+        '@typescript-eslint/no-non-null-assertion': 'error',
+        '@typescript-eslint/explicit-module-boundary-types': [
+          'error',
+          {
+            allowArgumentsExplicitlyTypedAsAny: false,
+            allowDirectConstAssertionInArrowFunctions: true,
+            allowHigherOrderFunctions: true,
+          },
+        ],
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
+        ],
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'TSEnumDeclaration',
+            message: 'Use const objects or union types instead of enums.',
+          },
+        ],
+      },
+    },
+    {
+      files: ['**/*.{ts,tsx,js,mjs,cjs}'],
+      plugins: { 'import-x': importX },
+      settings: {
+        'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
+      },
+      rules: {
+        'import-x/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: [
+              '**/*.{test,spec}.{ts,tsx}',
+              '**/test/**',
+              'eslint.config.js',
+              '*.config.{ts,js,mjs,cjs}',
+            ],
+            packageDir: [packageDir, resolve(packageDir, '../..')],
+          },
+        ],
+      },
+    },
+  ];
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@genshin/eslint-config",
+  "version": "0.0.0",
+  "description": "Shared ESLint flat config for the monorepo",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
+  "main": "./index.js",
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@eslint/js": "10.0.1",
+    "eslint-import-resolver-typescript": "4.4.4",
+    "eslint-plugin-import-x": "4.16.2",
+    "typescript-eslint": "8.60.0"
+  },
+  "peerDependencies": {
+    "eslint": "10.4.0"
+  }
+}

--- a/packages/game-data/eslint.config.js
+++ b/packages/game-data/eslint.config.js
@@ -1,43 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
+import genshinConfig from '@genshin/eslint-config';
 
-import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
-import tseslint from 'typescript-eslint';
-
-export default [
-  { ignores: ['dist', 'node_modules'] },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-  {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/explicit-function-return-type': 'warn',
-    },
-  },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
-];
+export default genshinConfig(import.meta.dirname);

--- a/packages/game-data/package.json
+++ b/packages/game-data/package.json
@@ -20,12 +20,11 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "@eslint/js": "10.0.1",
+    "@genshin/eslint-config": "workspace:*",
     "@types/node": "25.9.1",
     "@vitest/coverage-v8": "4.1.7",
     "eslint": "10.4.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"
   }
 }

--- a/packages/validation/eslint.config.js
+++ b/packages/validation/eslint.config.js
@@ -1,36 +1,6 @@
-/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
-/* SPDX-License-Identifier: MIT */
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
+import genshinConfig from '@genshin/eslint-config';
 
-import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
-import tseslint from 'typescript-eslint';
-
-export default [
-  { ignores: ['dist', 'node_modules'] },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
-];
+export default genshinConfig(import.meta.dirname);

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -22,11 +22,10 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@eslint/js": "10.0.1",
+    "@genshin/eslint-config": "workspace:*",
     "@vitest/coverage-v8": "4.1.7",
     "eslint": "10.4.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,6 @@ importers:
       eslint:
         specifier: 10.4.0
         version: 10.4.0(jiti@2.7.0)
-      eslint-import-resolver-typescript:
-        specifier: 4.4.4
-        version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
-      eslint-plugin-import-x:
-        specifier: 4.16.2
-        version: 4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))
       knip:
         specifier: 6.16.1
         version: 6.16.1
@@ -90,9 +84,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
-      '@eslint/js':
-        specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@genshin/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
       '@types/negotiator':
         specifier: 0.6.4
         version: 0.6.4
@@ -117,9 +111,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      typescript-eslint:
-        specifier: 8.60.0
-        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -184,9 +175,9 @@ importers:
         specifier: 5.0.13
         version: 5.0.13(@types/react@19.2.15)(react@19.2.6)
     devDependencies:
-      '@eslint/js':
-        specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@genshin/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
       '@tailwindcss/postcss':
         specifier: 4.3.0
         version: 4.3.0
@@ -253,9 +244,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      typescript-eslint:
-        specifier: 8.60.0
-        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: 8.0.14
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
@@ -265,9 +253,9 @@ importers:
 
   packages/collection-json:
     devDependencies:
-      '@eslint/js':
-        specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@genshin/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
       '@vitest/coverage-v8':
         specifier: 4.1.7
         version: 4.1.7(vitest@4.1.7)
@@ -277,9 +265,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      typescript-eslint:
-        specifier: 8.60.0
-        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -296,9 +281,9 @@ importers:
         specifier: workspace:*
         version: link:../validation
     devDependencies:
-      '@eslint/js':
-        specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@genshin/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
       '@vitest/coverage-v8':
         specifier: 4.1.7
         version: 4.1.7(vitest@4.1.7)
@@ -308,18 +293,33 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      typescript-eslint:
-        specifier: 8.60.0
-        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
-  packages/game-data:
-    devDependencies:
+  packages/eslint-config:
+    dependencies:
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      eslint:
+        specifier: 10.4.0
+        version: 10.4.0(jiti@2.7.0)
+      eslint-import-resolver-typescript:
+        specifier: 4.4.4
+        version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-import-x:
+        specifier: 4.16.2
+        version: 4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))
+      typescript-eslint:
+        specifier: 8.60.0
+        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+
+  packages/game-data:
+    devDependencies:
+      '@genshin/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
       '@types/node':
         specifier: 25.9.1
         version: 25.9.1
@@ -332,18 +332,15 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      typescript-eslint:
-        specifier: 8.60.0
-        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/validation:
     devDependencies:
-      '@eslint/js':
-        specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@genshin/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
       '@vitest/coverage-v8':
         specifier: 4.1.7
         version: 4.1.7(vitest@4.1.7)
@@ -353,9 +350,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      typescript-eslint:
-        specifier: 8.60.0
-        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -372,9 +366,9 @@ importers:
         specifier: 5.2.11
         version: 5.2.11
     devDependencies:
-      '@eslint/js':
-        specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@genshin/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
       '@types/node':
         specifier: 25.9.1
         version: 25.9.1
@@ -387,9 +381,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      typescript-eslint:
-        specifier: 8.60.0
-        version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))

--- a/tools/game-data-codegen/eslint.config.js
+++ b/tools/game-data-codegen/eslint.config.js
@@ -1,43 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { resolve } from 'node:path';
+import genshinConfig from '@genshin/eslint-config';
 
-import js from '@eslint/js';
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importX from 'eslint-plugin-import-x';
-import tseslint from 'typescript-eslint';
-
-export default [
-  { ignores: ['dist', 'node_modules'] },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-  {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/explicit-function-return-type': 'warn',
-    },
-  },
-  {
-    files: ['**/*.{ts,tsx,js,mjs,cjs}'],
-    plugins: { 'import-x': importX },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    },
-    rules: {
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: [
-            '**/*.{test,spec}.{ts,tsx}',
-            '**/test/**',
-            'eslint.config.js',
-            '*.config.{ts,js,mjs,cjs}',
-          ],
-          packageDir: [import.meta.dirname, resolve(import.meta.dirname, '../..')],
-        },
-      ],
-    },
-  },
-];
+export default genshinConfig(import.meta.dirname);

--- a/tools/game-data-codegen/package.json
+++ b/tools/game-data-codegen/package.json
@@ -20,12 +20,11 @@
     "genshin-db": "5.2.11"
   },
   "devDependencies": {
-    "@eslint/js": "10.0.1",
+    "@genshin/eslint-config": "workspace:*",
     "@types/node": "25.9.1",
     "@vitest/coverage-v8": "4.1.7",
     "eslint": "10.4.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.60.0",
     "vitest": "4.1.7"
   }
 }


### PR DESCRIPTION
## Summary

Strict TypeScript ESLint rules from #157 now run across every workspace, served from a single shared `@genshin/eslint-config` rather than per-workspace duplication.

## Gotchas

- The issue's `@typescript-eslint/no-enum` isn't a real rule — enums are banned via `no-restricted-syntax` on `TSEnumDeclaration` instead.
- Merge reconciliation: develop's #867 / #869 landed a parallel root `eslint.config.base.mjs` holding import-management rules (ordering, dedupe, `unused-imports`). This branch consolidates on the package instead — those rules are folded into `@genshin/eslint-config`, `eslint-plugin-unused-imports` moves into its dependencies, and `eslint.config.base.mjs` is removed.
- `repositories/profile/index.ts` `update()` throws when an existing doc has no data (its return type is non-nullable), while `get()` returns `null` — divergent on purpose.
- ESLint plugins live in the package's dependencies; root `eslint` is in knip's ignore list since the flat configs are per-workspace.

Closes #157