### PR TITLE
fix(web): dedupe auto-add of unowned weapon instances

### DIFF
--- a/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
@@ -30,120 +30,149 @@ function renderAuthed() {
   });
 }
 
+const SECOND_INSTANCE_ID = 'weapon-instance-2' as CollectionWeaponId;
+
 describe('useWeaponCollection', () => {
-  it('adds the server-confirmed weapon to the store', async () => {
-    let serverWeapons = weaponsDocument([]);
-    server.use(
-      http.get('http://localhost:8080/api/weapons', () => HttpResponse.json(serverWeapons)),
-      http.post('http://localhost:8080/api/weapons', () => {
-        serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
-        return HttpResponse.json(serverWeapons);
-      }),
-    );
+  describe('addWeapon', () => {
+    it('adds the server-confirmed weapon to the store', async () => {
+      let serverWeapons = weaponsDocument([]);
+      server.use(
+        http.get('http://localhost:8080/api/weapons', () => HttpResponse.json(serverWeapons)),
+        http.post('http://localhost:8080/api/weapons', () => {
+          serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
+          return HttpResponse.json(serverWeapons);
+        }),
+      );
 
-    const { result } = renderAuthed();
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+      const { result } = renderAuthed();
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    act(() => {
-      result.current.addWeapon(WEAPON_ID);
+      act(() => {
+        result.current.addWeapon(WEAPON_ID);
+      });
+
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.weaponId).toBe(WEAPON_ID));
     });
 
-    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.weaponId).toBe(WEAPON_ID));
+    it('creates another instance even when the weapon is already owned', async () => {
+      server.use(
+        http.get('http://localhost:8080/api/weapons', () =>
+          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
+        ),
+        http.post('http://localhost:8080/api/weapons', () =>
+          HttpResponse.json(weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, 1)])),
+        ),
+      );
+
+      const { result } = renderAuthed();
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
+
+      act(() => {
+        result.current.addWeapon(WEAPON_ID);
+      });
+
+      await waitFor(() => expect(result.current.weapons[SECOND_INSTANCE_ID]).toBeDefined());
+      expect(result.current.weapons[INSTANCE_ID]).toBeDefined();
+    });
   });
 
-  it('restores a removed weapon when the delete fails', async () => {
-    server.use(
-      http.get('http://localhost:8080/api/weapons', () =>
-        HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
-      ),
-      http.delete(
-        'http://localhost:8080/api/weapons/weapon-instance-1',
-        () => new HttpResponse(null, { status: 500 }),
-      ),
-    );
+  describe('ensureWeapon', () => {
+    it('creates only one instance when it fires repeatedly before the add lands', async () => {
+      let posts = 0;
+      let serverWeapons = weaponsDocument([]);
+      server.use(
+        http.get('http://localhost:8080/api/weapons', () => HttpResponse.json(serverWeapons)),
+        http.post('http://localhost:8080/api/weapons', () => {
+          posts += 1;
+          serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
+          return HttpResponse.json(serverWeapons);
+        }),
+      );
 
-    const { result } = renderAuthed();
-    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
+      const { result } = renderAuthed();
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    act(() => {
-      result.current.removeWeapon(INSTANCE_ID);
+      act(() => {
+        result.current.ensureWeapon(WEAPON_ID);
+        result.current.ensureWeapon(WEAPON_ID);
+        result.current.ensureWeapon(WEAPON_ID);
+      });
+
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.weaponId).toBe(WEAPON_ID));
+      expect(posts).toBe(1);
     });
 
-    // Optimistically gone, then restored once the delete errors.
-    expect(result.current.weapons[INSTANCE_ID]).toBeUndefined();
-    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
-    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('reverted'));
+    it('does not add another instance when the weapon is already owned', async () => {
+      let posts = 0;
+      server.use(
+        http.get('http://localhost:8080/api/weapons', () =>
+          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
+        ),
+        http.post('http://localhost:8080/api/weapons', () => {
+          posts += 1;
+          return HttpResponse.json(weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, 1)]));
+        }),
+      );
+
+      const { result } = renderAuthed();
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
+
+      act(() => {
+        result.current.ensureWeapon(WEAPON_ID);
+      });
+
+      expect(posts).toBe(0);
+    });
   });
 
