### PR TITLE
ci: add concurrency control to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,14 @@ on:
 permissions:
   contents: read
 
+# Only one deploy per ref at a time. Cloud Run and the `:develop` image tag
+# are single mutable targets, so concurrent runs race: an older run's health
+# verification sees a newer run's SHA and fails with sha_mismatch. Cancelling
+# superseded runs deploys only the latest commit.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   web:
     if: github.ref == 'refs/heads/develop'


### PR DESCRIPTION
Prevent concurrent deployments to Cloud Run by adding GitHub Actions concurrency configuration to the deploy workflow.

## Summary

Added concurrency control to the deploy workflow to ensure only one deployment runs per ref at a time. This prevents race conditions where older deployment runs can fail health verification after a newer run has already updated the mutable Cloud Run service and `:develop` image tag.

## Key changes

- Added `concurrency` configuration with `group: deploy-${{ github.ref }}` to serialize deployments per branch/tag
- Enabled `cancel-in-progress: true` to automatically cancel superseded runs, ensuring only the latest commit is deployed

## Implementation details

The concurrency group is scoped to the git ref (branch/tag), allowing parallel deployments across different refs while serializing them within a single ref. This is critical because:
- Cloud Run is a single mutable deployment target
- The `:develop` image tag is mutable
- Concurrent runs race to update these targets, causing older runs' health checks to fail with SHA mismatches

https://claude.ai/code/session_01BGNdnL98Kqf5J91NSmvxKW