### PR TITLE
fix(web): reset cleared team name to default

### DIFF
--- a/apps/web/src/features/teams/team-planner.tsx
+++ b/apps/web/src/features/teams/team-planner.tsx
@@ -58,10 +58,7 @@ export function TeamPlanner({
   }
 
   function commitEdit() {
-    const trimmed = editValue.trim();
-    if (trimmed) {
-      onNameChange(trimmed);
-    }
+    onNameChange(editValue);
     setEditing(false);
   }
 

--- a/apps/web/src/features/teams/use-team-store.test.ts
+++ b/apps/web/src/features/teams/use-team-store.test.ts
@@ -125,6 +125,25 @@ describe('useTeamStore', () => {
 
       expect(useTeamStore.getState().teams[1].name).toBe('National Team');
     });
+
+    it('trims surrounding whitespace', () => {
+      useTeamStore.getState().setTeamName(1, '  National Team  ');
+
+      expect(useTeamStore.getState().teams[1].name).toBe('National Team');
+    });
+
+    it('falls back to the default name when cleared', () => {
+      useTeamStore.getState().setTeamName(2, 'Freeze');
+      useTeamStore.getState().setTeamName(2, '');
+
+      expect(useTeamStore.getState().teams[2].name).toBe('Team 2');
+    });
+
+    it('falls back to the default name for a whitespace-only name', () => {
+      useTeamStore.getState().setTeamName(3, '   ');
+
+      expect(useTeamStore.getState().teams[3].name).toBe('Team 3');
+    });
   });
 
   describe('setTeams', () => {

--- a/apps/web/src/features/teams/use-team-store.ts
+++ b/apps/web/src/features/teams/use-team-store.ts
@@ -9,7 +9,7 @@ import type {
   CollectionWeaponId,
   TeamSlot,
 } from '@genshin/domain';
-import { initialTeams, isValidMemberIndex, nowTimestamp } from '@genshin/domain';
+import { defaultTeamName, initialTeams, isValidMemberIndex, nowTimestamp } from '@genshin/domain';
 import { create } from 'zustand';
 
 interface TeamStoreState {
@@ -157,10 +157,12 @@ export const useTeamStore = create<TeamStoreState>()((set, get) => ({
   },
 
   setTeamName: (slot, name) => {
+    const trimmed = name.trim();
+    const nextName = trimmed || defaultTeamName(slot);
     set((state) => ({
       teams: {
         ...state.teams,
-        [slot]: { ...state.teams[slot], name, updatedAt: nowTimestamp() },
+        [slot]: { ...state.teams[slot], name: nextName, updatedAt: nowTimestamp() },
       },
     }));
   },

--- a/packages/domain/src/collection-team.ts
+++ b/packages/domain/src/collection-team.ts
@@ -105,11 +105,16 @@ export function assertCollectionTeam(value: unknown): asserts value is Collectio
   }
 }
 
+/** The name a team slot shows before the user gives it a custom one. */
+export function defaultTeamName(slot: TeamSlot): string {
+  return `Team ${slot}`;
+}
+
 export function createEmptyTeam(slot: TeamSlot): CollectionTeam {
   const now = nowTimestamp();
   return {
     slot,
-    name: `Team ${slot}`,
+    name: defaultTeamName(slot),
     members: [null, null, null, null],
     createdAt: now,
     updatedAt: now,

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -16,6 +16,7 @@ export {
 export {
   assertCollectionTeam,
   createEmptyTeam,
+  defaultTeamName,
   initialTeams,
   isValidMemberIndex,
   isValidTeamSlot,


### PR DESCRIPTION
## Summary

Clearing a team name in the inline editor now reverts it to the default "Team N" instead of leaving the previous custom name in place — the last unmet acceptance criterion for editable team names (inline editing and persistence shipped with #625). The store's `setTeamName` resolves the fallback, so the value that persists and syncs to the API matches what's shown.

Closes #616

## Gotchas

- The editor no longer guards empty input; it always commits and the store owns normalization (trim, then default when empty). A blur with an unchanged name still writes — but a non-empty commit already did before, so this is only new for the empty case.
- `defaultTeamName(slot)` is added to `@genshin/domain` as the single source for the default and reused by `createEmptyTeam`, avoiding a duplicated `Team ${slot}` literal in the web store.

## Verification

- Added `use-team-store` tests for trim, cleared→default, and whitespace-only→default; ran `turbo run typecheck test lint` on `@genshin/domain` + `@genshin/web`, all green.