-  it('reverts a refinement change when the update fails', async () => {
-    server.use(
-      http.get('http://localhost:8080/api/weapons', () =>
-        HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
-      ),
-      http.patch(
-        'http://localhost:8080/api/weapons/weapon-instance-1',
-        () => new HttpResponse(null, { status: 500 }),
-      ),
-    );
+  describe('removeWeapon', () => {
+    it('restores a removed weapon when the delete fails', async () => {
+      server.use(
+        http.get('http://localhost:8080/api/weapons', () =>
+          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
+        ),
+        http.delete(
+          'http://localhost:8080/api/weapons/weapon-instance-1',
+          () => new HttpResponse(null, { status: 500 }),
+        ),
+      );
 
-    const { result } = renderAuthed();
-    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.refinementLevel).toBe(2));
+      const { result } = renderAuthed();
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
 
-    act(() => {
-      result.current.setRefinementLevel(INSTANCE_ID, 5);
+      act(() => {
+        result.current.removeWeapon(INSTANCE_ID);
+      });
+
+      // Optimistically gone, then restored once the delete errors.
+      expect(result.current.weapons[INSTANCE_ID]).toBeUndefined();
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('reverted'));
     });
-
-    expect(result.current.weapons[INSTANCE_ID]?.refinementLevel).toBe(5);
-    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.refinementLevel).toBe(2));
-    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('reverted'));
   });
 
-  it('creates only one instance when ensureWeapon fires repeatedly before the add lands', async () => {
-    let posts = 0;
-    let serverWeapons = weaponsDocument([]);
-    server.use(
-      http.get('http://localhost:8080/api/weapons', () => HttpResponse.json(serverWeapons)),
-      http.post('http://localhost:8080/api/weapons', () => {
-        posts += 1;
-        serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
-        return HttpResponse.json(serverWeapons);
-      }),
-    );
+  describe('setRefinementLevel', () => {
+    it('reverts a refinement change when the update fails', async () => {
+      server.use(
+        http.get('http://localhost:8080/api/weapons', () =>
+          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
+        ),
+        http.patch(
+          'http://localhost:8080/api/weapons/weapon-instance-1',
+          () => new HttpResponse(null, { status: 500 }),
+        ),
+      );
 
-    const { result } = renderAuthed();
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+      const { result } = renderAuthed();
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.refinementLevel).toBe(2));
 
-    act(() => {
-      result.current.ensureWeapon(WEAPON_ID);
-      result.current.ensureWeapon(WEAPON_ID);
-      result.current.ensureWeapon(WEAPON_ID);
+      act(() => {
+        result.current.setRefinementLevel(INSTANCE_ID, 5);
+      });
+
+      expect(result.current.weapons[INSTANCE_ID]?.refinementLevel).toBe(5);
+      await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.refinementLevel).toBe(2));
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('reverted'));
     });
-
-    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.weaponId).toBe(WEAPON_ID));
-    expect(posts).toBe(1);
-  });
-
-  it('does not add another instance when the weapon is already owned', async () => {
-    let posts = 0;
-    server.use(
-      http.get('http://localhost:8080/api/weapons', () =>
-        HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
-      ),
-      http.post('http://localhost:8080/api/weapons', () => {
-        posts += 1;
-        return HttpResponse.json(
-          weaponsDocument([makeWeapon('weapon-instance-2' as CollectionWeaponId, WEAPON_ID, 1)]),
-        );
-      }),
-    );
-
-    const { result } = renderAuthed();
-    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
-
-    act(() => {
-      result.current.ensureWeapon(WEAPON_ID);
-    });
-
-    expect(posts).toBe(0);
   });
 });

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
@@ -97,4 +97,53 @@ describe('useWeaponCollection', () => {
     await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.refinementLevel).toBe(2));
     expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('reverted'));
   });
