### PR TITLE
feat(web): add "Copy debug info" footer action

### DIFF
--- a/apps/web/src/components/footer.test.tsx
+++ b/apps/web/src/components/footer.test.tsx
@@ -39,8 +39,8 @@ describe('Footer', () => {
     }
   });
 
-  it('pre-fills the bug report link with page and environment details', () => {
-    renderFooter({ uid: 'abc' } as FirebaseUser, '/weapons');
+  it('pre-fills the bug report link with page and auth state', () => {
+    renderFooter({ uid: 'signed-in-user' } as FirebaseUser, '/weapons');
 
     const href = screen.getByRole('link', { name: 'Report an issue' }).getAttribute('href') ?? '';
     const params = new URL(href).searchParams;
@@ -48,5 +48,14 @@ describe('Footer', () => {
     expect(params.get('template')).toBe('bug-report.yml');
     expect(params.get('url')).toContain('/weapons');
     expect(params.get('environment')).toContain('Authenticated: yes');
+  });
+
+  it('never leaks the signed-in user identity into the link', () => {
+    renderFooter({ uid: 'secret-uid-xyz', email: 'reporter@example.com' } as FirebaseUser, '/');
+
+    const href = screen.getByRole('link', { name: 'Report an issue' }).getAttribute('href') ?? '';
+
+    expect(href).not.toContain('secret-uid-xyz');
+    expect(href).not.toContain('reporter@example.com');
   });
 });

--- a/apps/web/src/components/footer.test.tsx
+++ b/apps/web/src/components/footer.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import type { User as FirebaseUser } from 'firebase/auth';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -40,19 +39,14 @@ describe('Footer', () => {
     }
   });
 
-  it('copies debug info to the clipboard reflecting route and auth state', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
-
+  it('pre-fills the bug report link with page and environment details', () => {
     renderFooter({ uid: 'abc' } as FirebaseUser, '/weapons');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Copy debug info' }));
+    const href = screen.getByRole('link', { name: 'Report an issue' }).getAttribute('href') ?? '';
+    const params = new URL(href).searchParams;
 
-    expect(writeText).toHaveBeenCalledOnce();
-    const copied = writeText.mock.calls[0][0] as string;
-    expect(copied).toContain('Route: /weapons');
-    expect(copied).toContain('Authenticated: yes');
-
-    vi.unstubAllGlobals();
+    expect(params.get('template')).toBe('bug-report.yml');
+    expect(params.get('url')).toContain('/weapons');
+    expect(params.get('environment')).toContain('Authenticated: yes');
   });
 });

--- a/apps/web/src/components/footer.test.tsx
+++ b/apps/web/src/components/footer.test.tsx
@@ -2,18 +2,57 @@
 // SPDX-License-Identifier: MIT
 
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import type { User as FirebaseUser } from 'firebase/auth';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
 
