### PR TITLE
docs: codify testing principles in CONTRIBUTING.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,7 +62,6 @@
 
 - Use the [REST API conventions reference](../docs/reference/rest-api-conventions.md) as guidance for API route shape, methods, status codes, error format, pagination, and auth handling.
 - All error responses use RFC 9457 Problem Details (`application/problem+json`). Always include a `detail` field, even for generic errors, to keep a stable schema for clients.
-- Validate API success responses against the published JSON Schema in tests using AJV, not just individual field assertions. Keep one sanity-check assertion per test for a specific value.
 - Prefer explicit types over type munging. For example, define `ProfileUpdate` rather than using `Partial<Pick<UserProfile, 'name'>>` inline.
 
 ## Schema module conventions
@@ -72,6 +71,13 @@
 - Name files `{method}-{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). `{method}` is the lowercase HTTP method and `{direction}` is `request` or `response`. The serving path mirrors the filename: `/profiles/json-schema/{module}/{method}-{direction}-v{n}.json`. See [DSGEP-005](../docs/explanation/dsgep-005-schema-direction-segment.md).
 - Register every schema module in `apps/api/src/profiles/json-schema/registry.ts`. The registry completeness test discovers files on disk and asserts the registry contains each one.
 - The schema route stamps `$id` from the request origin at serve time. Don't declare `$id` in schema modules.
+
+## Testing
+
+- Test behavior, not constant values, and don't test what a library, the language, or config already guarantees.
+- Annotate fixtures with `satisfies` to validate their shape without changing the inferred type.
+- Validate route responses against the published JSON Schema with AJV first, then make one field-level spot check; don't re-assert the schema field by field.
+- See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the full testing principles.
 
 ## Frontend rules
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@
 
 ## Testing
 
-- Test behavior, not constant values, and don't test what a library, the language, or config already guarantees.
+- Test behavior, not constant values; don't assert what's true by definition or what a library, the language, or config already guarantees.
 - Annotate fixtures with `satisfies` to validate their shape without changing the inferred type.
 - Validate route responses against the published JSON Schema with AJV first, then make one field-level spot check; don't re-assert the schema field by field.
 - See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the full testing principles.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ workspace dependencies first. Turbo handles dependency ordering via `^build`.
 - Run `pre-commit run vale --all-files` for Vale, not `vale .`. Vale has no
   directory-ignore and scans `node_modules`.
 - API error responses use RFC 9457 Problem Details, `application/problem+json`.
-- Validate API responses with published JSON Schema using AJV in tests.
+- Testing: follow the Testing section in `CONTRIBUTING.md` (test behavior not
+  values, `satisfies` for fixtures, one schema assertion per route test then a
+  spot check).
 
 ## Detailed coding rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,16 @@ Shared API test utilities live in `apps/api/src/test/` with descriptive file nam
 
 ---
 
+## Testing
+
+- **Test behavior, not values**: assert what code does, not what a constant equals.
+- **Don't test what a library should encapsulate**: library behavior, language semantics, and configuration values are already tested by their authors.
+- **Assert only the necessary properties**: keep each assertion as close to the property under test as possible; redundant assertions obscure what the test proves.
+- **Use `satisfies` for fixture annotations**: it validates the fixture shape at the declaration site without changing the inferred type, avoiding index-signature assignability errors.
+- **One schema assertion per route test, then field-level spot checks**: validate the response against the published JSON Schema with AJV first, then assert one specific value; don't re-test the schema field by field.
+
+---
+
 ## Pull request workflow
 
 ### Branch flow for infrastructure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,7 @@ Shared API test utilities live in `apps/api/src/test/` with descriptive file nam
 
 - **Test behavior, not values**: assert what code does, not what a constant equals.
 - **Don't test what a library should encapsulate**: library behavior, language semantics, and configuration values are already tested by their authors.
+- **Don't assert what's true by definition**: a test that can't fail when the code under test is wrong proves nothing; if deleting the implementation wouldn't break it, rewrite or delete it.
 - **Assert only the necessary properties**: keep each assertion as close to the property under test as possible; redundant assertions obscure what the test proves.
 - **Use `satisfies` for fixture annotations**: it validates the fixture shape at the declaration site without changing the inferred type, avoiding index-signature assignability errors.
 - **One schema assertion per route test, then field-level spot checks**: validate the response against the published JSON Schema with AJV first, then assert one specific value; don't re-test the schema field by field.


### PR DESCRIPTION
## Summary

Closes #739. Testing conventions lived only as implicit knowledge from the Verzod migration (#587). This makes them a versioned, reviewable standard: a `## Testing` section in `CONTRIBUTING.md` is the single source of truth, and each AI tool config carries a distilled pointer rather than a copy — `.github/copilot-instructions.md` for Copilot and `CLAUDE.md` for Claude Code.

## Gotchas

- `CLAUDE.md` is included even though #739 deferred it to #728: the file exists now, so the testing principles are wired in as a thin pointer so Claude Code sessions actually pick them up. The broader question of which file is the canonical AI-conventions home (and whether `copilot-instructions.md` should become thin too) stays with #728 / a follow-up.
- The schema-validation/AJV rule was a partial duplicate in all three files. It now lives in full only in `CONTRIBUTING.md`; the Copilot and Claude configs reference it, satisfying acceptance criterion #4.
- Principle names use American "behavior" to match repo convention and Vale, not the issue's British "behaviour".
- Bullets in `CONTRIBUTING.md` use `**Term**: description` rather than an em dash because Vale's `Microsoft.Dashes` flags em dashes adjacent to bold/backtick markup.