### PR TITLE
feat(web): add privacy policy and terms of service pages

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -10,7 +10,9 @@ import { Toaster } from './components/ui/sonner';
 import { AuthProvider } from './features/auth';
 import { CharactersPage } from './pages/characters-page';
 import { NotFoundPage } from './pages/not-found-page';
+import { PrivacyPolicyPage } from './pages/privacy-policy-page';
 import { TeamsPage } from './pages/teams-page';
+import { TermsOfServicePage } from './pages/terms-of-service-page';
 import { WeaponsPage } from './pages/weapons-page';
 
 const queryClient = new QueryClient();
@@ -25,6 +27,8 @@ export function App(): JSX.Element {
               <Route path="/" element={<TeamsPage />} />
               <Route path="/characters" element={<CharactersPage />} />
               <Route path="/weapons" element={<WeaponsPage />} />
+              <Route path="/privacy" element={<PrivacyPolicyPage />} />
+              <Route path="/terms" element={<TermsOfServicePage />} />
               <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>

--- a/apps/web/src/components/footer.test.tsx
+++ b/apps/web/src/components/footer.test.tsx
@@ -2,18 +2,44 @@
 // SPDX-License-Identifier: MIT
 
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 
 import { Footer } from './footer';
 
-describe('Footer', () => {
-  it('opens links in new tabs with proper security attributes', () => {
-    render(<Footer />);
+function renderFooter() {
+  return render(
+    <MemoryRouter>
+      <Footer />
+    </MemoryRouter>,
+  );
+}
 
-    const links = screen.getAllByRole('link');
-    for (const link of links) {
+describe('Footer', () => {
+  it('opens external links in new tabs with proper security attributes', () => {
+    renderFooter();
+
+    const externalLinks = screen
+      .getAllByRole('link')
+      .filter((link) => link.getAttribute('href')?.startsWith('http'));
+
+    expect(externalLinks.length).toBeGreaterThan(0);
+    for (const link of externalLinks) {
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+
+  it('links to the legal pages as in-app navigation', () => {
+    renderFooter();
+
+    for (const [name, path] of [
+      [/privacy policy/i, '/privacy'],
+      [/terms of service/i, '/terms'],
+    ] as const) {
+      const link = screen.getByRole('link', { name });
+      expect(link).toHaveAttribute('href', path);
+      expect(link).not.toHaveAttribute('target');
     }
   });
 });

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -3,6 +3,7 @@
 
 import { GAME_DATA_VERSION } from '@genshin/game-data';
 import type { JSX } from 'react';
+import { Link } from 'react-router-dom';
 
 import { Container } from '@/components/container';
 
@@ -63,6 +64,16 @@ export function Footer(): JSX.Element {
               >
                 GitHub
               </a>
+            </li>
+            <li>
+              <Link to="/privacy" className="underline-offset-4 hover:underline">
+                Privacy Policy
+              </Link>
+            </li>
+            <li>
+              <Link to="/terms" className="underline-offset-4 hover:underline">
+                Terms of Service
+              </Link>
             </li>
           </ul>
         </nav>

--- a/apps/web/src/pages/privacy-policy-page.tsx
+++ b/apps/web/src/pages/privacy-policy-page.tsx
@@ -51,8 +51,8 @@ export function PrivacyPolicyPage(): JSX.Element {
 
         <h2 className="mt-8 text-xl font-semibold text-foreground">How we use your data</h2>
         <p className="mt-4 leading-relaxed">
-          We use your account information to sign you in and your collection data to save and sync
-          it across devices. That's the extent of it.
+          We use your account information to sign you in, and your collection data to save and sync
+          it across devices. We don't use it for anything else.
         </p>
 
         <h2 className="mt-8 text-xl font-semibold text-foreground">Service providers</h2>

--- a/apps/web/src/pages/privacy-policy-page.tsx
+++ b/apps/web/src/pages/privacy-policy-page.tsx
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Draft content describing the app's actual data practices as of HEAD. Needs a
+// legal review pass (and a dedicated privacy-contact address) before the 1.0.0
+// tag; see #647.
+
+import type { JSX } from 'react';
+
+import { Container } from '@/components/container';
+
+const EFFECTIVE_DATE = '3 July 2026';
+const GITHUB_REPO = 'https://github.com/dungeon-studio/genshin.dungeon.studio';
+
+export function PrivacyPolicyPage(): JSX.Element {
+  return (
+    <Container className="max-w-3xl py-12">
+      <article className="text-muted-foreground">
+        <h1 className="text-3xl font-bold text-foreground">Privacy Policy</h1>
+        <p className="mt-2 text-sm text-muted-foreground/70">Effective {EFFECTIVE_DATE}</p>
+
+        <p className="mt-6 leading-relaxed">
+          genshin.dungeon.studio is an unofficial, fan-made team-building companion for Genshin
+          Impact, operated by Dungeon Studio. This policy explains what data we collect, why, and
+          how you can control it.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">What we collect</h2>
+        <ul className="mt-4 list-disc space-y-2 pl-6 leading-relaxed">
+          <li>
+            <strong className="font-medium text-foreground">Account information.</strong> When you
+            sign in with Google, we receive your name, email address, profile photo, and Google
+            account identifier through Firebase Authentication. Signing in is optional.
+          </li>
+          <li>
+            <strong className="font-medium text-foreground">Your collection.</strong> The characters
+            and weapons you mark as owned and their levels. Before you sign in this stays in your
+            browser; once you sign in it is saved to our servers so it syncs across your devices.
+          </li>
+          <li>
+            <strong className="font-medium text-foreground">Preferences.</strong> Your light or dark
+            theme choice, stored only in your browser and never sent to us.
+          </li>
+        </ul>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">What we don't do</h2>
+        <p className="mt-4 leading-relaxed">
+          We do not use analytics or tracking, serve advertising, or set tracking cookies. We do not
+          sell your data or share it for marketing.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">How we use your data</h2>
+        <p className="mt-4 leading-relaxed">
+          We use your account information to sign you in and your collection data to save and sync
+          it across devices. That's the extent of it.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Service providers</h2>
+        <p className="mt-4 leading-relaxed">
+          We rely on Google Firebase (Firebase Authentication and Cloud Firestore) to authenticate
+          you and store your collection on our behalf. Their handling of that data is governed by
+          the{' '}
+          <a
+            href="https://policies.google.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline underline-offset-4 hover:no-underline"
+          >
+            Google Privacy Policy
+          </a>
+          .
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Your choices and rights</h2>
+        <p className="mt-4 leading-relaxed">
+          Signing out clears your collection from your browser. To access, correct, or delete the
+          data associated with your account, or to ask any question about your privacy, reach us
+          through our{' '}
+          <a
+            href={`${GITHUB_REPO}/issues/new/choose`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline underline-offset-4 hover:no-underline"
+          >
+            GitHub repository
+          </a>
+          . Depending on where you live, you may have additional rights over your personal data
+          under laws such as the GDPR or CCPA.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Children</h2>
+        <p className="mt-4 leading-relaxed">
+          This app is not directed to children under 13, and we do not knowingly collect their
+          personal information.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Changes to this policy</h2>
+        <p className="mt-4 leading-relaxed">
+          We may update this policy as the app evolves. When we do, we'll revise the effective date
+          above.
+        </p>
+      </article>
+    </Container>
+  );
+}

--- a/apps/web/src/pages/terms-of-service-page.tsx
+++ b/apps/web/src/pages/terms-of-service-page.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // Draft terms describing the service as of HEAD. Needs a legal review pass
-// (governing law, and a dedicated contact address) before the 1.0.0 tag; see
-// #647.
+// and a dedicated contact address before the 1.0.0 tag; see #647.
 
 import type { JSX } from 'react';
 import { Link } from 'react-router-dom';
@@ -71,6 +70,15 @@ export function TermsOfServicePage(): JSX.Element {
         <p className="mt-4 leading-relaxed">
           To the extent permitted by law, Dungeon Studio is not liable for any indirect, incidental,
           or consequential damages arising from your use of the app.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Governing law</h2>
+        <p className="mt-4 leading-relaxed">
+          These terms are governed by the laws of England and Wales, and any dispute will be subject
+          to the exclusive jurisdiction of the courts of England and Wales. If you are a consumer,
+          you may also be entitled to the protection of mandatory provisions of the law of the
+          country where you live, and nothing in these terms affects your rights as a consumer to
+          rely on those provisions.
         </p>
 
         <h2 className="mt-8 text-xl font-semibold text-foreground">Changes to these terms</h2>

--- a/apps/web/src/pages/terms-of-service-page.tsx
+++ b/apps/web/src/pages/terms-of-service-page.tsx
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Draft terms describing the service as of HEAD. Needs a legal review pass
+// (governing law, and a dedicated contact address) before the 1.0.0 tag; see
+// #647.
+
+import type { JSX } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Container } from '@/components/container';
+
+const EFFECTIVE_DATE = '3 July 2026';
+const GITHUB_REPO = 'https://github.com/dungeon-studio/genshin.dungeon.studio';
+
+export function TermsOfServicePage(): JSX.Element {
+  return (
+    <Container className="max-w-3xl py-12">
+      <article className="text-muted-foreground">
+        <h1 className="text-3xl font-bold text-foreground">Terms of Service</h1>
+        <p className="mt-2 text-sm text-muted-foreground/70">Effective {EFFECTIVE_DATE}</p>
+
+        <p className="mt-6 leading-relaxed">
+          By using genshin.dungeon.studio you agree to these terms. If you don't agree, please don't
+          use the app.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">The service</h2>
+        <p className="mt-4 leading-relaxed">
+          genshin.dungeon.studio is a free, unofficial team-building companion for Genshin Impact.
+          It helps you track your collection and plan teams. It is provided at no cost and with no
+          guarantee of continued availability.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">
+          Not affiliated with HoYoverse
+        </h2>
+        <p className="mt-4 leading-relaxed">
+          This is a fan-made project. It is not affiliated with, endorsed by, or sponsored by
+          HoYoverse (miHoYo/Cognosphere). Genshin Impact and all related names, characters, and art
+          are trademarks and copyright of their respective owners. Game data is presented for
+          reference and may be inaccurate or out of date.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Your account</h2>
+        <p className="mt-4 leading-relaxed">
+          Signing in uses your Google account through Firebase Authentication. You are responsible
+          for keeping that account secure. We describe what we do with your data in our{' '}
+          <Link
+            to="/privacy"
+            className="text-foreground underline underline-offset-4 hover:no-underline"
+          >
+            Privacy Policy
+          </Link>
+          .
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Acceptable use</h2>
+        <p className="mt-4 leading-relaxed">
+          Don't use the app to break the law, and don't attempt to disrupt, overload, or reverse the
+          service or gain unauthorized access to it or to other users' data.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">No warranty</h2>
+        <p className="mt-4 leading-relaxed">
+          The app is provided "as is" and "as available", without warranties of any kind. We don't
+          guarantee that it will be accurate, complete, uninterrupted, or error-free.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Limitation of liability</h2>
+        <p className="mt-4 leading-relaxed">
+          To the extent permitted by law, Dungeon Studio is not liable for any indirect, incidental,
+          or consequential damages arising from your use of the app.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Changes to these terms</h2>
+        <p className="mt-4 leading-relaxed">
+          We may update these terms as the app evolves. When we do, we'll revise the effective date
+          above.
+        </p>
+
+        <h2 className="mt-8 text-xl font-semibold text-foreground">Contact</h2>
+        <p className="mt-4 leading-relaxed">
+          Questions about these terms? Reach us through our{' '}
+          <a
+            href={`${GITHUB_REPO}/issues/new/choose`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline underline-offset-4 hover:no-underline"
+          >
+            GitHub repository
+          </a>
+          .
+        </p>
+      </article>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary

The 1.0 launch signs real users in with Google, whose terms require a posted privacy policy (GDPR/CCPA add the same). Adds `/privacy` and `/terms` as in-app routes matching the existing `pages/` pattern, linked from the footer.

The page text is plain-language and accurate to the app's real data use as of HEAD — Firebase email + Google profile, collection in localStorage/Firestore, theme in localStorage, no analytics or tracking. The ToS is governed by the laws of England and Wales (the operator's home jurisdiction) with the standard non-waivable consumer carve-out.

Closes #647

## Gotchas

- The legal content is accurate but a **draft**: it still needs a legal review pass and a dedicated privacy-contact address before the 1.0.0 tag (contact currently routes through GitHub issues). Flagged in a comment at the top of each page file.
- `footer.test.tsx` was rewritten: the footer now mixes external `<a target="_blank">` links with internal `<Link>` nav, so the old "every link opens in a new tab" assertion no longer holds. It now checks external links carry the security attributes and the legal links navigate in-app.