### PR TITLE
refactor: replace ArtifactPlan.sets tuple with named set IDs

### DIFF
--- a/apps/api/schema-snapshots/teams/v2.json
+++ b/apps/api/schema-snapshots/teams/v2.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 2
+    },
+    "name": {
+      "type": "string"
+    },
+    "members": {
+      "maxItems": 4,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "characterId": {
+                "type": "string"
+              },
+              "weaponInstanceId": {
+                "type": "string"
+              },
+              "artifactPlan": {
+                "type": "object",
+                "properties": {
+                  "sands": {
+                    "type": "string"
+                  },
+                  "goblet": {
+                    "type": "string"
+                  },
+                  "circlet": {
+                    "type": "string"
+                  },
+                  "primarySetId": {
+                    "type": "string"
+                  },
+                  "secondarySetId": {
+                    "type": "string"
+                  },
+                  "priorityMinorAffixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "secondaryMinorAffixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "characterId"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "description": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "name",
+    "members",
+    "createdAt",
+    "updatedAt"
+  ],
+  "additionalProperties": false
+}

--- a/apps/api/scripts/schema-registry.ts
+++ b/apps/api/scripts/schema-registry.ts
@@ -9,6 +9,7 @@ import { V1CharacterSchema } from '../src/repositories/characters/schemas/v1.js'
 import { CURRENT_VERSION as teamsCurrent } from '../src/repositories/teams/schemas/index.js';
 import { V0TeamSchema } from '../src/repositories/teams/schemas/v0.js';
 import { V1TeamSchema } from '../src/repositories/teams/schemas/v1.js';
+import { V2TeamSchema } from '../src/repositories/teams/schemas/v2.js';
 import { CURRENT_VERSION as weaponsCurrent } from '../src/repositories/weapons/schemas/index.js';
 import { V0WeaponSchema } from '../src/repositories/weapons/schemas/v0.js';
 import { V1WeaponSchema } from '../src/repositories/weapons/schemas/v1.js';
@@ -31,7 +32,7 @@ export const SCHEMA_REGISTRY: Record<string, RepositorySchemas> = {
     versions: [V0CharacterSchema, V1CharacterSchema],
     currentVersion: charactersCurrent,
   },
-  teams: { versions: [V0TeamSchema, V1TeamSchema], currentVersion: teamsCurrent },
+  teams: { versions: [V0TeamSchema, V1TeamSchema, V2TeamSchema], currentVersion: teamsCurrent },
   weapons: { versions: [V0WeaponSchema, V1WeaponSchema], currentVersion: weaponsCurrent },
 };
 