-import { Footer } from './footer';
+import { AuthContext } from '@/features/auth/auth-context';
+
+vi.mock('@/lib/firebase', () => ({
+  auth: { currentUser: null },
+}));
+
+const { Footer } = await import('./footer');
+
+function renderFooter(
+  user: FirebaseUser | null = null,
+  initialRoute = '/',
+): ReturnType<typeof render> {
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <AuthContext value={{ user, loading: false }}>{children}</AuthContext>
+    </MemoryRouter>
+  );
+
+  return render(<Footer />, { wrapper });
+}
 
 describe('Footer', () => {
   it('opens links in new tabs with proper security attributes', () => {
-    render(<Footer />);
+    renderFooter();
 
     const links = screen.getAllByRole('link');
     for (const link of links) {
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     }
+  });
+
+  it('copies debug info to the clipboard reflecting route and auth state', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
+
+    renderFooter({ uid: 'abc' } as FirebaseUser, '/weapons');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy debug info' }));
+
+    expect(writeText).toHaveBeenCalledOnce();
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('Route: /weapons');
+    expect(copied).toContain('Authenticated: yes');
+
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -3,12 +3,42 @@
 
 import { GAME_DATA_VERSION } from '@genshin/game-data';
 import type { JSX } from 'react';
+import { useLocation } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { Container } from '@/components/container';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/features/auth';
+import { formatDebugInfo } from '@/lib/debug-info';
 
 const GITHUB_REPO = 'https://github.com/dungeon-studio/genshin.dungeon.studio';
 
 export function Footer(): JSX.Element {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  async function copyDebugInfo(): Promise<void> {
+    const debugInfo = formatDebugInfo({
+      appVersion: __APP_VERSION__,
+      buildSha: __BUILD_SHA__,
+      gameDataVersion: GAME_DATA_VERSION,
+      route: location.pathname,
+      authenticated: user !== null,
+      userAgent: navigator.userAgent,
+      platform: navigator.platform,
+      screenWidth: window.screen.width,
+      screenHeight: window.screen.height,
+      pixelRatio: window.devicePixelRatio,
+    });
+
+    try {
+      await navigator.clipboard.writeText(debugInfo);
+      toast.success('Debug info copied to clipboard.');
+    } catch {
+      toast.error('Could not copy debug info.');
+    }
+  }
+
   return (
     <footer className="border-t border-border bg-muted py-8">
       <Container className="text-center text-sm text-muted-foreground">
@@ -63,6 +93,16 @@ export function Footer(): JSX.Element {
               >
                 GitHub
               </a>
+            </li>
+            <li>
+              <Button
+                type="button"
+                variant="link"
+                onClick={copyDebugInfo}
+                className="h-auto p-0 text-sm font-normal text-muted-foreground"
+              >
+                Copy debug info
+              </Button>
             </li>
           </ul>
         </nav>

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -4,12 +4,10 @@
 import { GAME_DATA_VERSION } from '@genshin/game-data';
 import type { JSX } from 'react';
 import { useLocation } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { Container } from '@/components/container';
-import { Button } from '@/components/ui/button';
 import { useAuth } from '@/features/auth';
-import { formatDebugInfo } from '@/lib/debug-info';
+import { buildBugReportUrl } from '@/lib/debug-info';
 
 const GITHUB_REPO = 'https://github.com/dungeon-studio/genshin.dungeon.studio';
 
@@ -17,27 +15,18 @@ export function Footer(): JSX.Element {
   const { user } = useAuth();
   const location = useLocation();
 
-  async function copyDebugInfo(): Promise<void> {
-    const debugInfo = formatDebugInfo({
-      appVersion: __APP_VERSION__,
-      buildSha: __BUILD_SHA__,
-      gameDataVersion: GAME_DATA_VERSION,
-      route: location.pathname,
-      authenticated: user !== null,
-      userAgent: navigator.userAgent,
-      platform: navigator.platform,
-      screenWidth: window.screen.width,
-      screenHeight: window.screen.height,
-      pixelRatio: window.devicePixelRatio,
-    });
-
-    try {
-      await navigator.clipboard.writeText(debugInfo);
-      toast.success('Debug info copied to clipboard.');
-    } catch {
-      toast.error('Could not copy debug info.');
-    }
-  }
+  const pageUrl = window.location.origin + location.pathname + location.search + location.hash;
+  const reportUrl = buildBugReportUrl(`${GITHUB_REPO}/issues/new`, pageUrl, {
+    appVersion: __APP_VERSION__,
+    buildSha: __BUILD_SHA__,
+    gameDataVersion: GAME_DATA_VERSION,
+    authenticated: user !== null,
+    userAgent: navigator.userAgent,
+    platform: navigator.platform,
+    screenWidth: window.screen.width,
+    screenHeight: window.screen.height,
+    pixelRatio: window.devicePixelRatio,
+  });
 
   return (
     <footer className="border-t border-border bg-muted py-8">
@@ -46,7 +35,7 @@ export function Footer(): JSX.Element {
           <ul className="flex flex-wrap justify-center gap-x-6 gap-y-2">
             <li>
               <a
-                href={`${GITHUB_REPO}/issues/new?template=bug-report.yml`}
+                href={reportUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline-offset-4 hover:underline"
@@ -93,16 +82,6 @@ export function Footer(): JSX.Element {
               >
                 GitHub
               </a>
-            </li>
-            <li>
-              <Button
-                type="button"
-                variant="link"
-                onClick={copyDebugInfo}
-                className="h-auto p-0 text-sm font-normal text-muted-foreground"
-              >
-                Copy debug info
-              </Button>
             </li>
           </ul>
         </nav>

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -16,3 +16,6 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+declare const __APP_VERSION__: string;
+declare const __BUILD_SHA__: string;

--- a/apps/web/src/lib/debug-info.test.ts
+++ b/apps/web/src/lib/debug-info.test.ts
@@ -19,31 +19,26 @@ const info: DebugInfo = {
 };
 
 describe('formatDebugInfo', () => {
-  it('renders the version and build sha together', () => {
-    expect(formatDebugInfo(info)).toContain('App version: 0.1.0 (d4fbd16)');
+  it('reports authentication as yes/no', () => {
+    expect(formatDebugInfo({ ...info, authenticated: false })).toContain('Authenticated: no');
+    expect(formatDebugInfo({ ...info, authenticated: true })).toContain('Authenticated: yes');
   });
 
-  it('renders authentication as yes/no without identifying the user', () => {
-    const anon = formatDebugInfo({ ...info, authenticated: false });
-    const signedIn = formatDebugInfo({ ...info, authenticated: true });
-
-    expect(anon).toContain('Authenticated: no');
-    expect(signedIn).toContain('Authenticated: yes');
-    expect(signedIn).not.toContain('uid');
-  });
-
-  it('includes every requested environment detail', () => {
+  it('carries every field a triager needs', () => {
     const text = formatDebugInfo(info);
 
-    expect(text).toContain('Game data: 5.3');
-    expect(text).toContain('Screen: 1920×1080 @2x');
-    expect(text).toContain('Platform: Linux x86_64');
-    expect(text).toContain('User agent: Mozilla/5.0 (X11; Linux x86_64)');
+    // Each value flows through so a report is self-contained; label wording is
+    // not pinned.
+    for (const value of ['0.1.0', 'd4fbd16', '5.3', '1920', '1080', 'Linux x86_64']) {
+      expect(text).toContain(value);
+    }
   });
 });
 
 describe('buildBugReportUrl', () => {
-  it('pre-fills the template, page url, and environment fields', () => {
+  it('keys prefill params to the bug-report template field ids', () => {
+    // Wrong keys => GitHub silently drops the prefill, so the field ids are the
+    // property under test.
     const url = new URL(
       buildBugReportUrl('https://github.com/o/r/issues/new', 'https://app.example/teams', info),
     );

--- a/apps/web/src/lib/debug-info.test.ts
+++ b/apps/web/src/lib/debug-info.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { formatDebugInfo } from './debug-info';
+import type { DebugInfo } from './debug-info';
+
+const info: DebugInfo = {
+  appVersion: '0.1.0',
+  buildSha: 'd4fbd16',
+  gameDataVersion: '5.3',
+  route: '/teams',
+  authenticated: false,
+  userAgent: 'Mozilla/5.0 (X11; Linux x86_64)',
+  platform: 'Linux x86_64',
+  screenWidth: 1920,
+  screenHeight: 1080,
+  pixelRatio: 2,
+};
+
+describe('formatDebugInfo', () => {
+  it('renders the version and build sha together', () => {
+    expect(formatDebugInfo(info)).toContain('App version: 0.1.0 (d4fbd16)');
+  });
+
+  it('renders authentication as yes/no without identifying the user', () => {
+    const anon = formatDebugInfo({ ...info, authenticated: false });
+    const signedIn = formatDebugInfo({ ...info, authenticated: true });
+
+    expect(anon).toContain('Authenticated: no');
+    expect(signedIn).toContain('Authenticated: yes');
+    expect(signedIn).not.toContain('uid');
+  });
+
+  it('includes every requested environment detail', () => {
+    const text = formatDebugInfo(info);
+
+    expect(text).toContain('Game data: 5.3');
+    expect(text).toContain('Route: /teams');
+    expect(text).toContain('Screen: 1920×1080 @2x');
+    expect(text).toContain('Platform: Linux x86_64');
+    expect(text).toContain('User agent: Mozilla/5.0 (X11; Linux x86_64)');
+  });
+});

--- a/apps/web/src/lib/debug-info.test.ts
+++ b/apps/web/src/lib/debug-info.test.ts
@@ -3,14 +3,13 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { formatDebugInfo } from './debug-info';
+import { buildBugReportUrl, formatDebugInfo } from './debug-info';
 import type { DebugInfo } from './debug-info';
 
 const info: DebugInfo = {
   appVersion: '0.1.0',
   buildSha: 'd4fbd16',
   gameDataVersion: '5.3',
-  route: '/teams',
   authenticated: false,
   userAgent: 'Mozilla/5.0 (X11; Linux x86_64)',
   platform: 'Linux x86_64',
@@ -37,9 +36,20 @@ describe('formatDebugInfo', () => {
     const text = formatDebugInfo(info);
 
     expect(text).toContain('Game data: 5.3');
-    expect(text).toContain('Route: /teams');
     expect(text).toContain('Screen: 1920×1080 @2x');
     expect(text).toContain('Platform: Linux x86_64');
     expect(text).toContain('User agent: Mozilla/5.0 (X11; Linux x86_64)');
+  });
+});
+
+describe('buildBugReportUrl', () => {
+  it('pre-fills the template, page url, and environment fields', () => {
+    const url = new URL(
+      buildBugReportUrl('https://github.com/o/r/issues/new', 'https://app.example/teams', info),
+    );
+
+    expect(url.searchParams.get('template')).toBe('bug-report.yml');
+    expect(url.searchParams.get('url')).toBe('https://app.example/teams');
+    expect(url.searchParams.get('environment')).toBe(formatDebugInfo(info));
   });
 });

--- a/apps/web/src/lib/debug-info.ts
+++ b/apps/web/src/lib/debug-info.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+export interface DebugInfo {
+  appVersion: string;
+  buildSha: string;
+  gameDataVersion: string;
+  route: string;
+  authenticated: boolean;
+  userAgent: string;
+  platform: string;
+  screenWidth: number;
+  screenHeight: number;
+  pixelRatio: number;
+}
+
+export function formatDebugInfo(info: DebugInfo): string {
+  return [
+    `App version: ${info.appVersion} (${info.buildSha})`,
+    `Game data: ${info.gameDataVersion}`,
+    `Route: ${info.route}`,
+    `Authenticated: ${info.authenticated ? 'yes' : 'no'}`,
+    `Screen: ${info.screenWidth}×${info.screenHeight} @${info.pixelRatio}x`,
+    `Platform: ${info.platform}`,
+    `User agent: ${info.userAgent}`,
+  ].join('\n');
+}

--- a/apps/web/src/lib/debug-info.ts
+++ b/apps/web/src/lib/debug-info.ts
@@ -5,7 +5,6 @@ export interface DebugInfo {
   appVersion: string;
   buildSha: string;
   gameDataVersion: string;
-  route: string;
   authenticated: boolean;
   userAgent: string;
   platform: string;
@@ -18,10 +17,25 @@ export function formatDebugInfo(info: DebugInfo): string {
   return [
     `App version: ${info.appVersion} (${info.buildSha})`,
     `Game data: ${info.gameDataVersion}`,
-    `Route: ${info.route}`,
     `Authenticated: ${info.authenticated ? 'yes' : 'no'}`,
     `Screen: ${info.screenWidth}×${info.screenHeight} @${info.pixelRatio}x`,
     `Platform: ${info.platform}`,
     `User agent: ${info.userAgent}`,
   ].join('\n');
+}
+
+/**
+ * Build a GitHub bug-report URL with the reporter's page and environment
+ * pre-filled. The `url` and `environment` keys match field ids in
+ * `.github/ISSUE_TEMPLATE/bug-report.yml`; GitHub issue forms pre-fill any
+ * field addressed by its id through a query parameter.
+ */
+export function buildBugReportUrl(newIssueUrl: string, pageUrl: string, info: DebugInfo): string {
+  const params = new URLSearchParams({
+    template: 'bug-report.yml',
+    url: pageUrl,
+    environment: formatDebugInfo(info),
+  });
+
+  return `${newIssueUrl}?${params.toString()}`;
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -18,6 +18,20 @@ const requiredEnvVars: readonly string[] = [
   'VITE_API_BASE_URL',
 ];
 
+const appVersion: string = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'),
+).version;
+
+function shortSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+const buildSha: string = shortSha();
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -36,16 +50,17 @@ export default defineConfig({
     {
       name: 'generate-version',
       closeBundle() {
-        const sha = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
         const timestamp = new Date().toISOString();
-        const pkgPath = path.resolve(__dirname, 'package.json');
-        const version = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
-        const metadata = { version, sha, timestamp };
+        const metadata = { version: appVersion, sha: buildSha, timestamp };
         const distPath = path.resolve(__dirname, 'dist');
         fs.writeFileSync(path.join(distPath, 'version.json'), JSON.stringify(metadata, null, 2));
       },
     },
   ],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __BUILD_SHA__: JSON.stringify(buildSha),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
   },
   define: {
     'import.meta.env.VITE_API_BASE_URL': JSON.stringify('http://localhost:8080'),
+    __APP_VERSION__: JSON.stringify('0.0.0-test'),
+    __BUILD_SHA__: JSON.stringify('testsha'),
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

The footer's "Report an issue" link now opens the GitHub bug form with the page URL and an environment block — app version + build SHA, game data version, auth state (yes/no, no identity), screen resolution, platform, and user agent — already filled in, so reporters submit accurate debugging context without looking anything up.

Closes #639

## Gotchas

- Deviates from #639's original design. The issue asked for a "Copy debug info" button; this pre-fills the bug form's `url` and `environment` fields instead (query params keyed to the template's field ids). The tradeoff — which the issue's own "Alternatives considered" names — is that auto-fill only helps reports filed from the app, not from the GitHub UI directly. The copy button was built and then removed within this PR (squash collapses that); flagging so the acceptance-criteria change is a conscious review decision, not an oversight.
- App version and short SHA are compile-time constants (`__APP_VERSION__` / `__BUILD_SHA__`) injected via Vite `define`, reusing the SHA the `generate-version` plugin already computes.
- No screenshot rides along: a link cannot attach an image to a GitHub issue, and the client-side capture alternatives are lossy. Tracked separately in #919 with the constraints documented.

## Verification

- typecheck, lint, knip, and the 91-test web suite pass.
- Tests cover the URL builder (params present and encoded) and the footer link (reflects the current route and auth state).