### PR TITLE
fix(ci): prevent Renovate from stalling silently on lockfile OOM

### DIFF
--- a/.github/workflows/renovate-watchdog.yml
+++ b/.github/workflows/renovate-watchdog.yml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Renovate Watchdog
+
+# A failed Renovate job on Mend's hosted runner stalls silently with no retry:
+# the repo went 29 days without updates before anyone noticed. This watchdog
+# fails (and thus emails repo admins) when Renovate's Dependency Dashboard has
+# not been refreshed within the staleness window, turning a silent stall into
+# a weekly alert.
+
+on:
+  schedule:
+    # Daily 09:00 UTC. A passing run is silent; only a stale dashboard fails
+    # (and emails admins), so daily costs nothing when healthy but bounds
+    # detection latency to roughly a day once the staleness window is crossed.
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check-freshness:
+    name: Check Renovate freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Fail if the Dependency Dashboard is stale
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        with:
+          script: |
+            const STALE_DAYS = 10;
+
+            const q = [
+              `repo:${context.repo.owner}/${context.repo.repo}`,
+              'is:issue',
+              'is:open',
+              'in:title "Dependency Dashboard"',
+              'author:app/renovate',
+            ].join(' ');
+
+            const { data } = await github.rest.search.issuesAndPullRequests({ q });
+            const dashboard = data.items[0];
+
+            if (!dashboard) {
+              core.setFailed(
+                'No open Renovate "Dependency Dashboard" issue found. Renovate may ' +
+                'be uninstalled or disabled on this repository.',
+              );
+              return;
+            }
+
+            const updatedAt = new Date(dashboard.updated_at);
+            const ageDays = (Date.now() - updatedAt.getTime()) / 86_400_000;
+            const summary =
+              `Dependency Dashboard (#${dashboard.number}) last updated ` +
+              `${updatedAt.toISOString()} (${ageDays.toFixed(1)} days ago).`;
+
+            if (ageDays > STALE_DAYS) {
+              core.setFailed(
+                `${summary} Exceeds the ${STALE_DAYS}-day staleness window — ` +
+                'Renovate has likely stalled (check the Mend job log for ' +
+                'kernel-out-of-memory). Trigger a manual run to recover.',
+              );
+              return;
+            }
+
+            core.info(`${summary} Within the ${STALE_DAYS}-day window.`);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,5 +18,11 @@ allowBuilds:
 engines:
   pnpm: '>=9.15.4'
 
+# pnpm 11's minimumReleaseAge verification pass retains per-package registry
+# metadata for every locked entry, OOMing installs on a lockfile this size
+# (notably Renovate's --lockfile-only regen on Mend's 3GB runner). Trust
+# already-locked entries; newly resolved versions are still age-checked.
+trustLockfile: true
+
 minimumReleaseAgeExclude:
   - firebase-tools@15.22.3

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6pm on friday"]
+    "schedule": ["* 0-17 1-7 * 5"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Renovate silently stopped updating this repo for 29 days: its Mend-hosted job was OOM-killed during pnpm lockfile regeneration and never retried, so every dependency PR (including the pin-digest #819) froze with a stale, never-clearing stability check. This fixes the OOM at its root and adds a watchdog so a future stall surfaces in days instead of by accident.

The OOM is pnpm 11 + this lockfile's size: `minimumReleaseAge` is on by default and re-verifies every locked entry on each install, holding per-package registry metadata for the whole run, which blows Mend's 3GB runner. `trustLockfile` skips that re-verification for already-locked entries (new resolutions are still age-checked), and `lockFileMaintenance` drops from weekly to monthly so the heaviest full-tree regen runs less often.

## Gotchas

- `trustLockfile: true` is a deliberate supply-chain trade — already-locked deps aren't re-age-checked on every install. Sound here because every lockfile change lands via reviewed PR, but worth a conscious nod.
- `lockFileMaintenance.schedule` is a raw cron (`* 0-17 1-7 * 5`) because Renovate/later can't parse "first friday" as text. It means *first Friday of the month, before 6pm* (day-of-month 1-7 intersected with Friday — Renovate's cron ANDs them). JSON can't carry a comment, so the intent lives in the commit message.
- The OOM fix is doc-verified, not runtime-proven: confirming it needs the next Mend regen to survive. If it still OOMs, the next levers are `networkConcurrency: 16`, pinning pnpm to 10.x, or self-hosting Renovate for a 16GB runner.
- The watchdog can't be exercised from this branch — scheduled workflows and `workflow_dispatch` only run from the default branch, so it goes live on merge. Fire it once manually afterward to confirm it reads the dashboard.

## Verification

- `renovate-config-validator --strict` accepts the config; `trustLockfile` field name checked against current pnpm docs.
- Resolved the cron with Renovate's own engine (`@breejs/later`): fired 2026-07-03, 08-07, 09-04, 10-02 — every one the first Friday of its month, within an hours-0-17 window.