### PR TITLE
chore(lint): enforce no-duplicate and newline-after import rules

### DIFF
--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { WeaponType } from '@genshin/game-data';
-import { WEAPONS } from '@genshin/game-data';
-import { WEAPON_TYPES } from '@genshin/game-data';
+import { WEAPONS, WEAPON_TYPES } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';

--- a/eslint.config.base.mjs
+++ b/eslint.config.base.mjs
@@ -50,6 +50,8 @@ export default function importConfig(packageDir) {
             alphabetize: { order: 'asc', caseInsensitive: true },
           },
         ],
+        'import-x/no-duplicates': 'error',
+        'import-x/newline-after-import': 'error',
         // `unused-imports` owns unused-symbol reporting so removals are
         // autofixable; the recommended `no-unused-vars` rules are disabled to
         // avoid double-reporting.


### PR DESCRIPTION
## Summary

Import linting now also collapses duplicate imports from the same module and enforces a blank line after the import block — the two acceptance criteria from #158 that #867 left unconfigured. Both ride the existing `eslint` pre-commit hook.

Closes #158

## Gotchas

- Most of #158 (grouping, ordering, alphabetization, pre-commit autofix) already shipped in #867 (which closed #156). This is just the remaining two-rule delta, so the diff is intentionally small.
- #158 named `eslint-plugin-import`; the repo standardized on the maintained `eslint-plugin-import-x` fork, so these are `import-x/*` rules.

## Verification

- Ran `eslint --fix` across all 7 packages: passes clean (the lone `react-hooks/exhaustive-deps` warning in `auth-provider.tsx` is pre-existing, untouched). The only source change was one duplicate-import merge in `weapons-page.tsx`; no `newline-after-import` violations existed.