+
+  it('creates only one instance when ensureWeapon fires repeatedly before the add lands', async () => {
+    let posts = 0;
+    let serverWeapons = weaponsDocument([]);
+    server.use(
+      http.get('http://localhost:8080/api/weapons', () => HttpResponse.json(serverWeapons)),
+      http.post('http://localhost:8080/api/weapons', () => {
+        posts += 1;
+        serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
+        return HttpResponse.json(serverWeapons);
+      }),
+    );
+
+    const { result } = renderAuthed();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.ensureWeapon(WEAPON_ID);
+      result.current.ensureWeapon(WEAPON_ID);
+      result.current.ensureWeapon(WEAPON_ID);
+    });
+
+    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]?.weaponId).toBe(WEAPON_ID));
+    expect(posts).toBe(1);
+  });
+
+  it('does not add another instance when the weapon is already owned', async () => {
+    let posts = 0;
+    server.use(
+      http.get('http://localhost:8080/api/weapons', () =>
+        HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
+      ),
+      http.post('http://localhost:8080/api/weapons', () => {
+        posts += 1;
+        return HttpResponse.json(
+          weaponsDocument([makeWeapon('weapon-instance-2' as CollectionWeaponId, WEAPON_ID, 1)]),
+        );
+      }),
+    );
+
+    const { result } = renderAuthed();
+    await waitFor(() => expect(result.current.weapons[INSTANCE_ID]).toBeDefined());
+
+    act(() => {
+      result.current.ensureWeapon(WEAPON_ID);
+    });
+
+    expect(posts).toBe(0);
+  });
 });

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.ts
@@ -82,8 +82,7 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
     [addWeaponApi, applyMutationResult],
   );
 
-  // Explicitly add another instance of a weapon (e.g. the sidebar's
-  // "add another"); each call creates a new instance.
+  // Additive: every call creates a new instance. Contrast ensureWeapon.
   const addWeapon = useCallback(
     (weaponId: Weapon['id']) => {
       if (!isAuthenticated) return;
@@ -92,11 +91,9 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
     [isAuthenticated, runAdd],
   );
 
-  // Guarantee at least one instance exists, idempotently. Weapon instances are
-  // keyed by a server-generated id, so an add cannot be reflected in the store
-  // until the POST resolves. Tracking in-flight ensures per weapon id closes the
-  // window where rapid clicks on an unowned weapon would each auto-create an
-  // instance before the first one lands.
+  // Weapon instances carry a server-generated id, so an add can't reach the
+  // store until the POST resolves. Tracking in-flight adds per weapon id closes
+  // the window where rapid clicks would each auto-create an instance.
   const pendingEnsures = useRef<Set<Weapon['id']>>(new Set());
 
   const ensureWeapon = useCallback(

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.ts
@@ -69,24 +69,34 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
     storeSetWeapons(apiWeapons);
   }, [apiWeapons, storeSetWeapons]);
 
