### PR TITLE
fix(devcontainer): make apt commands non-interactive

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -23,9 +23,10 @@ corepack install
 # ---------------------------------------------------------------------------
 step "Installing Google Cloud SDK"
 
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/cloud.google.gpg && \
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
-sudo apt-get update && sudo apt-get install -y google-cloud-sdk
+sudo DEBIAN_FRONTEND=noninteractive apt-get update && \
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y google-cloud-sdk
 
 # ---------------------------------------------------------------------------
 # 3. Project dependencies


### PR DESCRIPTION
## Summary

`postCreateCommand.sh` ran the Google Cloud SDK apt-get commands without `DEBIAN_FRONTEND=noninteractive`, so debconf package-configuration prompts could hang an attended DevContainer rebuild. Auditing the rest of the script, the only other interactive hazard was `gpg --dearmor -o`, which prompts before overwriting an existing keyring on re-run. This sets `DEBIAN_FRONTEND=noninteractive` on the `apt-get update`/`install` calls and adds `--batch --yes` to gpg. Everything else (corepack, pnpm, pre-commit, pipx-based reuse, hadolint/lychee curl downloads, Playwright) is already non-interactive.

## Gotchas

The prompts only surface with a TTY attached (local VS Code rebuild); the `devcontainer` CI build runs headless, where apt-get already suppresses them — so this hardening is what CI can't catch, verified by reasoning + shellcheck rather than a reproduced hang.

Closes #594