### PR TITLE
feat(ci): scan GitHub Actions with zizmor

### DIFF
--- a/.github/actions/node-ci/action.yml
+++ b/.github/actions/node-ci/action.yml
@@ -43,7 +43,7 @@ runs:
       env:
         SEED_SOURCE: ${{ github.event.pull_request.head.sha || github.sha }}
       # SEED_SOURCE is a commit SHA (trusted, hex), not attacker-controlled;
-      # low-confidence finding tracked for recheck in the follow-up issue.
+      # low-confidence finding tracked for recheck in #910.
       run: echo "FAST_CHECK_SEED=$((16#${SEED_SOURCE:0:8}))" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
 
     - name: Test

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Get pnpm store directory
       shell: bash
       # STORE_PATH is pnpm's own store path (trusted), not attacker-controlled;
-      # low-confidence finding tracked for recheck in the follow-up issue.
+      # low-confidence finding tracked for recheck in #910.
       run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
 
     - name: Setup pnpm cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/node-ci
         with:
@@ -85,11 +87,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           git fetch --no-tags --depth=1 \
-            origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+            origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
       - uses: ./.github/actions/setup-node-pnpm
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -92,6 +94,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -136,10 +140,13 @@ jobs:
           echo "image_uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
 
       - name: Log Tags & Image
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          IMAGE_URI: ${{ steps.image.outputs.image_uri }}
         run: |
           echo "Published image tags:"
-          printf '%s\n' "${{ steps.meta.outputs.tags }}"
-          echo "Deploy image URI: ${{ steps.image.outputs.image_uri }}"
+          printf '%s\n' "$IMAGE_TAGS"
+          echo "Deploy image URI: $IMAGE_URI"
 
       # Service lifecycle is intentionally CI-managed for fast app rollouts.
       # Terraform in dev manages supporting infra (APIs, Artifact Registry,
@@ -164,8 +171,10 @@ jobs:
 
       - name: Verify Public Health
         continue-on-error: true
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
         run: >-
-          curl -fsSL "${{ steps.deploy.outputs.url }}/health"
+          curl -fsSL "$SERVICE_URL/health"
           | jq -e '.status == "ok"'
 
       - uses: ./.github/actions/setup-node-pnpm
@@ -182,4 +191,5 @@ jobs:
       - name: Verify Authenticated Health
         env:
           HEALTH_BEARER_TOKEN: ${{ steps.verify-token.outputs.id_token }}
-        run: pnpm --filter @genshin/api exec tsx scripts/verify-deployment.ts "${{ steps.deploy.outputs.url }}"
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
+        run: pnpm --filter @genshin/api exec tsx scripts/verify-deployment.ts "$SERVICE_URL"

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -30,10 +30,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Build devcontainer and run pnpm validate
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
         with:
           imageName: genshin-planner-devcontainer
           push: never

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4

--- a/.github/workflows/external-link-check.yml
+++ b/.github/workflows/external-link-check.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Check all links
         id: lychee

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Check internal links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-pnpm
 

--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -15,11 +15,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   core:
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
@@ -28,6 +30,9 @@ jobs:
   dev:
     if: github.ref == 'refs/heads/develop'
     needs: core
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: dev
@@ -36,6 +41,9 @@ jobs:
   staging:
     if: startsWith(github.ref, 'refs/heads/release/')
     needs: core
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: staging

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Scan Terraform
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98 # master
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Scan Dockerfile
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98 # master
@@ -85,6 +89,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,9 +19,9 @@ concurrency:
 
 jobs:
   # Online supply-chain audits (impostor commits, known-vulnerable actions)
-  # need a token and network, so they can't run in pre-commit.ci. Findings
-  # surface in the Security tab rather than blocking merge, matching trivy.yml;
-  # the offline audits are the blocking gate via the zizmor pre-commit hook.
+  # need a token and network, so they can't run in pre-commit.ci. This job
+  # uploads SARIF to the Security tab and blocks on findings; the offline
+  # audits are gated separately via the zizmor pre-commit hook.
   actions:
     name: GitHub Actions
     runs-on: ubuntu-latest
