### PR TITLE
chore: swap detect-secrets for TruffleHog CI scan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,8 +35,8 @@ jobs:
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
+          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }}
 
       - uses: ./.github/actions/setup-node-pnpm
 
@@ -95,8 +95,8 @@ jobs:
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
+          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
@@ -174,8 +174,8 @@ jobs:
         id: verify-token
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
-          service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }} # pragma: allowlist secret
+          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_RW_DEV_SERVICE_ACCOUNT_EMAIL }}
           token_format: id_token
           id_token_audience: ${{ steps.deploy.outputs.url }}
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Verified-mode secret scanning: TruffleHog confirms a detected credential is
+  # live before failing, so this gate is high-signal and needs no allowlist.
+  # It complements GitHub's free push protection (known-provider patterns,
+  # server-side) with broad, verified detection that GitHub only offers under
+  # the paid Secret Protection product. fetch-depth: 0 gives TruffleHog the full
+  # commit range so it scans only the diff, not a snapshot.
+  trufflehog:
+    name: TruffleHog
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan for verified secrets
+        uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
+        with:
+          extra_args: --results=verified

--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -41,7 +41,7 @@ jobs:
       # indexing, which fixes CodeQL actions/excessive-secrets-exposure.
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
+          workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: >-
             ${{
               inputs.environment == 'core' && secrets.GCP_RW_CORE_SERVICE_ACCOUNT_EMAIL ||

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
-    secrets: inherit # pragma: allowlist secret
+    secrets: inherit
 
   dev:
     if: github.ref == 'refs/heads/develop'
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: dev
-    secrets: inherit # pragma: allowlist secret
+    secrets: inherit
 
   staging:
     if: startsWith(github.ref, 'refs/heads/release/')
@@ -39,4 +39,4 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: staging
-    secrets: inherit # pragma: allowlist secret
+    secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -49,7 +49,7 @@ jobs:
       # secret indexing (fixes CodeQL actions/excessive-secrets-exposure).
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_RO_WORKLOAD_IDENTITY_PROVIDER }} # pragma: allowlist secret
+          workload_identity_provider: ${{ secrets.GCP_RO_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: >-
             ${{
               matrix.environment == 'core' && secrets.GCP_RO_CORE_SERVICE_ACCOUNT_EMAIL ||

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,12 +113,6 @@ repos:
       - id: reuse
         always_run: true
 
-  # Secrets detection
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
-    hooks:
-      - id: detect-secrets
-
   # Renovate config validation
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 43.150.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Pre-commit enforces formatting, linting, documentation, and hygiene checks on ev
 - [.github/workflows/pre-commit.yml](.github/workflows/pre-commit.yml) runs only hooks that can't run in pre-commit.ci.
 - [.github/workflows/ci.yml](.github/workflows/ci.yml) runs build and type check jobs for apps and packages.
 - [.github/workflows/link-check.yml](.github/workflows/link-check.yml) blocks pull requests on broken internal documentation links ([lychee](https://lychee.cli.rs), offline); [.github/workflows/external-link-check.yml](.github/workflows/external-link-check.yml) checks external URLs weekly and reports breakage via a GitHub issue.
-- [.github/workflows/secret-scan.yml](.github/workflows/secret-scan.yml) blocks pull requests that introduce verified secrets ([TruffleHog](https://github.com/trufflesecurity/trufflehog)); GitHub secret scanning push protection additionally blocks known-provider secrets at push time.
+- [.github/workflows/secret-scan.yml](.github/workflows/secret-scan.yml) blocks pull requests that introduce verified secrets ([TruffleHog](https://github.com/trufflesecurity/trufflehog)).
 - Feature work adds tests and enforces them when it introduces testable behavior.
 
 **Commit types**. Use these prefixes in your commit messages:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ The API is available at `http://localhost:8080`. See [apps/api/Dockerfile](apps/
 
 ### Quality checks overview
 
-Pre-commit enforces formatting, linting, documentation, secrets, and hygiene checks on every commit and on pull requests. If checks fail, fix the issues—see the Code quality section below for guidance.
+Pre-commit enforces formatting, linting, documentation, and hygiene checks on every commit and on pull requests. If checks fail, fix the issues—see the Code quality section below for guidance.
 
 ### Quality gate ownership
 
@@ -91,6 +91,7 @@ Pre-commit enforces formatting, linting, documentation, secrets, and hygiene che
 - [.github/workflows/pre-commit.yml](.github/workflows/pre-commit.yml) runs only hooks that can't run in pre-commit.ci.
 - [.github/workflows/ci.yml](.github/workflows/ci.yml) runs build and type check jobs for apps and packages.
 - [.github/workflows/link-check.yml](.github/workflows/link-check.yml) blocks pull requests on broken internal documentation links ([lychee](https://lychee.cli.rs), offline); [.github/workflows/external-link-check.yml](.github/workflows/external-link-check.yml) checks external URLs weekly and reports breakage via a GitHub issue.
+- [.github/workflows/secret-scan.yml](.github/workflows/secret-scan.yml) blocks pull requests that introduce verified secrets ([TruffleHog](https://github.com/trufflesecurity/trufflehog)); GitHub secret scanning push protection additionally blocks known-provider secrets at push time.
 - Feature work adds tests and enforces them when it introduces testable behavior.
 
 **Commit types**. Use these prefixes in your commit messages:
@@ -121,7 +122,7 @@ Pre-commit hooks automatically enforce key checks, including:
 - **ESLint** - JavaScript/TypeScript linting with automatic fixes when possible
 - CSS linting with Tailwind directives
 - Documentation and config linting for Markdown, YAML, and prose
-- Safety and repository hygiene checks for secrets, merge conflict markers, large files, trailing whitespace, line endings, and YAML/JSON validation
+- Safety and repository hygiene checks for merge conflict markers, large files, trailing whitespace, line endings, and YAML/JSON validation
 - Exact dependency versions via [syncpack](https://jamiemason.github.io/syncpack/): `package.json` dependencies stay pinned with no `^` or `~` ranges. Run `pnpm exec syncpack fix` to pin offenders
 
 Pull requests must pass type checks in [ci.yml](.github/workflows/ci.yml). Run type checks locally before committing when your change affects TypeScript code:


### PR DESCRIPTION
## Summary

Secret scanning now runs as a TruffleHog verified-mode CI job alongside GitHub push protection, replacing the local `detect-secrets` hook. On this public repo GitHub's free tier covers only partner patterns plus push protection — non-provider patterns and validity checks are paid Secret Protection features — so TruffleHog buys back verified, broad detection for free, in CI where its network verification actually works. Dropping detect-secrets also removes its 11 `pragma: allowlist secret` annotations, which were its only "findings" in a clean repo.

Closes #724

## Gotchas

- **Scope shifted from the issue text.** It's a dedicated `secret-scan.yml` workflow, not a `pre-commit.yml` step. The TruffleHog pre-commit hook scans `--since-commit HEAD` — an empty range in CI, so it can't gate PRs — whereas the action scans the PR/push diff via `fetch-depth: 0`. Same dedicated-workflow rationale as lychee's `link-check.yml`.
- **Verified-only is deliberate.** `--results=verified` means a detected-but-unverifiable secret (no verify endpoint, or offline) won't fail the build. That's the signal/noise choice — push protection is the backstop for known providers, and we're not reintroducing detect-secrets' entropy noise. The positive fail-on-detection path isn't exercised here (no planted secret).
- **Push protection lives outside this repo.** It's on via the org "GitHub recommended" code-security config applied org-wide; if that's ever unapplied, push-time blocking of known-provider secrets goes with it.

## Verification

- Confirmed `secret_scanning_push_protection` reads `enabled` on the repo via the API after the org config applied (not CI-covered).
- Grepped repo-wide: no `detect-secrets` or `allowlist secret` references remain.