### PR TITLE
feat(ci): add @claude on-demand review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  claude:
+    name: Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: contains(github.event.comment.body, '@claude')
+
+    steps:
+      - uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: '@claude'
+
+# ---------------------------------------------------------------------------
+# Maintenance notes
+# - Requires the ANTHROPIC_API_KEY secret (org- or repo-level), added manually
+#   by a maintainer. It is the Anthropic API credential, separate from any
+#   GitHub App install; the built-in GITHUB_TOKEN handles posting comments.
+# - Comment "@claude" (or "@claude review") on a PR or issue to trigger a run.
+# ---------------------------------------------------------------------------

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,7 +10,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
   actions: read
@@ -27,6 +27,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: '@claude'
+          claude_args: '--model sonnet --max-turns 15 --disallowedTools WebSearch,WebFetch'
 
 # ---------------------------------------------------------------------------
 # Maintenance notes
@@ -34,4 +35,10 @@ jobs:
 #   by a maintainer. It is the Anthropic API credential, separate from any
 #   GitHub App install; the built-in GITHUB_TOKEN handles posting comments.
 # - Comment "@claude" (or "@claude review") on a PR or issue to trigger a run.
+# - Public-repo posture: only users with write access can trigger this (the
+#   action's default; allowed_non_write_users is intentionally unset). Scoped
+#   to review/advise -- contents: read (no pushes) and web tools disabled --
+#   so a prompt-injection from untrusted PR content cannot push code or reach
+#   the network. Bash stays enabled for review context. Raise capability
+#   deliberately if "@claude fix it and push" is ever wanted.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Not merging — closed (see #732)

Closing without merging. On reflection, an `@claude` GitHub Action is largely redundant for a solo, CLI-first workflow — interactive Claude Code already provides a steerable, monitorable session the Actions bot can't match — and it adds a cost/risk surface (API billing + prompt-injection exposure on a public repo) that isn't worth it without outside contributors who don't run Claude Code themselves. #732 closed as not planned.

Work is preserved on this branch if revisited: a SHA-pinned, review/advise-only `claude.yml` (`contents: read`, web tools disabled, `--max-turns`, pinned model; triggers only for write-access users).

Refs #732