@@ -38,6 +38,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
-        continue-on-error: true
         with:
           config: .github/zizmor.yml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Zizmor
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Online supply-chain audits (impostor commits, known-vulnerable actions)
+  # need a token and network, so they can't run in pre-commit.ci. Findings
+  # surface in the Security tab rather than blocking merge, matching trivy.yml;
+  # the offline audits are the blocking gate via the zizmor pre-commit hook.
+  actions:
+    name: GitHub Actions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        continue-on-error: true
+        with:
+          config: .github/zizmor.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+rules:
+  ref-version-mismatch:
+    # SHA pins carry a major-version comment (# v6) by house convention; this
+    # audit wants the exact patch tag (# v6.0.2), which Renovate rewrites on the
+    # next bump. Comment hygiene, not a security signal, so opt out repo-wide.
+    disable: true
+
+  secrets-inherit:
+    # terraform-apply.yml uses secret inheritance into its reusable workflow
+    # because the GCP_RW_* credentials are environment-scoped (core/dev/staging).
+    # Only the reusable declares `environment:`, so the caller cannot resolve
+    # those credentials to pass them explicitly.
+    ignore:
+      - terraform-apply.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,6 +119,14 @@ repos:
     hooks:
       - id: detect-secrets
 
+  # GitHub Actions static analysis. Offline gate here (local + pre-commit.ci);
+  # online supply-chain audits run in .github/workflows/zizmor.yml with a token.
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor
+        args: [--no-progress, --offline]
+
   # Renovate config validation
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 43.150.0


### PR DESCRIPTION
## Summary

GitHub Actions security issues (script injection, broad permissions, unpinned/impostor actions) are now caught automatically. Offline audits run as a pre-commit hook (local + pre-commit.ci); online supply-chain audits run in a dedicated `zizmor.yml` that uploads SARIF to the Security tab. Both fail on findings.

Closes #723.

## Gotchas

- Mechanism diverges from the issue on purpose. The issue asked for the `eslint` pattern (`ci.skip` + a `pre-commit.yml` step), but that pattern exists for hooks pre-commit.ci *can't* run (no node/terraform binary). zizmor is a `language: python` hook pre-commit.ci runs fine, so it's an unskipped offline hook plus a separate online workflow — not shoehorned into `pre-commit.yml`. The issue's `woodruffw/zizmor` also moved to `zizmorcore/zizmor` (hook repo `zizmorcore/zizmor-pre-commit`).
- Scope grew past `.github/workflows/` to composite actions under `.github/actions/`, which zizmor also scans — `node-ci` (runs on every PR) had 3 High-confidence `${{ inputs.filter }}` injections. Fixed via env indirection.
- `.github/zizmor.yml` carries two deliberate exceptions with rationale: `secrets-inherit` on `terraform-apply.yml` is *not* fixed in-code because the `GCP_RW_*` secrets are environment-scoped (core/dev/staging) and only the reusable declares `environment:` — passing them explicitly from the caller would send empty values and break `terraform apply`. `ref-version-mismatch` is disabled (it wants exact `# v6.0.2` comments that Renovate rewrites).
- Two low-confidence `github-env` findings (writing a commit SHA and `pnpm store path` to `$GITHUB_ENV`, both trusted) are suppressed inline; recheck tracked in #910.
- `terraform-apply.yml`: `id-token: write` moved from workflow level to the three jobs that need it.
- The online workflow blocks on findings (no `continue-on-error`), unlike `trivy.yml`'s monitor-only posture. With `ref-version-mismatch` disabled, the remaining online audits fire rarely, so this should be low-noise — worth watching whether an advisory/tag change ever fails an unrelated PR.

## Verification

- Ran zizmor 1.26.1 across the whole repo both offline and online (token) — no findings; the 5 "ignored" are the documented suppressions.
- Deploy/terraform permission and secret changes aren't exercised by PR CI (deploys don't run here) — reviewer attention on those is worthwhile.