### PR TITLE
refactor: rename weaponInstanceId to collectionWeaponId

### DIFF
--- a/apps/api/schema-snapshots/teams/v2.json
+++ b/apps/api/schema-snapshots/teams/v2.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 2
+    },
+    "name": {
+      "type": "string"
+    },
+    "members": {
+      "maxItems": 4,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "characterId": {
+                "type": "string"
+              },
+              "collectionWeaponId": {
+                "type": "string"
+              },
+              "artifactPlan": {
+                "type": "object",
+                "properties": {
+                  "sands": {
+                    "type": "string"
+                  },
+                  "goblet": {
+                    "type": "string"
+                  },
+                  "circlet": {
+                    "type": "string"
+                  },
+                  "sets": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "priorityMinorAffixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "secondaryMinorAffixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "characterId"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "description": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "name",
+    "members",
+    "createdAt",
+    "updatedAt"
+  ],
+  "additionalProperties": false
+}

--- a/apps/api/scripts/schema-registry.ts
+++ b/apps/api/scripts/schema-registry.ts
@@ -9,6 +9,7 @@ import { V1CharacterSchema } from '../src/repositories/characters/schemas/v1.js'
 import { CURRENT_VERSION as teamsCurrent } from '../src/repositories/teams/schemas/index.js';
 import { V0TeamSchema } from '../src/repositories/teams/schemas/v0.js';
 import { V1TeamSchema } from '../src/repositories/teams/schemas/v1.js';
+import { V2TeamSchema } from '../src/repositories/teams/schemas/v2.js';
 import { CURRENT_VERSION as weaponsCurrent } from '../src/repositories/weapons/schemas/index.js';
 import { V0WeaponSchema } from '../src/repositories/weapons/schemas/v0.js';
 import { V1WeaponSchema } from '../src/repositories/weapons/schemas/v1.js';
@@ -31,7 +32,7 @@ export const SCHEMA_REGISTRY: Record<string, RepositorySchemas> = {
     versions: [V0CharacterSchema, V1CharacterSchema],
     currentVersion: charactersCurrent,
   },
-  teams: { versions: [V0TeamSchema, V1TeamSchema], currentVersion: teamsCurrent },
+  teams: { versions: [V0TeamSchema, V1TeamSchema, V2TeamSchema], currentVersion: teamsCurrent },
   weapons: { versions: [V0WeaponSchema, V1WeaponSchema], currentVersion: weaponsCurrent },
 };
 

--- a/apps/api/src/profiles/alps/registry.ts
+++ b/apps/api/src/profiles/alps/registry.ts
@@ -4,6 +4,14 @@
 import { characterItemV1 } from '@/profiles/alps/character/item-v1.js';
 import type { AlpsProfile } from '@/profiles/alps/profile.js';
 import { teamItemV1 } from '@/profiles/alps/team/item-v1.js';
+import { teamItemV2 } from '@/profiles/alps/team/item-v2.js';
 import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
+import { weaponItemV2 } from '@/profiles/alps/weapon/item-v2.js';
 
-export const alpsRegistry: readonly AlpsProfile[] = [characterItemV1, teamItemV1, weaponItemV1];
+export const alpsRegistry: readonly AlpsProfile[] = [
+  characterItemV1,
+  teamItemV1,
+  teamItemV2,
+  weaponItemV1,
+  weaponItemV2,
+];