-  const addWeapon = useCallback(
-    (weaponId: Weapon['id']) => {
-      if (!isAuthenticated) return;
-
+  const runAdd = useCallback(
+    (weaponId: Weapon['id'], onSettled?: () => void) => {
       addWeaponApi(weaponId, {
         onSuccess: applyMutationResult,
         onError: () => {
           toast.error('Failed to add weapon.');
         },
+        onSettled,
       });
     },
-    [isAuthenticated, addWeaponApi, applyMutationResult],
+    [addWeaponApi, applyMutationResult],
   );
 
-  // Weapon instances are keyed by a server-generated id, so an add cannot be
-  // reflected in the store until the POST resolves. Tracking in-flight ensures
-  // per weapon id closes the window where rapid clicks on an unowned weapon
-  // would each auto-create an instance before the first one lands.
+  // Explicitly add another instance of a weapon (e.g. the sidebar's
+  // "add another"); each call creates a new instance.
+  const addWeapon = useCallback(
+    (weaponId: Weapon['id']) => {
+      if (!isAuthenticated) return;
+      runAdd(weaponId);
+    },
+    [isAuthenticated, runAdd],
+  );
+
+  // Guarantee at least one instance exists, idempotently. Weapon instances are
+  // keyed by a server-generated id, so an add cannot be reflected in the store
+  // until the POST resolves. Tracking in-flight ensures per weapon id closes the
+  // window where rapid clicks on an unowned weapon would each auto-create an
+  // instance before the first one lands.
   const pendingEnsures = useRef<Set<Weapon['id']>>(new Set());
 
   const ensureWeapon = useCallback(
@@ -99,17 +109,11 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
       if (alreadyOwned || pendingEnsures.current.has(weaponId)) return;
 
       pendingEnsures.current.add(weaponId);
-      addWeaponApi(weaponId, {
-        onSuccess: applyMutationResult,
-        onError: () => {
-          toast.error('Failed to add weapon.');
-        },
-        onSettled: () => {
-          pendingEnsures.current.delete(weaponId);
-        },
+      runAdd(weaponId, () => {
+        pendingEnsures.current.delete(weaponId);
       });
     },
-    [isAuthenticated, addWeaponApi, applyMutationResult],
+    [isAuthenticated, runAdd],
   );
 
   const removeWeapon = useCallback(

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.ts
@@ -4,7 +4,7 @@
 import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
 import { isValidRefinementLevel } from '@genshin/domain';
 import type { Weapon } from '@genshin/game-data';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { useAuth } from '@/features/auth/use-auth';
@@ -21,6 +21,7 @@ import { useWeaponCollectionStore } from './use-weapon-collection-store';
 export interface UseWeaponCollectionResult {
   weapons: Record<CollectionWeaponId, CollectionWeapon>;
   isAuthenticated: boolean;
+  ensureWeapon: (weaponId: Weapon['id']) => void;
   addWeapon: (weaponId: Weapon['id']) => void;
   removeWeapon: (collectionWeaponId: CollectionWeaponId) => void;
   setRefinementLevel: (collectionWeaponId: CollectionWeaponId, level: number) => void;
@@ -76,6 +77,35 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
         onSuccess: applyMutationResult,
         onError: () => {
           toast.error('Failed to add weapon.');
+        },
+      });
+    },
+    [isAuthenticated, addWeaponApi, applyMutationResult],
+  );
+
+  // Weapon instances are keyed by a server-generated id, so an add cannot be
+  // reflected in the store until the POST resolves. Tracking in-flight ensures
+  // per weapon id closes the window where rapid clicks on an unowned weapon
+  // would each auto-create an instance before the first one lands.
+  const pendingEnsures = useRef<Set<Weapon['id']>>(new Set());
+
+  const ensureWeapon = useCallback(
+    (weaponId: Weapon['id']) => {
+      if (!isAuthenticated) return;
+
+      const alreadyOwned = Object.values(useWeaponCollectionStore.getState().weapons).some(
+        (w) => w.weaponId === weaponId,
+      );
+      if (alreadyOwned || pendingEnsures.current.has(weaponId)) return;
+
+      pendingEnsures.current.add(weaponId);
+      addWeaponApi(weaponId, {
+        onSuccess: applyMutationResult,
+        onError: () => {
+          toast.error('Failed to add weapon.');
+        },
+        onSettled: () => {
+          pendingEnsures.current.delete(weaponId);
         },
       });
     },
@@ -146,6 +176,7 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
   return {
     weapons,
     isAuthenticated,
+    ensureWeapon,
     addWeapon,
     removeWeapon,
     setRefinementLevel,

--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -21,6 +21,7 @@ export function WeaponsPage(): JSX.Element {
   const {
     weapons,
     isAuthenticated,
+    ensureWeapon,
     addWeapon,
     removeWeapon,
     setRefinementLevel,
@@ -87,14 +88,10 @@ export function WeaponsPage(): JSX.Element {
         return;
       }
 
-      const hasInstances = (instanceCounts[weaponId] ?? 0) > 0;
-      if (!hasInstances) {
-        addWeapon(weaponId);
-      }
-
+      ensureWeapon(weaponId);
       setSelectedWeaponId(weaponId);
     },
-    [selectedWeaponId, isAuthenticated, instanceCounts, addWeapon],
+    [selectedWeaponId, isAuthenticated, ensureWeapon],
   );
 
   const handleAddWeapon = useCallback(


### PR DESCRIPTION
## Summary

Rapidly clicking an unowned weapon card no longer creates more than one
instance. The auto-add decision used to read `instanceCounts` from the
store, which only reflects the create once the POST resolves, so
reopening the same weapon before then fired a second create.

The hook now exposes `ensureWeapon`, which no-ops when the weapon already
has an instance or an add is already in flight for that weapon id (a
pending set cleared on settle). Weapon instances carry a server-generated
id, so unlike the character collection they can't be added to the store
optimistically — hence the in-flight guard rather than an optimistic
store write.

Closes #598

## Gotchas

- `addWeapon` is unchanged and still backs the sidebar's explicit "add
  another instance"; only the card-click path routes through
  `ensureWeapon`. The dedup must not touch the multi-add path.
- The character collection is intentionally untouched: its adds write to
  the store optimistically and guard on it, so the same race can't occur.

## Verification

- Added hook tests asserting three rapid `ensureWeapon` calls issue one
  POST and that an already-owned weapon issues none; full web suite,
  typecheck, and lint pass.