### PR TITLE
Run typecheck and lint at Claude Code session stop

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm turbo run typecheck lint"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ service-account*.json
 # Claustre session identifier (generated per worktree session)
 .claustre_session_id
 
-# Claude Code local settings and hooks (claustre-injected, session-specific)
+# Claude Code per-developer overrides (shared config lives in .claude/settings.json)
 .claude/settings.local.json
 .claude/hooks/
 

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -49,6 +49,7 @@ ignore:
   - '**/test-results'
   - .git
   # Tool-convention directories (names dictated by external tooling):
+  - .claude
   - .devcontainer
   - .github
   - .reuse


### PR DESCRIPTION
## Summary

Closed unmerged. A `Stop` hook is the wrong surface for quality enforcement: it's session-turn feedback, not a gate, and it fires even when no code changed. The real gate is `git commit`, owned by pre-commit — which today has holes for exactly these checks (eslint matches no files; whole-repo typecheck is `stages: [manual]`). The fix belongs in that commit gate, not a session-end hook.

Superseded by #888.