--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -42,7 +42,7 @@ export const teamItemV1 = {
               },
             },
             {
-              id: 'weaponInstanceId',
+              id: 'collectionWeaponId',
               type: 'semantic',
               doc: {
                 value:

--- a/apps/api/src/profiles/alps/team/item-v2.ts
+++ b/apps/api/src/profiles/alps/team/item-v2.ts
@@ -3,8 +3,8 @@
 
 import type { AlpsProfile } from '@/profiles/alps/profile.js';
 
-export const teamItemV1 = {
-  path: '/profiles/alps/team/item-v1.json',
+export const teamItemV2 = {
+  path: '/profiles/alps/team/item-v2.json',
   profile: {
     alps: {
       version: '1.0',
@@ -42,7 +42,7 @@ export const teamItemV1 = {
               },
             },
             {
-              id: 'weaponInstanceId',
+              id: 'collectionWeaponId',
               type: 'semantic',
               doc: {
                 value:

--- a/apps/api/src/profiles/alps/weapon/item-v1.ts
+++ b/apps/api/src/profiles/alps/weapon/item-v1.ts
@@ -14,7 +14,7 @@ export const weaponItemV1 = {
       },
       descriptor: [
         {
-          id: 'weaponInstanceId',
+          id: 'collectionWeaponId',
           type: 'semantic',
           doc: {
             value: 'Unique identifier distinguishing one copy of a weapon from another',

--- a/apps/api/src/profiles/alps/weapon/item-v2.ts
+++ b/apps/api/src/profiles/alps/weapon/item-v2.ts
@@ -3,8 +3,8 @@
 
 import type { AlpsProfile } from '@/profiles/alps/profile.js';
 
-export const weaponItemV1 = {
-  path: '/profiles/alps/weapon/item-v1.json',
+export const weaponItemV2 = {
+  path: '/profiles/alps/weapon/item-v2.json',
   profile: {
     alps: {
       version: '1.0',
@@ -14,7 +14,7 @@ export const weaponItemV1 = {
       },
       descriptor: [
         {
-          id: 'weaponInstanceId',
+          id: 'collectionWeaponId',
           type: 'semantic',
           doc: {
             value: 'Unique identifier distinguishing one copy of a weapon from another',

--- a/apps/api/src/profiles/json-schema/registry.ts
+++ b/apps/api/src/profiles/json-schema/registry.ts
@@ -7,6 +7,7 @@ import { profileGetResponseV1 } from '@/profiles/json-schema/profile/get-respons
 import { profilePatchRequestV1 } from '@/profiles/json-schema/profile/patch-request-v1.js';
 import { rootGetResponseV1 } from '@/profiles/json-schema/root/get-response-v1.js';
 import { teamPutRequestV1 } from '@/profiles/json-schema/teams/put-request-v1.js';
+import { teamPutRequestV2 } from '@/profiles/json-schema/teams/put-request-v2.js';
 import { weaponPatchRequestV1 } from '@/profiles/json-schema/weapons/patch-request-v1.js';
 import { weaponPostRequestV1 } from '@/profiles/json-schema/weapons/post-request-v1.js';
 
@@ -16,6 +17,7 @@ export const jsonSchemaRegistry: readonly JsonSchemaProfile[] = [
   profilePatchRequestV1,
   characterPutRequestV1,
   teamPutRequestV1,
+  teamPutRequestV2,
   weaponPostRequestV1,
   weaponPatchRequestV1,
 ];

--- a/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
+++ b/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
@@ -42,7 +42,7 @@ export const teamPutRequestV1 = {
             minLength: 1,
             description: 'Character ID from game data',
           },
-          weaponInstanceId: {
+          collectionWeaponId: {
             type: 'string',
             minLength: 1,
             description: "Weapon instance UUID from user's collection",

--- a/apps/api/src/profiles/json-schema/teams/put-request-v2.ts
+++ b/apps/api/src/profiles/json-schema/teams/put-request-v2.ts
@@ -3,8 +3,8 @@
 
 import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 
-export const teamPutRequestV1 = {
-  path: '/profiles/json-schema/teams/put-request-v1.json',
+export const teamPutRequestV2 = {
+  path: '/profiles/json-schema/teams/put-request-v2.json',
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Update Team Request',
@@ -42,7 +42,7 @@ export const teamPutRequestV1 = {
             minLength: 1,
             description: 'Character ID from game data',
           },
-          weaponInstanceId: {
+          collectionWeaponId: {
             type: 'string',
             minLength: 1,
             description: "Weapon instance UUID from user's collection",

--- a/apps/api/src/repositories/teams/document.test.ts
+++ b/apps/api/src/repositories/teams/document.test.ts
@@ -7,14 +7,15 @@ import { describe, expect, it } from 'vitest';
 
 import { arbCharacterId, arbTimestamp } from '@/test/arbitraries.js';
 
-import { CURRENT_VERSION, fromDocument, toDocument, type V1Team, type V0Team } from './document.js';
+import { CURRENT_VERSION, fromDocument, toDocument, type V0Team } from './document.js';
+import { type V1Team } from './schemas/v1.js';
 
 const TIMESTAMP = '2024-01-15T12:00:00.000Z';
 
 const arbMember: fc.Arbitrary<CollectionTeamMember> = fc.record(
   {
     characterId: arbCharacterId,
-    weaponInstanceId: fc.uuid().map((id) => id as UUID),
+    collectionWeaponId: fc.uuid().map((id) => id as UUID),
   },
   { requiredKeys: ['characterId'] },
 );
@@ -107,6 +108,17 @@ describe('fromDocument', () => {
       }),
     );
     expect(team.members[0]?.artifactPlan?.priorityMinorAffixes).toEqual(['crit-rate']);
+  });
+
+  it('migrates a v1 member weaponInstanceId → collectionWeaponId', () => {
+    const team = fromDocument(
+      1,
+      makeV1Document({
+        members: [{ characterId: 'columbina', weaponInstanceId: 'weapon-1' }, null, null, null],
+      }),
+    );
+    expect(team.members[0]?.collectionWeaponId).toBe('weapon-1');
+    expect(team.members[0]).not.toHaveProperty('weaponInstanceId');
   });
 
   it('throws for too many members', () => {

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -13,25 +13,25 @@ import { assertCollectionTeam } from '@genshin/domain';
 import {
   entity,
   CURRENT_VERSION,
-  type V1Team,
+  type V2Team,
   type V0Team,
-  type V1Member,
+  type V2Member,
 } from './schemas/index.js';
 
-export { CURRENT_VERSION, type V1Team, type V0Team };
+export { CURRENT_VERSION, type V2Team, type V0Team };
 
-function memberFromDocument(m: V1Member): CollectionTeamMember {
+function memberFromDocument(m: V2Member): CollectionTeamMember {
   return {
     characterId: m.characterId,
-    ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
+    ...(m.collectionWeaponId !== undefined ? { collectionWeaponId: m.collectionWeaponId } : {}),
     ...(m.artifactPlan !== undefined ? { artifactPlan: m.artifactPlan } : {}),
   } as CollectionTeamMember;
 }
 
-function memberToDocument(m: CollectionTeamMember): V1Member {
+function memberToDocument(m: CollectionTeamMember): V2Member {
   return {
     characterId: m.characterId,
-    ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
+    ...(m.collectionWeaponId !== undefined ? { collectionWeaponId: m.collectionWeaponId } : {}),
     ...(m.artifactPlan !== undefined ? { artifactPlan: m.artifactPlan } : {}),
   };
 }
@@ -60,7 +60,7 @@ export function fromDocument(slot: TeamSlot, raw: Record<string, unknown>): Coll
   return team;
 }
 
-export function toDocument(team: CollectionTeam): V1Team {
+export function toDocument(team: CollectionTeam): V2Team {
   return {
     schemaVersion: CURRENT_VERSION,
     name: team.name,

--- a/apps/api/src/repositories/teams/schemas/index.ts
+++ b/apps/api/src/repositories/teams/schemas/index.ts
@@ -5,15 +5,16 @@ import { createVersionedEntity, type InferredEntity } from 'verzod';
 
 import { v0 } from './v0.js';
 import { v1 } from './v1.js';
+import { v2 } from './v2.js';
 
 export { type V0Team } from './v0.js';
-export { type V1Member } from './v1.js';
+export { type V2Member } from './v2.js';
 
-export const CURRENT_VERSION = 1 as const;
+export const CURRENT_VERSION = 2 as const;
 
 export const entity = createVersionedEntity({
   latestVersion: CURRENT_VERSION,
-  versionMap: { 0: v0, 1: v1 },
+  versionMap: { 0: v0, 1: v1, 2: v2 },
   getVersion(data: unknown) {
     if (typeof data !== 'object' || data === null) return null;
     const ver = (data as Record<string, unknown>).schemaVersion;
@@ -21,4 +22,4 @@ export const entity = createVersionedEntity({
   },
 });
 
-export type V1Team = InferredEntity<typeof entity>;
+export type V2Team = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/teams/schemas/v1.ts
+++ b/apps/api/src/repositories/teams/schemas/v1.ts
@@ -22,8 +22,6 @@ export const V1MemberSchema = z.object({
     .optional(),
 });
 
-export type V1Member = z.infer<typeof V1MemberSchema>;
-
 export const V1TeamSchema = z.object({
   schemaVersion: z.literal(1),
   name: z.string(),

--- a/apps/api/src/repositories/teams/schemas/v1.ts
+++ b/apps/api/src/repositories/teams/schemas/v1.ts
@@ -33,6 +33,8 @@ export const V1TeamSchema = z.object({
   updatedAt: z.string(),
 });
 
+export type V1Team = z.infer<typeof V1TeamSchema>;
+
 export const v1 = defineVersion({
   initial: false,
   schema: V1TeamSchema,

--- a/apps/api/src/repositories/teams/schemas/v2.ts
+++ b/apps/api/src/repositories/teams/schemas/v2.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { MAX_TEAM_MEMBERS } from '@genshin/domain';
+import { defineVersion } from 'verzod';
+import { z } from 'zod';
+
+import { type V1Team } from './v1.js';
+
+export const V2MemberSchema = z.object({
+  characterId: z.string(),
+  collectionWeaponId: z.string().optional(),
+  artifactPlan: z
+    .object({
+      sands: z.string().optional(),
+      goblet: z.string().optional(),
+      circlet: z.string().optional(),
+      sets: z.array(z.string()).optional(),
+      priorityMinorAffixes: z.array(z.string()).optional(),
+      secondaryMinorAffixes: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+export type V2Member = z.infer<typeof V2MemberSchema>;
+
+export const V2TeamSchema = z.object({
+  schemaVersion: z.literal(2),
+  name: z.string(),
+  members: z.array(z.union([z.null(), V2MemberSchema])).max(MAX_TEAM_MEMBERS),
+  description: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const v2 = defineVersion({
+  initial: false,
+  schema: V2TeamSchema,
+  up: (old: V1Team): z.infer<typeof V2TeamSchema> => ({
+    schemaVersion: 2,
+    name: old.name,
+    members: old.members.map((m): z.infer<typeof V2MemberSchema> | null => {
+      if (m === null) return null;
+      const { weaponInstanceId, ...rest } = m;
+      return {
+        ...rest,
+        ...(weaponInstanceId !== undefined ? { collectionWeaponId: weaponInstanceId } : {}),
+      };
+    }),
+    ...(old.description !== undefined ? { description: old.description } : {}),
+    createdAt: old.createdAt,
+    updatedAt: old.updatedAt,
+  }),
+});

--- a/apps/api/src/repositories/weapons/document.test.ts
+++ b/apps/api/src/repositories/weapons/document.test.ts
@@ -19,7 +19,7 @@ const TIMESTAMP = '2024-01-15T12:00:00.000Z';
 const WEAPON_INSTANCE_ID = '11111111-1111-1111-1111-111111111111' as UUID;
 
 const arbWeapon = fc.record({
-  weaponInstanceId: fc.uuid().map((id) => id as UUID),
+  collectionWeaponId: fc.uuid().map((id) => id as UUID),
   weaponId: arbWeaponId,
   refinementLevel: fc.integer({ min: MIN_REFINEMENT_LEVEL, max: MAX_REFINEMENT_LEVEL }),
   createdAt: arbTimestamp,
@@ -78,7 +78,7 @@ describe('toDocument', () => {
     fc.assert(
       fc.property(arbWeapon, (weapon) => {
         const restored = fromDocument(
-          weapon.weaponInstanceId,
+          weapon.collectionWeaponId,
           toDocument(weapon) as unknown as Record<string, unknown>,
         );
         expect(restored).toEqual(weapon);

--- a/apps/api/src/repositories/weapons/document.ts
+++ b/apps/api/src/repositories/weapons/document.ts
@@ -9,7 +9,7 @@ import { entity, CURRENT_VERSION, type V1Weapon, type V0Weapon } from './schemas
 export { CURRENT_VERSION, type V1Weapon, type V0Weapon };
 
 export function fromDocument(
-  weaponInstanceId: UUID,
+  collectionWeaponId: UUID,
   raw: Record<string, unknown>,
 ): CollectionWeapon {
   const result = entity.safeParse(raw);
@@ -18,7 +18,7 @@ export function fromDocument(
   }
   const data = result.value;
   const weapon = {
-    weaponInstanceId,
+    collectionWeaponId,
     weaponId: data.weaponId,
     refinementLevel: data.refinementLevel,
     createdAt: data.createdAt as ISOTimestamp,

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -24,9 +24,9 @@ export async function list(userId: string, weaponId?: string): Promise<Collectio
 
 export async function get(
   userId: string,
-  weaponInstanceId: UUID,
+  collectionWeaponId: UUID,
 ): Promise<CollectionWeapon | null> {
-  const doc = await collectionRef(userId).doc(weaponInstanceId).get();
+  const doc = await collectionRef(userId).doc(collectionWeaponId).get();
 
   if (!doc.exists) {
     return null;
@@ -37,7 +37,7 @@ export async function get(
     return null;
   }
 
-  return fromDocument(weaponInstanceId, data);
+  return fromDocument(collectionWeaponId, data);
 }
 
 export async function create(
@@ -45,28 +45,28 @@ export async function create(
   weaponId: string,
   refinementLevel: number,
 ): Promise<CollectionWeapon> {
-  const weaponInstanceId = randomUUID() as UUID;
+  const collectionWeaponId = randomUUID() as UUID;
   const now = new Date().toISOString() as ISOTimestamp;
 
   const weapon: CollectionWeapon = {
-    weaponInstanceId,
+    collectionWeaponId,
     weaponId,
     refinementLevel,
     createdAt: now,
     updatedAt: now,
   };
 
-  await collectionRef(userId).doc(weaponInstanceId).set(toDocument(weapon));
+  await collectionRef(userId).doc(collectionWeaponId).set(toDocument(weapon));
 
   return weapon;
 }
 
 export async function update(
   userId: string,
-  weaponInstanceId: UUID,
+  collectionWeaponId: UUID,
   refinementLevel: number,
 ): Promise<CollectionWeapon | null> {
-  const docRef = collectionRef(userId).doc(weaponInstanceId);
+  const docRef = collectionRef(userId).doc(collectionWeaponId);
   const existing = await docRef.get();
 
   if (!existing.exists) {
@@ -78,11 +78,11 @@ export async function update(
     return null;
   }
 
-  const existingWeapon = fromDocument(weaponInstanceId, existingData);
+  const existingWeapon = fromDocument(collectionWeaponId, existingData);
   const now = new Date().toISOString() as ISOTimestamp;
 
   const weapon: CollectionWeapon = {
-    weaponInstanceId,
+    collectionWeaponId,
     weaponId: existingWeapon.weaponId,
     refinementLevel,
     createdAt: existingWeapon.createdAt,
@@ -94,6 +94,6 @@ export async function update(
   return weapon;
 }
 
-export async function remove(userId: string, weaponInstanceId: UUID): Promise<void> {
-  await collectionRef(userId).doc(weaponInstanceId).delete();
+export async function remove(userId: string, collectionWeaponId: UUID): Promise<void> {
+  await collectionRef(userId).doc(collectionWeaponId).delete();
 }

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
 import { toMediaTypeString } from '@/middleware/negotiate-content.js';
-import { teamItemV1 } from '@/profiles/alps/team/item-v1.js';
+import { teamItemV2 } from '@/profiles/alps/team/item-v2.js';
 import * as Characters from '@/repositories/characters/index.js';
 import * as Teams from '@/repositories/teams/index.js';
 import * as Weapons from '@/repositories/weapons/index.js';
@@ -55,7 +55,7 @@ const FAKE_EMPTY_TEAM: CollectionTeam = {
 };
 
 const EXPECTED_CONTENT_TYPE = toMediaTypeString(
-  { mediaType: COLLECTION_JSON, profile: teamItemV1 },
+  { mediaType: COLLECTION_JSON, profile: teamItemV2 },
   'http://localhost',
 );
 

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -37,10 +37,10 @@ const FAKE_TEAM: CollectionTeam = {
   slot: 1,
   name: 'Team 1',
   members: [
-    { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' as UUID },
-    { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' as UUID },
-    { characterId: 'zhongli', weaponInstanceId: 'uuid-3' as UUID },
-    { characterId: 'albedo', weaponInstanceId: 'uuid-4' as UUID },
+    { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' as UUID },
+    { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' as UUID },
+    { characterId: 'zhongli', collectionWeaponId: 'uuid-3' as UUID },
+    { characterId: 'albedo', collectionWeaponId: 'uuid-4' as UUID },
   ],
   createdAt: '2026-01-01T00:00:00.000Z' as CollectionTeam['createdAt'],
   updatedAt: '2026-03-13T00:00:00.000Z' as CollectionTeam['updatedAt'],
@@ -70,7 +70,7 @@ function mockCharacterOwned() {
 
 function mockWeaponOwned() {
   vi.mocked(Weapons.get).mockResolvedValue({
-    weaponInstanceId: 'uuid-1' as UUID,
+    collectionWeaponId: 'uuid-1' as UUID,
     weaponId: 'staff-of-homa',
     refinementLevel: 1,
     createdAt: '2026-01-01T00:00:00.000Z',
@@ -303,7 +303,7 @@ describe('Team routes', () => {
         team: {
           ...FAKE_TEAM,
           members: [
-            { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' as UUID },
+            { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' as UUID },
             null,
             null,
             null,
@@ -314,7 +314,7 @@ describe('Team routes', () => {
 
       const res = await app.request(
         authedRequest('PUT', '/api/teams/1', {
-          members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }, null, null, null],
+          members: [{ characterId: 'hu-tao', collectionWeaponId: 'uuid-1' }, null, null, null],
         }),
       );
 
@@ -343,11 +343,11 @@ describe('Team routes', () => {
       const res = await app.request(
         authedRequest('PUT', '/api/teams/1', {
           members: [
-            { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
-            { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-            { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-            { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
-            { characterId: 'ganyu', weaponInstanceId: 'uuid-5' },
+            { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' },
+            { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+            { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+            { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
+            { characterId: 'ganyu', collectionWeaponId: 'uuid-5' },
           ],
         }),
       );
@@ -358,7 +358,7 @@ describe('Team routes', () => {
     it('returns 422 when members array has fewer than 4', async () => {
       const res = await app.request(
         authedRequest('PUT', '/api/teams/1', {
-          members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }],
+          members: [{ characterId: 'hu-tao', collectionWeaponId: 'uuid-1' }],
         }),
       );
 
@@ -390,10 +390,10 @@ describe('Team routes', () => {
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
             members: [
-              { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
-              { characterId: 'hu-tao', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' },
+              { characterId: 'hu-tao', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -409,10 +409,10 @@ describe('Team routes', () => {
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
             members: [
-              { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -428,10 +428,10 @@ describe('Team routes', () => {
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
             members: [
-              { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -445,8 +445,8 @@ describe('Team routes', () => {
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
             members: [
-              { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-1' },
+              { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-1' },
               null,
               null,
             ],
@@ -464,7 +464,7 @@ describe('Team routes', () => {
             ...FAKE_TEAM,
             slot: 2,
             members: [
-              { characterId: 'ganyu', weaponInstanceId: 'uuid-1' as UUID },
+              { characterId: 'ganyu', collectionWeaponId: 'uuid-1' as UUID },
               null,
               null,
               null,
@@ -474,7 +474,7 @@ describe('Team routes', () => {
 
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
-            members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }, null, null, null],
+            members: [{ characterId: 'hu-tao', collectionWeaponId: 'uuid-1' }, null, null, null],
           }),
         );
 
@@ -489,7 +489,7 @@ describe('Team routes', () => {
             ...FAKE_TEAM,
             slot: 2,
             members: [
-              { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' as UUID },
+              { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' as UUID },
               null,
               null,
               null,
@@ -500,7 +500,7 @@ describe('Team routes', () => {
           team: {
             ...FAKE_TEAM,
             members: [
-              { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' as UUID },
+              { characterId: 'hu-tao', collectionWeaponId: 'uuid-1' as UUID },
               null,
               null,
               null,
@@ -511,7 +511,7 @@ describe('Team routes', () => {
 
         const res = await app.request(
           authedRequest('PUT', '/api/teams/1', {
-            members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }, null, null, null],
+            members: [{ characterId: 'hu-tao', collectionWeaponId: 'uuid-1' }, null, null, null],
           }),
         );
 
@@ -524,7 +524,7 @@ describe('Team routes', () => {
             members: [
               {
                 characterId: 'hu-tao',
-                weaponInstanceId: 'uuid-1',
+                collectionWeaponId: 'uuid-1',
                 artifactPlan: {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
@@ -534,9 +534,9 @@ describe('Team routes', () => {
                   secondaryMinorAffixes: ['ATK Percentage'],
                 },
               },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -552,7 +552,7 @@ describe('Team routes', () => {
             members: [
               {
                 characterId: 'hu-tao',
-                weaponInstanceId: 'uuid-1',
+                collectionWeaponId: 'uuid-1',
                 artifactPlan: {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
@@ -562,9 +562,9 @@ describe('Team routes', () => {
                   secondaryMinorAffixes: ['CRIT Rate', 'ATK Percentage'],
                 },
               },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -585,7 +585,7 @@ describe('Team routes', () => {
             members: [
               {
                 characterId: 'hu-tao',
-                weaponInstanceId: 'uuid-1',
+                collectionWeaponId: 'uuid-1',
                 artifactPlan: {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
@@ -595,9 +595,9 @@ describe('Team routes', () => {
                   secondaryMinorAffixes: ['ATK Percentage', 'HP Percentage'],
                 },
               },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -616,16 +616,16 @@ describe('Team routes', () => {
             members: [
               {
                 characterId: 'hu-tao',
-                weaponInstanceId: 'uuid-1',
+                collectionWeaponId: 'uuid-1',
                 artifactPlan: {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
                   circlet: 'CRIT DMG',
                 },
               },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -644,14 +644,14 @@ describe('Team routes', () => {
             members: [
               {
                 characterId: 'hu-tao',
-                weaponInstanceId: 'uuid-1',
+                collectionWeaponId: 'uuid-1',
                 artifactPlan: {
                   sets: ['crimson-witch-of-flames'],
                 },
               },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );
@@ -670,12 +670,12 @@ describe('Team routes', () => {
             members: [
               {
                 characterId: 'hu-tao',
-                weaponInstanceId: 'uuid-1',
+                collectionWeaponId: 'uuid-1',
                 artifactPlan: {},
               },
-              { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
-              { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
-              { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
+              { characterId: 'xingqiu', collectionWeaponId: 'uuid-2' },
+              { characterId: 'zhongli', collectionWeaponId: 'uuid-3' },
+              { characterId: 'albedo', collectionWeaponId: 'uuid-4' },
             ],
           }),
         );

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -21,8 +21,8 @@ import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-re
 import { negotiateRequestSchema } from '@/middleware/negotiate-request-schema.js';
 import type { ValidatedRequestBodyVariables } from '@/middleware/validate-request-body.js';
 import { validateRequestBody } from '@/middleware/validate-request-body.js';
-import { teamItemV1 } from '@/profiles/alps/team/item-v1.js';
-import { teamPutRequestV1 } from '@/profiles/json-schema/teams/put-request-v1.js';
+import { teamItemV2 } from '@/profiles/alps/team/item-v2.js';
+import { teamPutRequestV2 } from '@/profiles/json-schema/teams/put-request-v2.js';
 import * as Characters from '@/repositories/characters/index.js';
 import * as Teams from '@/repositories/teams/index.js';
 import * as Weapons from '@/repositories/weapons/index.js';
@@ -36,7 +36,7 @@ export const teams = new Hono<{
 
 teams.use('*', auth);
 
-teams.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: teamItemV1 }]));
+teams.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: teamItemV2 }]));
 
 interface UpdateTeamBody {
   name?: string;
@@ -86,8 +86,8 @@ teams.get('/:slot', async (c) => {
 // PUT /api/teams/:slot — Create or update team composition (idempotent upsert)
 teams.put(
   '/:slot',
-  negotiateRequestSchema([teamPutRequestV1]),
-  validateRequestBody([teamPutRequestV1]),
+  negotiateRequestSchema([teamPutRequestV2]),
+  validateRequestBody([teamPutRequestV2]),
   async (c) => {
     const userId = c.get('user').uid;
     const slot = parseSlot(c.req.param('slot'));

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -141,7 +141,7 @@ async function validateMembers(userId: string, members: CollectionTeamMember[]):
   }
 
   // No duplicate weapon instance IDs
-  const weaponIds = members.flatMap((m) => (m.weaponInstanceId ? [m.weaponInstanceId] : []));
+  const weaponIds = members.flatMap((m) => (m.collectionWeaponId ? [m.collectionWeaponId] : []));
   if (new Set(weaponIds).size !== weaponIds.length) {
     throw new HTTPException(400, { message: 'Duplicate weapon instance IDs in team' });
   }
@@ -157,11 +157,11 @@ async function validateMembers(userId: string, members: CollectionTeamMember[]):
       }
 
       // Weapon instance must be in user's collection (if provided)
-      if (member.weaponInstanceId) {
-        const weapon = await Weapons.get(userId, member.weaponInstanceId as UUID);
+      if (member.collectionWeaponId) {
+        const weapon = await Weapons.get(userId, member.collectionWeaponId as UUID);
         if (!weapon) {
           throw new HTTPException(400, {
-            message: `Weapon instance not in collection: ${member.weaponInstanceId}`,
+            message: `Weapon instance not in collection: ${member.collectionWeaponId}`,
           });
         }
       }

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -31,7 +31,7 @@ vi.mock('@genshin/game-data', () => ({
 }));
 
 const FAKE_WEAPON: CollectionWeapon = {
-  weaponInstanceId: 'instance-uuid-1' as UUID,
+  collectionWeaponId: 'instance-uuid-1' as UUID,
   weaponId: 'mistsplitter-reforged',
   refinementLevel: 1,
   createdAt: '2026-01-01T00:00:00.000Z' as CollectionWeapon['createdAt'],
@@ -39,7 +39,7 @@ const FAKE_WEAPON: CollectionWeapon = {
 };
 
 const FAKE_WEAPON_ITEM_DATA = [
-  { name: 'weaponInstanceId', value: 'instance-uuid-1' },
+  { name: 'collectionWeaponId', value: 'instance-uuid-1' },
   { name: 'weaponId', value: 'mistsplitter-reforged' },
   { name: 'refinementLevel', value: 1 },
   { name: 'createdAt', value: '2026-01-01T00:00:00.000Z' },
@@ -361,7 +361,7 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('GET /api/weapons/:weaponInstanceId', () => {
+  describe('GET /api/weapons/:collectionWeaponId', () => {
     let res: Response;
     let body: CollectionDocument;
 
@@ -398,7 +398,7 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('PATCH /api/weapons/:weaponInstanceId', () => {
+  describe('PATCH /api/weapons/:collectionWeaponId', () => {
     let res: Response;
     let body: CollectionDocument;
 
@@ -491,7 +491,7 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('DELETE /api/weapons/:weaponInstanceId', () => {
+  describe('DELETE /api/weapons/:collectionWeaponId', () => {
     it('returns 204 with no body', async () => {
       vi.mocked(Weapons.remove).mockResolvedValue();
 

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { app } from '@/app.js';
 import { verifyToken } from '@/lib/firebase/auth.js';
 import { toMediaTypeString } from '@/middleware/negotiate-content.js';
-import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
+import { weaponItemV2 } from '@/profiles/alps/weapon/item-v2.js';
 import * as Weapons from '@/repositories/weapons/index.js';
 import { FAKE_TOKEN, authedRequest } from '@/test/auth-requests.js';
 
@@ -47,7 +47,7 @@ const FAKE_WEAPON_ITEM_DATA = [
 ];
 
 const EXPECTED_CONTENT_TYPE = toMediaTypeString(
-  { mediaType: COLLECTION_JSON, profile: weaponItemV1 },
+  { mediaType: COLLECTION_JSON, profile: weaponItemV2 },
   'http://localhost',
 );
 

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -16,7 +16,7 @@ import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-re
 import { negotiateRequestSchema } from '@/middleware/negotiate-request-schema.js';
 import type { ValidatedRequestBodyVariables } from '@/middleware/validate-request-body.js';
 import { validateRequestBody } from '@/middleware/validate-request-body.js';
-import { weaponItemV1 } from '@/profiles/alps/weapon/item-v1.js';
+import { weaponItemV2 } from '@/profiles/alps/weapon/item-v2.js';
 import { weaponPatchRequestV1 } from '@/profiles/json-schema/weapons/patch-request-v1.js';
 import { weaponPostRequestV1 } from '@/profiles/json-schema/weapons/post-request-v1.js';
 import * as Weapons from '@/repositories/weapons/index.js';
@@ -30,7 +30,7 @@ export const weapons = new Hono<{
 
 weapons.use('*', auth);
 
-weapons.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: weaponItemV1 }]));
+weapons.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: weaponItemV2 }]));
 
 interface CreateWeaponBody {
   weaponId: string;

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -121,12 +121,12 @@ weapons.post(
   },
 );
 
-// GET /api/weapons/:weaponInstanceId — Get single weapon instance
-weapons.get('/:weaponInstanceId', async (c) => {
+// GET /api/weapons/:collectionWeaponId — Get single weapon instance
+weapons.get('/:collectionWeaponId', async (c) => {
   const userId = c.get('user').uid;
-  const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
+  const collectionWeaponId = c.req.param('collectionWeaponId') as UUID;
 
-  const weapon = await Weapons.get(userId, weaponInstanceId);
+  const weapon = await Weapons.get(userId, collectionWeaponId);
 
   if (!weapon) {
     throw new HTTPException(404, { message: 'Weapon instance not found' });
@@ -146,18 +146,18 @@ weapons.get('/:weaponInstanceId', async (c) => {
   );
 });
 
-// PATCH /api/weapons/:weaponInstanceId — Update weapon instance
+// PATCH /api/weapons/:collectionWeaponId — Update weapon instance
 weapons.patch(
-  '/:weaponInstanceId',
+  '/:collectionWeaponId',
   negotiateRequestSchema([weaponPatchRequestV1]),
   validateRequestBody([weaponPatchRequestV1]),
   async (c) => {
     const userId = c.get('user').uid;
-    const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
+    const collectionWeaponId = c.req.param('collectionWeaponId') as UUID;
 
     const { refinementLevel } = c.get('validatedBody') as UpdateWeaponBody;
 
-    const weapon = await Weapons.update(userId, weaponInstanceId, refinementLevel);
+    const weapon = await Weapons.update(userId, collectionWeaponId, refinementLevel);
 
     if (!weapon) {
       throw new HTTPException(404, { message: 'Weapon instance not found' });
@@ -178,12 +178,12 @@ weapons.patch(
   },
 );
 
-// DELETE /api/weapons/:weaponInstanceId — Delete weapon instance
-weapons.delete('/:weaponInstanceId', async (c) => {
+// DELETE /api/weapons/:collectionWeaponId — Delete weapon instance
+weapons.delete('/:collectionWeaponId', async (c) => {
   const userId = c.get('user').uid;
-  const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
+  const collectionWeaponId = c.req.param('collectionWeaponId') as UUID;
 
-  await Weapons.remove(userId, weaponInstanceId);
+  await Weapons.remove(userId, collectionWeaponId);
 
   return c.body(null, 204);
 });

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-api.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-api.ts
@@ -25,7 +25,7 @@ export function parseWeaponCollectionResponse(response: unknown): WeaponRecord {
 
   for (const item of response.collection.items) {
     const weapon = deserialiseWeapon(item);
-    record[weapon.weaponInstanceId] = weapon;
+    record[weapon.collectionWeaponId] = weapon;
   }
 
   return record;

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-store.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-store.test.ts
@@ -8,12 +8,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { useWeaponCollectionStore } from './use-weapon-collection-store';
 
 function makeWeapon(
-  weaponInstanceId: string,
+  collectionWeaponId: string,
   weaponId: string,
   refinementLevel = 1,
 ): CollectionWeapon {
   return {
-    weaponInstanceId: weaponInstanceId as CollectionWeaponId,
+    collectionWeaponId: collectionWeaponId as CollectionWeaponId,
     weaponId: weaponId as Weapon['id'],
     refinementLevel,
     createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-store.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-store.ts
@@ -27,7 +27,7 @@ export const useWeaponCollectionStore = create<WeaponCollectionState>()((set, ge
     set((state) => ({
       weapons: {
         ...state.weapons,
-        [weapon.weaponInstanceId]: weapon,
+        [weapon.collectionWeaponId]: weapon,
       },
     }));
   },

--- a/apps/web/src/features/collection/weapons/weapon-instance-sidebar.tsx
+++ b/apps/web/src/features/collection/weapons/weapon-instance-sidebar.tsx
@@ -100,7 +100,7 @@ export function WeaponInstanceSidebar({
             .sort((a, b) => b.refinementLevel - a.refinementLevel)
             .map((instance, index) => (
               <div
-                key={instance.weaponInstanceId}
+                key={instance.collectionWeaponId}
                 className="flex items-center gap-3 rounded-lg border border-border bg-card p-3"
               >
                 <div className="min-w-0 flex-1">
@@ -114,7 +114,7 @@ export function WeaponInstanceSidebar({
                     <button
                       key={level}
                       type="button"
-                      onClick={() => onRefinementChange(instance.weaponInstanceId, level)}
+                      onClick={() => onRefinementChange(instance.collectionWeaponId, level)}
                       className={cn(
                         'h-7 w-7 rounded text-xs font-bold tabular-nums transition-colors',
                         level === instance.refinementLevel
@@ -131,7 +131,7 @@ export function WeaponInstanceSidebar({
 
                 <button
                   type="button"
-                  onClick={() => onRemove(instance.weaponInstanceId)}
+                  onClick={() => onRemove(instance.collectionWeaponId)}
                   className="shrink-0 rounded-md p-1 text-destructive transition-opacity hover:bg-destructive hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
                   aria-label={`Remove instance ${index + 1}`}
                 >

--- a/apps/web/src/features/teams/team-planner.tsx
+++ b/apps/web/src/features/teams/team-planner.tsx
@@ -118,7 +118,9 @@ export function TeamPlanner({
             member={member}
             collectionCharacter={member ? getCharacter(member.characterId) : undefined}
             collectionWeapon={
-              member?.weaponInstanceId ? getCollectionWeapon(member.weaponInstanceId) : undefined
+              member?.collectionWeaponId
+                ? getCollectionWeapon(member.collectionWeaponId)
+                : undefined
             }
             selected={selectedMemberIndex === i}
             onSelect={onMemberSelect ? () => onMemberSelect(i) : undefined}

--- a/apps/web/src/features/teams/team-strip.tsx
+++ b/apps/web/src/features/teams/team-strip.tsx
@@ -61,7 +61,9 @@ export function TeamStrip({
               member={member}
               collectionCharacter={member ? getCharacter(member.characterId) : undefined}
               collectionWeapon={
-                member?.weaponInstanceId ? getCollectionWeapon(member.weaponInstanceId) : undefined
+                member?.collectionWeaponId
+                  ? getCollectionWeapon(member.collectionWeaponId)
+                  : undefined
               }
             />
           </button>

--- a/apps/web/src/features/teams/use-team-store.test.ts
+++ b/apps/web/src/features/teams/use-team-store.test.ts
@@ -60,7 +60,7 @@ describe('useTeamStore', () => {
       useTeamStore.getState().assignCharacter(2, 0, 'amber');
 
       const team2 = useTeamStore.getState().teams[2];
-      expect(team2.members[0]?.weaponInstanceId).toBe(weaponId);
+      expect(team2.members[0]?.collectionWeaponId).toBe(weaponId);
     });
   });
 
@@ -87,7 +87,7 @@ describe('useTeamStore', () => {
       useTeamStore.getState().assignCharacter(1, 0, 'amber');
       useTeamStore.getState().assignWeapon(1, 0, weaponId);
 
-      expect(useTeamStore.getState().teams[1].members[0]?.weaponInstanceId).toBe(weaponId);
+      expect(useTeamStore.getState().teams[1].members[0]?.collectionWeaponId).toBe(weaponId);
     });
 
     it('does nothing if no character occupies the position', () => {
@@ -105,7 +105,7 @@ describe('useTeamStore', () => {
       useTeamStore.getState().assignWeapon(1, 0, weaponId);
       useTeamStore.getState().removeWeapon(1, 0);
 
-      expect(useTeamStore.getState().teams[1].members[0]?.weaponInstanceId).toBeUndefined();
+      expect(useTeamStore.getState().teams[1].members[0]?.collectionWeaponId).toBeUndefined();
     });
   });
 

--- a/apps/web/src/features/teams/use-team-store.ts
+++ b/apps/web/src/features/teams/use-team-store.ts
@@ -44,12 +44,12 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
 
     // Auto-populate weapon from another team where this character already has one equipped.
     const allTeams = get().teams;
-    let existingWeaponId: CollectionTeamMember['weaponInstanceId'];
+    let existingWeaponId: CollectionTeamMember['collectionWeaponId'];
     for (const other of Object.values(allTeams)) {
       if (other.slot === slot) continue;
       for (const member of other.members) {
-        if (member?.characterId === characterId && member.weaponInstanceId) {
-          existingWeaponId = member.weaponInstanceId;
+        if (member?.characterId === characterId && member.collectionWeaponId) {
+          existingWeaponId = member.collectionWeaponId;
           break;
         }
       }
@@ -63,7 +63,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
           ...state.teams[slot],
           members: state.teams[slot].members.map((m, i) =>
             i === memberIndex
-              ? { characterId, ...(existingWeaponId && { weaponInstanceId: existingWeaponId }) }
+              ? { characterId, ...(existingWeaponId && { collectionWeaponId: existingWeaponId }) }
               : m,
           ) as CollectionTeamMembers,
         },
@@ -97,7 +97,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
         [slot]: {
           ...state.teams[slot],
           members: state.teams[slot].members.map((m, i) =>
-            i === memberIndex && m ? { ...m, weaponInstanceId: collectionWeaponId } : m,
+            i === memberIndex && m ? { ...m, collectionWeaponId: collectionWeaponId } : m,
           ) as CollectionTeamMembers,
         },
       },
@@ -114,7 +114,7 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
         [slot]: {
           ...state.teams[slot],
           members: state.teams[slot].members.map((m, i) =>
-            i === memberIndex && m ? { ...m, weaponInstanceId: undefined } : m,
+            i === memberIndex && m ? { ...m, collectionWeaponId: undefined } : m,
           ) as CollectionTeamMembers,
         },
       },

--- a/apps/web/src/features/teams/weapon-pool.tsx
+++ b/apps/web/src/features/teams/weapon-pool.tsx
@@ -29,8 +29,8 @@ function buildEquippedWeapons(
   const map = new Map<CollectionWeaponId, string>();
   for (const team of Object.values(teams)) {
     for (const member of team.members) {
-      if (member?.weaponInstanceId) {
-        map.set(member.weaponInstanceId, member.characterId);
+      if (member?.collectionWeaponId) {
+        map.set(member.collectionWeaponId, member.characterId);
       }
     }
   }
@@ -159,20 +159,20 @@ export function WeaponPool({
           {filteredWeapons.flatMap((weapon) => {
             const instances = instancesByWeaponId.get(weapon.id) ?? [];
             return instances.map((instance) => {
-              const equippedBy = equippedWeapons.get(instance.weaponInstanceId);
+              const equippedBy = equippedWeapons.get(instance.collectionWeaponId);
               const equippedByOther = equippedBy !== undefined && equippedBy !== currentCharacterId;
               return (
                 <PoolWeaponCard
-                  key={instance.weaponInstanceId}
+                  key={instance.collectionWeaponId}
                   weapon={weapon}
                   refinementLevel={instance.refinementLevel}
-                  selected={instance.weaponInstanceId === selectedCollectionWeaponId}
+                  selected={instance.collectionWeaponId === selectedCollectionWeaponId}
                   equipped={equippedByOther}
                   onClick={() => {
-                    if (instance.weaponInstanceId === selectedCollectionWeaponId) {
+                    if (instance.collectionWeaponId === selectedCollectionWeaponId) {
                       onClear();
                     } else {
-                      onSelect(instance.weaponInstanceId);
+                      onSelect(instance.collectionWeaponId);
                     }
                   }}
                 />

--- a/apps/web/src/pages/teams-page.tsx
+++ b/apps/web/src/pages/teams-page.tsx
@@ -187,7 +187,7 @@ export function TeamsPage(): JSX.Element {
                       key={selectedMemberWeaponType}
                       collectionWeapons={collectionWeapons}
                       weaponType={selectedMemberWeaponType}
-                      selectedCollectionWeaponId={selectedMember.weaponInstanceId}
+                      selectedCollectionWeaponId={selectedMember.collectionWeaponId}
                       slot={selectedSlot}
                       memberIndex={selectedMemberIndex}
                       onSelect={handleWeaponSelect}

--- a/packages/domain/src/collection-team-member.ts
+++ b/packages/domain/src/collection-team-member.ts
@@ -11,10 +11,10 @@ import type { UUID } from './uuid.js';
  * equipped weapon and artifacts.
  *
  * Character details should be looked up from @genshin/game-data using characterId.
- * The weaponInstanceId references a specific weapon instance in the user's collection.
+ * The collectionWeaponId references a specific weapon instance in the user's collection.
  */
 export interface CollectionTeamMember {
   characterId: Character['id'];
-  weaponInstanceId?: UUID;
+  collectionWeaponId?: UUID;
   artifactPlan?: ArtifactPlan;
 }

--- a/packages/domain/src/collection-weapon.test.ts
+++ b/packages/domain/src/collection-weapon.test.ts
@@ -15,7 +15,7 @@ import type { UUID } from './uuid.js';
 const VALID_TIMESTAMP = '2024-01-15T12:00:00Z' as ISOTimestamp;
 
 const VALID_WEAPON = {
-  weaponInstanceId: 'abc-123' as UUID,
+  collectionWeaponId: 'abc-123' as UUID,
   weaponId: 'mistsplitter-reforged',
   refinementLevel: 1,
   createdAt: VALID_TIMESTAMP,
@@ -69,9 +69,9 @@ describe('assertCollectionWeapon', () => {
     expect(() => assertCollectionWeapon('string')).toThrow(TypeError);
   });
 
-  it('throws for missing weaponInstanceId', () => {
-    const { weaponInstanceId: _, ...rest } = VALID_WEAPON;
-    expect(() => assertCollectionWeapon(rest)).toThrow(/weaponInstanceId/);
+  it('throws for missing collectionWeaponId', () => {
+    const { collectionWeaponId: _, ...rest } = VALID_WEAPON;
+    expect(() => assertCollectionWeapon(rest)).toThrow(/collectionWeaponId/);
   });
 
   it('throws for missing weaponId', () => {

--- a/packages/domain/src/collection-weapon.ts
+++ b/packages/domain/src/collection-weapon.ts
@@ -12,14 +12,14 @@ export const MIN_REFINEMENT_LEVEL = 1;
 export const MAX_REFINEMENT_LEVEL = 5;
 
 export interface CollectionWeapon {
-  weaponInstanceId: UUID;
+  collectionWeaponId: UUID;
   weaponId: Weapon['id'];
   refinementLevel: number;
   createdAt: ISOTimestamp;
   updatedAt: ISOTimestamp;
 }
 
-export type CollectionWeaponId = CollectionWeapon['weaponInstanceId'];
+export type CollectionWeaponId = CollectionWeapon['collectionWeaponId'];
 
 export function isValidRefinementLevel(value: unknown): value is number {
   return (
@@ -37,9 +37,9 @@ export function assertCollectionWeapon(value: unknown): asserts value is Collect
     );
   }
   const obj = value as Record<string, unknown>;
-  if (typeof obj.weaponInstanceId !== 'string') {
+  if (typeof obj.collectionWeaponId !== 'string') {
     throw new TypeError(
-      `CollectionWeapon.weaponInstanceId must be a string, got: ${JSON.stringify(obj.weaponInstanceId)}`,
+      `CollectionWeapon.collectionWeaponId must be a string, got: ${JSON.stringify(obj.collectionWeaponId)}`,
     );
   }
   if (typeof obj.weaponId !== 'string') {

--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -12,7 +12,7 @@ const BASE_URL = 'http://localhost:8080';
 const VALID_TIMESTAMP = '2024-01-15T12:00:00Z' as ISOTimestamp;
 
 const VALID_MEMBERS: CollectionTeamMembers = [
-  { characterId: 'columbina', weaponInstanceId: 'wep-001' as UUID },
+  { characterId: 'columbina', collectionWeaponId: 'wep-001' as UUID },
   { characterId: 'durin' },
   null,
   null,
@@ -58,7 +58,7 @@ describe('team serialisation round-trip', () => {
   it('preserves weapon instance IDs on members through round-trip', () => {
     const item = serialiseTeam(VALID_TEAM, BASE_URL);
     const result = deserialiseTeam(item);
-    expect(result.members[0]?.weaponInstanceId).toBe('wep-001');
+    expect(result.members[0]?.collectionWeaponId).toBe('wep-001');
   });
 
   it('preserves artifact plans on members through round-trip', () => {

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -100,9 +100,9 @@ function deserialiseCollectionTeamMember(value: unknown, index: number): Collect
       `members[${index}].characterId must be a string, got: ${JSON.stringify(raw.characterId)}`,
     );
   }
-  if (raw.weaponInstanceId !== undefined && typeof raw.weaponInstanceId !== 'string') {
+  if (raw.collectionWeaponId !== undefined && typeof raw.collectionWeaponId !== 'string') {
     throw new TypeError(
-      `members[${index}].weaponInstanceId must be a string, got: ${JSON.stringify(raw.weaponInstanceId)}`,
+      `members[${index}].collectionWeaponId must be a string, got: ${JSON.stringify(raw.collectionWeaponId)}`,
     );
   }
   if (raw.artifactPlan !== undefined) {

--- a/packages/domain/src/representations/collection-json/weapons.test.ts
+++ b/packages/domain/src/representations/collection-json/weapons.test.ts
@@ -12,7 +12,7 @@ const BASE_URL = 'http://localhost:8080';
 const VALID_TIMESTAMP = '2024-01-15T12:00:00Z' as ISOTimestamp;
 
 const VALID_WEAPON: CollectionWeapon = {
-  weaponInstanceId: 'wep-001' as UUID,
+  collectionWeaponId: 'wep-001' as UUID,
   weaponId: 'mistsplitter-reforged',
   refinementLevel: 3,
   createdAt: VALID_TIMESTAMP,

--- a/packages/domain/src/representations/collection-json/weapons.ts
+++ b/packages/domain/src/representations/collection-json/weapons.ts
@@ -33,7 +33,7 @@ const WEAPON_TEMPLATE: Template = {
 };
 
 export function weaponItemHref(baseUrl: string, weapon: CollectionWeapon): string {
-  return `${baseUrl}/api/weapons/${weapon.weaponInstanceId}`;
+  return `${baseUrl}/api/weapons/${weapon.collectionWeaponId}`;
 }
 
 export function serialiseWeapon(weapon: CollectionWeapon, baseUrl: string): Item {
@@ -48,7 +48,7 @@ export function serialiseWeapon(weapon: CollectionWeapon, baseUrl: string): Item
   return buildItem(
     weaponItemHref(baseUrl, weapon),
     [
-      { name: 'weaponInstanceId', value: weapon.weaponInstanceId },
+      { name: 'collectionWeaponId', value: weapon.collectionWeaponId },
       { name: 'weaponId', value: weapon.weaponId },
       { name: 'refinementLevel', value: weapon.refinementLevel },
       { name: 'createdAt', value: weapon.createdAt },

--- a/packages/domain/src/team-validation.test.ts
+++ b/packages/domain/src/team-validation.test.ts
@@ -38,8 +38,8 @@ describe('validateTeam', () => {
     const issues = validateTeam({
       name: 'Dupe weapons',
       members: [
-        { characterId: 'columbina', weaponInstanceId: 'weapon-1' as UUID },
-        { characterId: 'durin', weaponInstanceId: 'weapon-1' as UUID },
+        { characterId: 'columbina', collectionWeaponId: 'weapon-1' as UUID },
+        { characterId: 'durin', collectionWeaponId: 'weapon-1' as UUID },
         null,
         null,
       ],
@@ -51,7 +51,7 @@ describe('validateTeam', () => {
   describe('with ownership context', () => {
     const context: TeamValidationContext = {
       ownedCharacterIds: new Set(['columbina', 'durin']),
-      ownedWeaponInstanceIds: new Set(['weapon-1']),
+      ownedCollectionWeaponIds: new Set(['weapon-1']),
     };
 
     it('returns no issues when all characters are owned', () => {
@@ -82,7 +82,7 @@ describe('validateTeam', () => {
         {
           name: 'Bad weapon',
           members: [
-            { characterId: 'columbina', weaponInstanceId: 'weapon-999' as UUID },
+            { characterId: 'columbina', collectionWeaponId: 'weapon-999' as UUID },
             null,
             null,
             null,
@@ -123,7 +123,7 @@ describe('validateTeams', () => {
 
   it('allows the same character with the same weapon on different teams', () => {
     const members: CollectionTeamMembers = [
-      { characterId: 'columbina', weaponInstanceId: 'weapon-1' as UUID },
+      { characterId: 'columbina', collectionWeaponId: 'weapon-1' as UUID },
       null,
       null,
       null,
@@ -134,7 +134,7 @@ describe('validateTeams', () => {
 
   it('detects weapon conflicts across teams', () => {
     const current: CollectionTeamMembers = [
-      { characterId: 'columbina', weaponInstanceId: 'weapon-1' as UUID },
+      { characterId: 'columbina', collectionWeaponId: 'weapon-1' as UUID },
       null,
       null,
       null,
@@ -142,7 +142,7 @@ describe('validateTeams', () => {
     const otherTeam = {
       slot: 2 as TeamSlot,
       members: [
-        { characterId: 'durin', weaponInstanceId: 'weapon-1' as UUID },
+        { characterId: 'durin', collectionWeaponId: 'weapon-1' as UUID },
         null,
         null,
         null,
@@ -155,7 +155,7 @@ describe('validateTeams', () => {
 
   it('ignores the same team slot when checking other teams', () => {
     const members: CollectionTeamMembers = [
-      { characterId: 'columbina', weaponInstanceId: 'weapon-1' as UUID },
+      { characterId: 'columbina', collectionWeaponId: 'weapon-1' as UUID },
       null,
       null,
       null,

--- a/packages/domain/src/team-validation.ts
+++ b/packages/domain/src/team-validation.ts
@@ -27,8 +27,8 @@ import type { CollectionTeamMembers, TeamSlot } from './collection-team.js';
 export interface TeamValidationContext {
   /** Character IDs the user owns. */
   ownedCharacterIds: ReadonlySet<string>;
-  /** Weapon instance IDs the user owns. */
-  ownedWeaponInstanceIds: ReadonlySet<string>;
+  /** Collection weapon IDs the user owns. */
+  ownedCollectionWeaponIds: ReadonlySet<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,11 +68,14 @@ export function validateTeam(
           issue(`Character not in collection: ${member.characterId}`, `members[${i}].characterId`),
         );
       }
-      if (member.weaponInstanceId && !context.ownedWeaponInstanceIds.has(member.weaponInstanceId)) {
+      if (
+        member.collectionWeaponId &&
+        !context.ownedCollectionWeaponIds.has(member.collectionWeaponId)
+      ) {
         issues.push(
           issue(
-            `Weapon instance not in collection: ${member.weaponInstanceId}`,
-            `members[${i}].weaponInstanceId`,
+            `Weapon instance not in collection: ${member.collectionWeaponId}`,
+            `members[${i}].collectionWeaponId`,
           ),
         );
       }
@@ -83,16 +86,16 @@ export function validateTeam(
   const seenWeapons = new Set<string>();
   for (const [i, member] of team.members.entries()) {
     if (member === null) continue;
-    if (member.weaponInstanceId) {
-      if (seenWeapons.has(member.weaponInstanceId)) {
+    if (member.collectionWeaponId) {
+      if (seenWeapons.has(member.collectionWeaponId)) {
         issues.push(
           issue(
-            `Duplicate weapon instance ID: ${member.weaponInstanceId}`,
-            `members[${i}].weaponInstanceId`,
+            `Duplicate weapon instance ID: ${member.collectionWeaponId}`,
+            `members[${i}].collectionWeaponId`,
           ),
         );
       }
-      seenWeapons.add(member.weaponInstanceId);
+      seenWeapons.add(member.collectionWeaponId);
     }
   }
 
@@ -131,26 +134,26 @@ export function validateTeams(
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
-  // Build a map of weaponInstanceId → characterId from other teams.
+  // Build a map of collectionWeaponId → characterId from other teams.
   const equippedWeapons = new Map<string, string>();
   for (const team of allTeams) {
     if (team.slot === slot) continue;
     for (const member of team.members) {
-      if (member?.weaponInstanceId) {
-        equippedWeapons.set(member.weaponInstanceId, member.characterId);
+      if (member?.collectionWeaponId) {
+        equippedWeapons.set(member.collectionWeaponId, member.characterId);
       }
     }
   }
 
   for (const [i, member] of currentMembers.entries()) {
-    if (member === null || !member.weaponInstanceId) continue;
+    if (member === null || !member.collectionWeaponId) continue;
 
-    const existingOwner = equippedWeapons.get(member.weaponInstanceId);
+    const existingOwner = equippedWeapons.get(member.collectionWeaponId);
     if (existingOwner && existingOwner !== member.characterId) {
       issues.push(
         issue(
-          `Weapon instance ${member.weaponInstanceId} is already equipped by character ${existingOwner}`,
-          `members[${i}].weaponInstanceId`,
+          `Weapon instance ${member.collectionWeaponId} is already equipped by character ${existingOwner}`,
+          `members[${i}].collectionWeaponId`,
         ),
       );
     }


### PR DESCRIPTION
> **Blocked by #920 — do not merge.** As-is, this rename breaks every client/API version-skew combination during rollout (see #920's break matrix): our web client sends no `profile` parameter, so the frozen v1 profiles are inert and a stale bundle gets the new body shape and throws (or 422s on write), in both skew directions. #920 builds the safe-rollout machinery this depends on; land it first, then rebase this.

## Summary

Aligns the identifier field with its type: `CollectionWeapon`'s id was already aliased `CollectionWeaponId`, but the field was still `weaponInstanceId`. Renamed across the domain model, Collection+JSON representations, API routes (incl. the `:collectionWeaponId` URL param), repositories, and web consumers.

Closes #628

## Gotchas

- `TeamMember.weaponInstanceId` is a *stored* Firestore field, so the rename lands as teams schema **v2** with an `up`-migration from v1 — not an in-place edit, which the schema-compat gate rejects (a released version may only widen). v0/v1 schemas and the `v1.json` snapshot stay frozen; legacy documents migrate transparently on read (unit test covers v1→v2).
- The published ALPS / JSON-Schema profiles get the same immutability treatment (DSGEP-003): `item-v1` / `put-request-v1` restored to their shipped shape, **v2** profiles carrying `collectionWeaponId` published, routes serve/validate v2, v1 stays registered. But this only completes the "publish v2" step — the full transition machinery (cross-version serving, non-pinning-client handling, deploy ordering) is **#920**, which this is blocked on. Until then the v2 profiles are documentation, not rollout safety.
- The weapons repository's identifier is a Firestore *document id* only (never a stored field), so its rename is code-level — no weapons schema field change beyond the ALPS item representation.