--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -78,10 +78,17 @@ export const teamItemV1 = {
                   },
                 },
                 {
-                  id: 'sets',
+                  id: 'primarySetId',
                   type: 'semantic',
                   doc: {
-                    value: '1-2 artifact set IDs from game data',
+                    value: 'Primary artifact set ID: a 4-piece, or the first half of a 2+2 split',
+                  },
+                },
+                {
+                  id: 'secondarySetId',
+                  type: 'semantic',
+                  doc: {
+                    value: 'Second 2-piece set ID for a 2+2 split',
                   },
                 },
                 {

--- a/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
+++ b/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
@@ -70,12 +70,15 @@ export const teamPutRequestV1 = {
             minLength: 1,
             description: 'Desired main stat for Circlet of Logos',
           },
-          sets: {
-            type: 'array',
-            items: { type: 'string', minLength: 1 },
-            minItems: 1,
-            maxItems: 2,
-            description: '1-2 artifact set IDs from game data',
+          primarySetId: {
+            type: 'string',
+            minLength: 1,
+            description: 'Primary artifact set ID: a 4-piece, or the first half of a 2+2 split',
+          },
+          secondarySetId: {
+            type: 'string',
+            minLength: 1,
+            description: 'Second 2-piece set ID for a 2+2 split',
           },
           priorityMinorAffixes: {
             type: 'array',

--- a/apps/api/src/repositories/teams/document.test.ts
+++ b/apps/api/src/repositories/teams/document.test.ts
@@ -109,6 +109,44 @@ describe('fromDocument', () => {
     expect(team.members[0]?.artifactPlan?.priorityMinorAffixes).toEqual(['crit-rate']);
   });
 
+  it('migrates artifactPlan.sets → primarySetId/secondarySetId in v1 documents', () => {
+    const team = fromDocument(
+      1,
+      makeV1Document({
+        members: [
+          {
+            characterId: 'columbina',
+            artifactPlan: {
+              sets: ['crimson-witch-of-flames', 'aubade-of-morningstar-and-moon'],
+            },
+          },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.primarySetId).toBe('crimson-witch-of-flames');
+    expect(team.members[0]?.artifactPlan?.secondarySetId).toBe('aubade-of-morningstar-and-moon');
+    expect(team.members[0]?.artifactPlan).not.toHaveProperty('sets');
+  });
+
+  it('migrates a single-set v1 plan to primarySetId only', () => {
+    const team = fromDocument(
+      1,
+      makeV1Document({
+        members: [
+          { characterId: 'columbina', artifactPlan: { sets: ['crimson-witch-of-flames'] } },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.primarySetId).toBe('crimson-witch-of-flames');
+    expect(team.members[0]?.artifactPlan).not.toHaveProperty('secondarySetId');
+  });
+
   it('throws for too many members', () => {
     expect(() =>
       fromDocument(1, makeV1Document({ members: [null, null, null, null, null] })),

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -13,14 +13,15 @@ import { assertCollectionTeam } from '@genshin/domain';
 import {
   entity,
   CURRENT_VERSION,
+  type V2Team,
   type V1Team,
   type V0Team,
-  type V1Member,
+  type V2Member,
 } from './schemas/index.js';
 
-export { CURRENT_VERSION, type V1Team, type V0Team };
+export { CURRENT_VERSION, type V2Team, type V1Team, type V0Team };
 
-function memberFromDocument(m: V1Member): CollectionTeamMember {
+function memberFromDocument(m: V2Member): CollectionTeamMember {
   return {
     characterId: m.characterId,
     ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
@@ -28,7 +29,7 @@ function memberFromDocument(m: V1Member): CollectionTeamMember {
   } as CollectionTeamMember;
 }
 
-function memberToDocument(m: CollectionTeamMember): V1Member {
+function memberToDocument(m: CollectionTeamMember): V2Member {
   return {
     characterId: m.characterId,
     ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
@@ -60,7 +61,7 @@ export function fromDocument(slot: TeamSlot, raw: Record<string, unknown>): Coll
   return team;
 }
 
-export function toDocument(team: CollectionTeam): V1Team {
+export function toDocument(team: CollectionTeam): V2Team {
   return {
     schemaVersion: CURRENT_VERSION,
     name: team.name,

--- a/apps/api/src/repositories/teams/schemas/index.ts
+++ b/apps/api/src/repositories/teams/schemas/index.ts
@@ -5,15 +5,17 @@ import { createVersionedEntity, type InferredEntity } from 'verzod';
 
 import { v0 } from './v0.js';
 import { v1 } from './v1.js';
+import { v2 } from './v2.js';
 
 export { type V0Team } from './v0.js';
-export { type V1Member } from './v1.js';
+export { type V1Team } from './v1.js';
+export { type V2Member } from './v2.js';
 
-export const CURRENT_VERSION = 1 as const;
+export const CURRENT_VERSION = 2 as const;
 
 export const entity = createVersionedEntity({
   latestVersion: CURRENT_VERSION,
-  versionMap: { 0: v0, 1: v1 },
+  versionMap: { 0: v0, 1: v1, 2: v2 },
   getVersion(data: unknown) {
     if (typeof data !== 'object' || data === null) return null;
     const ver = (data as Record<string, unknown>).schemaVersion;
@@ -21,4 +23,4 @@ export const entity = createVersionedEntity({
   },
 });
 
-export type V1Team = InferredEntity<typeof entity>;
+export type V2Team = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/teams/schemas/v2.ts
+++ b/apps/api/src/repositories/teams/schemas/v2.ts
@@ -5,9 +5,9 @@ import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { defineVersion } from 'verzod';
 import { z } from 'zod';
 
-import { type V0Team, V0MemberSchema } from './v0.js';
+import { type V1Team } from './v1.js';
 
-export const V1MemberSchema = z.object({
+export const V2MemberSchema = z.object({
   characterId: z.string(),
   weaponInstanceId: z.string().optional(),
   artifactPlan: z
@@ -15,32 +15,32 @@ export const V1MemberSchema = z.object({
       sands: z.string().optional(),
       goblet: z.string().optional(),
       circlet: z.string().optional(),
-      sets: z.array(z.string()).optional(),
+      primarySetId: z.string().optional(),
+      secondarySetId: z.string().optional(),
       priorityMinorAffixes: z.array(z.string()).optional(),
       secondaryMinorAffixes: z.array(z.string()).optional(),
     })
     .optional(),
 });
 
-export type V1Member = z.infer<typeof V1MemberSchema>;
-export type V1Team = z.infer<typeof V1TeamSchema>;
+export type V2Member = z.infer<typeof V2MemberSchema>;
 
-export const V1TeamSchema = z.object({
-  schemaVersion: z.literal(1),
+export const V2TeamSchema = z.object({
+  schemaVersion: z.literal(2),
   name: z.string(),
-  members: z.array(z.union([z.null(), V1MemberSchema])).max(MAX_TEAM_MEMBERS),
+  members: z.array(z.union([z.null(), V2MemberSchema])).max(MAX_TEAM_MEMBERS),
   description: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
 
-export const v1 = defineVersion({
+export const v2 = defineVersion({
   initial: false,
-  schema: V1TeamSchema,
-  up: (old: V0Team): z.infer<typeof V1TeamSchema> => ({
-    schemaVersion: 1,
+  schema: V2TeamSchema,
+  up: (old: V1Team): z.infer<typeof V2TeamSchema> => ({
+    schemaVersion: 2,
     name: old.name,
-    members: old.members.map((m): z.infer<typeof V1MemberSchema> | null => {
+    members: old.members.map((m): z.infer<typeof V2MemberSchema> | null => {
       if (m === null) return null;
       if (!m.artifactPlan) {
         return {
@@ -48,16 +48,8 @@ export const v1 = defineVersion({
           ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
         };
       }
-      const {
-        primaryStats,
-        secondaryStats,
-        sands,
-        goblet,
-        circlet,
-        sets,
-        priorityMinorAffixes,
-        secondaryMinorAffixes,
-      } = m.artifactPlan;
+      const { sands, goblet, circlet, sets, priorityMinorAffixes, secondaryMinorAffixes } =
+        m.artifactPlan;
       return {
         characterId: m.characterId,
         ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
@@ -65,17 +57,10 @@ export const v1 = defineVersion({
           ...(sands !== undefined ? { sands } : {}),
           ...(goblet !== undefined ? { goblet } : {}),
           ...(circlet !== undefined ? { circlet } : {}),
-          ...(sets !== undefined ? { sets } : {}),
-          ...(primaryStats !== undefined
-            ? { priorityMinorAffixes: primaryStats }
-            : priorityMinorAffixes !== undefined
-              ? { priorityMinorAffixes }
-              : {}),
-          ...(secondaryStats !== undefined
-            ? { secondaryMinorAffixes: secondaryStats }
-            : secondaryMinorAffixes !== undefined
-              ? { secondaryMinorAffixes }
-              : {}),
+          ...(sets?.[0] !== undefined ? { primarySetId: sets[0] } : {}),
+          ...(sets?.[1] !== undefined ? { secondarySetId: sets[1] } : {}),
+          ...(priorityMinorAffixes !== undefined ? { priorityMinorAffixes } : {}),
+          ...(secondaryMinorAffixes !== undefined ? { secondaryMinorAffixes } : {}),
         },
       };
     }),
@@ -84,7 +69,3 @@ export const v1 = defineVersion({
     updatedAt: old.updatedAt,
   }),
 });
-
-// V0MemberSchema re-exported so the map callback type is available without
-// reaching into v0 directly from outside the schemas directory.
-export { V0MemberSchema };

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -529,7 +529,7 @@ describe('Team routes', () => {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
                   circlet: 'CRIT DMG',
-                  sets: ['fake-set'],
+                  primarySetId: 'fake-set',
                   priorityMinorAffixes: ['CRIT Rate'],
                   secondaryMinorAffixes: ['ATK Percentage'],
                 },
@@ -557,7 +557,7 @@ describe('Team routes', () => {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
                   circlet: 'CRIT DMG',
-                  sets: ['crimson-witch-of-flames'],
+                  primarySetId: 'crimson-witch-of-flames',
                   priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
                   secondaryMinorAffixes: ['CRIT Rate', 'ATK Percentage'],
                 },
@@ -590,7 +590,7 @@ describe('Team routes', () => {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
                   circlet: 'CRIT DMG',
-                  sets: ['crimson-witch-of-flames'],
+                  primarySetId: 'crimson-witch-of-flames',
                   priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
                   secondaryMinorAffixes: ['ATK Percentage', 'HP Percentage'],
                 },
@@ -633,7 +633,7 @@ describe('Team routes', () => {
         expect(res.status).toBe(201);
       });
 
-      it('accepts partial artifact plan with only sets', async () => {
+      it('accepts partial artifact plan with only set IDs', async () => {
         vi.mocked(Teams.save).mockResolvedValue({
           team: FAKE_TEAM,
           created: true,
@@ -646,7 +646,7 @@ describe('Team routes', () => {
                 characterId: 'hu-tao',
                 weaponInstanceId: 'uuid-1',
                 artifactPlan: {
-                  sets: ['crimson-witch-of-flames'],
+                  primarySetId: 'crimson-witch-of-flames',
                 },
               },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },

--- a/apps/web/src/components/artifact-planner.tsx
+++ b/apps/web/src/components/artifact-planner.tsx
@@ -67,7 +67,11 @@ export function ArtifactPlanner({ plan, onChange }: ArtifactPlannerProps): JSX.E
           onChange={(value) => updatePlan({ circlet: value as CircletMainAffix | undefined })}
         />
 
-        <SetConfiguration sets={plan?.sets} onChange={(sets) => updatePlan({ sets })} />
+        <SetConfiguration
+          primarySetId={plan?.primarySetId}
+          secondarySetId={plan?.secondarySetId}
+          onChange={updatePlan}
+        />
 
         <PrioritySubstats
           label="Priority substats"
@@ -119,33 +123,30 @@ function MainAffixSelector({
 }
 
 function SetConfiguration({
-  sets,
+  primarySetId,
+  secondarySetId,
   onChange,
 }: {
-  sets: ArtifactPlan['sets'] | undefined;
-  onChange: (sets: ArtifactPlan['sets'] | undefined) => void;
+  primarySetId: ArtifactPlan['primarySetId'];
+  secondarySetId: ArtifactPlan['secondarySetId'];
+  onChange: (fields: Pick<ArtifactPlan, 'primarySetId' | 'secondarySetId'>) => void;
 }) {
-  const handleFirstChange = (setId: ArtifactSet['id']) => {
-    if (sets && sets.length === 2) {
-      onChange([setId, sets[1]]);
-    } else {
-      onChange([setId]);
-    }
+  const handlePrimaryChange = (setId: ArtifactSet['id']) => {
+    onChange({ primarySetId: setId, secondarySetId });
   };
 
-  const handleSecondChange = (setId: ArtifactSet['id']) => {
-    if (sets === undefined) return;
-    onChange([sets[0], setId]);
+  const handleSecondaryChange = (setId: ArtifactSet['id']) => {
+    onChange({ primarySetId, secondarySetId: setId });
   };
 
-  const handleClearSecond = () => {
-    if (sets) {
-      onChange([sets[0]]);
-    }
+  // Clearing the primary set drops the secondary too: a 2-piece split has no
+  // meaning without a primary half.
+  const handleClearPrimary = () => {
+    onChange({ primarySetId: undefined, secondarySetId: undefined });
   };
 
-  const handleClearFirst = () => {
-    onChange(undefined);
+  const handleClearSecondary = () => {
+    onChange({ primarySetId, secondarySetId: undefined });
   };
 
   return (
@@ -154,17 +155,17 @@ function SetConfiguration({
 
       <ArtifactSetSearch
         label="Search artifact set..."
-        value={sets?.[0]}
-        onChange={handleFirstChange}
-        onClear={sets?.[0] ? handleClearFirst : undefined}
+        value={primarySetId}
+        onChange={handlePrimaryChange}
+        onClear={primarySetId ? handleClearPrimary : undefined}
       />
 
-      {sets && sets.length >= 1 && (
+      {primarySetId && (
         <ArtifactSetSearch
           label="Optional second 2-piece set..."
-          value={sets?.[1]}
-          onChange={handleSecondChange}
-          onClear={sets?.[1] ? handleClearSecond : undefined}
+          value={secondarySetId}
+          onChange={handleSecondaryChange}
+          onClear={secondarySetId ? handleClearSecondary : undefined}
         />
       )}
     </div>

--- a/packages/domain/src/artifact-plan-validation.test.ts
+++ b/packages/domain/src/artifact-plan-validation.test.ts
@@ -16,7 +16,7 @@ describe('validateArtifactPlan', () => {
       sands: 'ATK Percentage',
       goblet: 'Pyro DMG Bonus',
       circlet: 'CRIT Rate',
-      sets: ['aubade-of-morningstar-and-moon'],
+      primarySetId: 'aubade-of-morningstar-and-moon',
       priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
       secondaryMinorAffixes: ['ATK Percentage'],
     });
@@ -41,28 +41,32 @@ describe('validateArtifactPlan', () => {
     expect(issues.some((i) => i.path === 'circlet')).toBe(true);
   });
 
-  it('rejects zero sets', () => {
-    const issues = validateArtifactPlan({ sets: [] });
+  it('rejects an unknown primary artifact set ID', () => {
+    const issues = validateArtifactPlan({ primarySetId: 'nonexistent-set' });
     expect(issues.length).toBeGreaterThan(0);
-    expect(issues.some((i) => i.path === 'sets')).toBe(true);
+    expect(issues.some((i) => i.path === 'primarySetId')).toBe(true);
   });
 
-  it('rejects more than 2 sets', () => {
+  it('rejects an unknown secondary artifact set ID', () => {
     const issues = validateArtifactPlan({
-      sets: [
-        'aubade-of-morningstar-and-moon',
-        'a-day-carved-from-rising-winds',
-        'silken-moons-serenade',
-      ],
+      primarySetId: 'aubade-of-morningstar-and-moon',
+      secondarySetId: 'nonexistent-set',
     });
     expect(issues.length).toBeGreaterThan(0);
-    expect(issues.some((i) => i.path === 'sets')).toBe(true);
+    expect(issues.some((i) => i.path === 'secondarySetId')).toBe(true);
   });
 
-  it('rejects an unknown artifact set ID', () => {
-    const issues = validateArtifactPlan({ sets: ['nonexistent-set'] });
-    expect(issues.length).toBeGreaterThan(0);
-    expect(issues.some((i) => i.path === 'sets[0]')).toBe(true);
+  it('rejects a secondary set without a primary set', () => {
+    const issues = validateArtifactPlan({ secondarySetId: 'aubade-of-morningstar-and-moon' });
+    expect(issues.some((i) => i.path === 'secondarySetId')).toBe(true);
+  });
+
+  it('accepts two distinct valid sets', () => {
+    const issues = validateArtifactPlan({
+      primarySetId: 'aubade-of-morningstar-and-moon',
+      secondarySetId: 'a-day-carved-from-rising-winds',
+    });
+    expect(isValid(issues)).toBe(true);
   });
 
   it('rejects more than 3 priority minor affixes', () => {

--- a/packages/domain/src/artifact-plan-validation.ts
+++ b/packages/domain/src/artifact-plan-validation.ts
@@ -27,7 +27,8 @@ export function validateArtifactPlan(plan: {
   sands?: string;
   goblet?: string;
   circlet?: string;
-  sets?: string[];
+  primarySetId?: string;
+  secondarySetId?: string;
   priorityMinorAffixes?: string[];
   secondaryMinorAffixes?: string[];
 }): ValidationIssue[] {
@@ -53,15 +54,16 @@ export function validateArtifactPlan(plan: {
   }
 
   // Sets ---------------------------------------------------------------
-  if (plan.sets !== undefined) {
-    if (plan.sets.length < 1 || plan.sets.length > 2) {
-      issues.push(issue('Artifact plan must have 1-2 sets', 'sets'));
-    } else {
-      for (const [i, setId] of plan.sets.entries()) {
-        if (!getArtifactSetById(setId)) {
-          issues.push(issue(`Unknown artifact set: ${setId}`, `sets[${i}]`));
-        }
-      }
+  if (plan.primarySetId !== undefined && !getArtifactSetById(plan.primarySetId)) {
+    issues.push(issue(`Unknown artifact set: ${plan.primarySetId}`, 'primarySetId'));
+  }
+
+  if (plan.secondarySetId !== undefined) {
+    if (plan.primarySetId === undefined) {
+      issues.push(issue('secondarySetId requires primarySetId', 'secondarySetId'));
+    }
+    if (!getArtifactSetById(plan.secondarySetId)) {
+      issues.push(issue(`Unknown artifact set: ${plan.secondarySetId}`, 'secondarySetId'));
     }
   }
 

--- a/packages/domain/src/artifact-plan.ts
+++ b/packages/domain/src/artifact-plan.ts
@@ -25,8 +25,10 @@ export interface ArtifactPlan {
   goblet?: GobletMainAffix;
   /** Desired main affix for Circlet of Logos */
   circlet?: CircletMainAffix;
-  /** 1–2 artifact set IDs from game-data */
-  sets?: [ArtifactSet['id']] | [ArtifactSet['id'], ArtifactSet['id']];
+  /** Primary artifact set: a 4-piece, or the first half of a 2+2 split */
+  primarySetId?: ArtifactSet['id'];
+  /** Second 2-piece set for a 2+2 split; only meaningful alongside primarySetId */
+  secondarySetId?: ArtifactSet['id'];
   /** 0–3 priority minor affixes to prioritize */
   priorityMinorAffixes?: ArtifactMinorAffix[];
   /** 0–3 secondary minor affixes (must be disjoint from priorityMinorAffixes) */

--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -71,7 +71,7 @@ describe('team serialisation round-trip', () => {
             sands: 'ATK Percentage',
             goblet: 'Hydro DMG Bonus',
             circlet: 'CRIT Rate',
-            sets: ['aubade-of-morningstar-and-moon'],
+            primarySetId: 'aubade-of-morningstar-and-moon',
             priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
             secondaryMinorAffixes: ['ATK Percentage'],
           },

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -78,10 +78,17 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
       );
     }
   }
-  for (const field of ['sets', 'priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
+  for (const field of ['priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
     if (!Array.isArray(plan[field])) {
       throw new TypeError(
         `artifactPlan.${field} must be an array, got: ${JSON.stringify(plan[field])}`,
+      );
+    }
+  }
+  for (const field of ['primarySetId', 'secondarySetId'] as const) {
+    if (plan[field] !== undefined && typeof plan[field] !== 'string') {
+      throw new TypeError(
+        `artifactPlan.${field} must be a string, got: ${JSON.stringify(plan[field])}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Team artifact plans now carry `primarySetId` and `secondarySetId` instead of a `sets` faux-tuple, so set access is self-documenting and the `[0]`/`[1]` indexing and `.length` branching are gone across the domain type, validation, Collection+JSON wire format, request profiles, and the planner UI.

Closes #601

## Gotchas

- The issue scoped an in-place edit of the Firestore schema, but the schema-compat gate (#886) forbids narrowing v1 (a stored doc with `sets` would stop validating). This instead adds storage schema **v2** with a v1→v2 migration mapping `sets[0]`/`sets[1]` onto the named fields — `apps/api/src/repositories/teams/schemas/v2.ts` is where to spend review attention. v0/v1 snapshots are untouched, so the gate stays green.
- The published JSON-Schema and ALPS profiles are edited in place rather than versioned to v2: they carry no compat gate, nothing is shipped pre-1.0.0, and the versioned-profile transition machinery is unbuilt (#920).

## Verification

- `pnpm turbo run typecheck test` green across all 11 packages; added migration tests (v1 `sets` → primary/secondary, and the single-set case) plus updated round-trip, validation, and route tests.