### PR TITLE
fix: bump team updatedAt on store mutations

### DIFF
--- a/apps/web/src/features/teams/use-team-store.test.ts
+++ b/apps/web/src/features/teams/use-team-store.test.ts
@@ -3,7 +3,7 @@
 
 import type { CollectionTeam, CollectionWeaponId, ISOTimestamp, TeamSlot } from '@genshin/domain';
 import { initialTeams } from '@genshin/domain';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useTeamStore } from './use-team-store';
 
@@ -183,6 +183,68 @@ describe('useTeamStore', () => {
       useTeamStore.getState().setArtifactPlan(1, 0, undefined);
 
       expect(useTeamStore.getState().teams[1].members[0]?.artifactPlan).toBeUndefined();
+    });
+  });
+
+  describe('updatedAt', () => {
+    const weaponId = 'weapon-1' as CollectionWeaponId;
+
+    const cases: { name: string; setup?: () => void; mutate: () => void }[] = [
+      {
+        name: 'assignCharacter',
+        mutate: () => useTeamStore.getState().assignCharacter(1, 0, 'amber'),
+      },
+      {
+        name: 'removeCharacter',
+        setup: () => useTeamStore.getState().assignCharacter(1, 0, 'amber'),
+        mutate: () => useTeamStore.getState().removeCharacter(1, 0),
+      },
+      {
+        name: 'assignWeapon',
+        setup: () => useTeamStore.getState().assignCharacter(1, 0, 'amber'),
+        mutate: () => useTeamStore.getState().assignWeapon(1, 0, weaponId),
+      },
+      {
+        name: 'removeWeapon',
+        setup: () => {
+          useTeamStore.getState().assignCharacter(1, 0, 'amber');
+          useTeamStore.getState().assignWeapon(1, 0, weaponId);
+        },
+        mutate: () => useTeamStore.getState().removeWeapon(1, 0),
+      },
+      {
+        name: 'setArtifactPlan',
+        setup: () => useTeamStore.getState().assignCharacter(1, 0, 'amber'),
+        mutate: () => useTeamStore.getState().setArtifactPlan(1, 0, { sands: 'ATK Percentage' }),
+      },
+      {
+        name: 'clearTeam',
+        setup: () => useTeamStore.getState().assignCharacter(1, 0, 'amber'),
+        mutate: () => useTeamStore.getState().clearTeam(1),
+      },
+      { name: 'setTeamName', mutate: () => useTeamStore.getState().setTeamName(1, 'National') },
+    ];
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      useTeamStore.getState().resetTeams();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it.each(cases)('$name bumps updatedAt to the mutation time', ({ setup, mutate }) => {
+      setup?.();
+      const { createdAt } = useTeamStore.getState().teams[1];
+
+      vi.advanceTimersByTime(1000);
+      mutate();
+
+      const { updatedAt } = useTeamStore.getState().teams[1];
+      expect(updatedAt).not.toBe(createdAt);
+      expect(updatedAt).toBe('2026-01-01T00:00:01.000Z');
     });
   });
 

--- a/apps/web/src/features/teams/use-team-store.ts
+++ b/apps/web/src/features/teams/use-team-store.ts
@@ -9,7 +9,7 @@ import type {
   CollectionWeaponId,
   TeamSlot,
 } from '@genshin/domain';
-import { initialTeams, isValidMemberIndex } from '@genshin/domain';
+import { initialTeams, isValidMemberIndex, nowTimestamp } from '@genshin/domain';
 import { create } from 'zustand';
 
 interface TeamStoreState {
@@ -66,6 +66,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
               ? { characterId, ...(existingWeaponId && { weaponInstanceId: existingWeaponId }) }
               : m,
           ) as CollectionTeamMembers,
+          updatedAt: nowTimestamp(),
         },
       },
     }));
@@ -82,6 +83,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
           members: state.teams[slot].members.map((m, i) =>
             i === memberIndex ? null : m,
           ) as CollectionTeamMembers,
+          updatedAt: nowTimestamp(),
         },
       },
     }));
@@ -99,6 +101,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
           members: state.teams[slot].members.map((m, i) =>
             i === memberIndex && m ? { ...m, weaponInstanceId: collectionWeaponId } : m,
           ) as CollectionTeamMembers,
+          updatedAt: nowTimestamp(),
         },
       },
     }));
@@ -116,6 +119,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
           members: state.teams[slot].members.map((m, i) =>
             i === memberIndex && m ? { ...m, weaponInstanceId: undefined } : m,
           ) as CollectionTeamMembers,
+          updatedAt: nowTimestamp(),
         },
       },
     }));
@@ -133,6 +137,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
           members: state.teams[slot].members.map((m, i) =>
             i === memberIndex && m ? { ...m, artifactPlan: plan } : m,
           ) as CollectionTeamMembers,
+          updatedAt: nowTimestamp(),
         },
       },
     }));
@@ -145,6 +150,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
         [slot]: {
           ...state.teams[slot],
           members: [null, null, null, null],
+          updatedAt: nowTimestamp(),
         },
       },
     }));
@@ -154,7 +160,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
     set((state) => ({
       teams: {
         ...state.teams,
-        [slot]: { ...state.teams[slot], name },
+        [slot]: { ...state.teams[slot], name, updatedAt: nowTimestamp() },
       },
     }));
   },


### PR DESCRIPTION
## Summary

Team store mutations rebuilt the team object but never touched `updatedAt`, leaving it frozen at the `createEmptyTeam` value (always equal to `createdAt`). This stamps `nowTimestamp()` into all seven mutating actions — `assignCharacter`, `removeCharacter`, `assignWeapon`, `removeWeapon`, `setArtifactPlan`, `clearTeam`, `setTeamName` — so `updatedAt` tracks the most recent change.

## Gotchas

- `nowTimestamp` was already exported from `@genshin/domain` but not yet imported in the store; added to the existing import.
- `setTeam`/`setTeams`/`resetTeams` are intentionally left alone — they accept or restore whole team objects that carry their own timestamps, so bumping there would clobber caller-supplied values.

## Verification

New parameterized `updatedAt` tests (fake timers) assert each of the seven actions advances `updatedAt` to the mutation time and off `createdAt`. `pnpm turbo run typecheck test --filter=@genshin/web` passes (93 tests).

Closes #632