### PR TITLE
docs: add checklist for adding a workspace package

### DIFF
--- a/.claude/commands/add-workspace-package.md
+++ b/.claude/commands/add-workspace-package.md
@@ -19,6 +19,7 @@ copies).
 ## Requirements
 
 1. Don't skip the Dockerfile section when the package is a runtime dependency
-   of `apps/api`. A missed COPY fails the Docker build, not CI.
+   of `apps/api`. A missed COPY fails the Docker workflow build that runs on
+   every PR, with an opaque module-resolution error rather than a clear cause.
 2. Copy `packages/validation/` as the closest scaffolding template.
 3. Run the how-to's Verify section before opening a PR.

--- a/.claude/commands/add-workspace-package.md
+++ b/.claude/commands/add-workspace-package.md
@@ -1,0 +1,24 @@
+---
+description: Scaffold and integrate a new workspace package under `packages/`
+argument-hint: '[name]'
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Add workspace package
+
+Work the how-to top to bottom:
+[`add-workspace-package.md`](../../docs/how-tos/add-workspace-package.md). It's
+the source of truth for every integration point (scaffolding, workspace wiring,
+the CI matrix, the Codecov flag and component, and the `apps/api` Dockerfile
+copies).
+
+## Inputs
+
+- Package name: **$1** (the `@genshin/<name>` short name)
+
+## Requirements
+
+1. Don't skip the Dockerfile section when the package is a runtime dependency
+   of `apps/api`. A missed COPY fails the Docker build, not CI.
+2. Copy `packages/validation/` as the closest scaffolding template.
+3. Run the how-to's Verify section before opening a PR.

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -6,9 +6,10 @@ SPDX-License-Identifier: MIT
 # Add a workspace package
 
 This guide covers the integration points touched when adding a new package
-under `packages/` (or a tool under `tools/`). Miss one and the failure usually
-surfaces far from the change—a CI matrix gap, a Docker build that can't
-resolve the new dependency, an uncovered flag in Codecov.
+under `packages/` (or a tool under `tools/`). Several fail unhelpfully when
+omitted. A forgotten CI matrix entry or Codecov flag leaves the package
+uncovered with CI still green. A missing Dockerfile COPY fails the `apps/api`
+image build on every PR.
 
 Work top to bottom. Each section ends at a committable state.
 

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -1,0 +1,144 @@
+<!--
+SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Add a workspace package
+
+This guide covers the integration points touched when adding a new package
+under `packages/` (or a tool under `tools/`). Miss one and the failure usually
+surfaces far from the change—a CI matrix gap, a Docker build that can't
+resolve the new dependency, an uncovered flag in Codecov.
+
+Work top to bottom. Each section ends at a committable state.
+
+---
+
+## 1) Scaffold the package
+
+Create `packages/<name>/` with these files. Copy `packages/validation/` as the
+closest template.
+
+- [ ] `package.json`:
+
+  ```json
+  {
+    "name": "@genshin/<name>",
+    "version": "0.0.0",
+    "description": "...",
+    "private": true,
+    "type": "module",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "files": ["dist"],
+    "scripts": {
+      "typecheck": "tsc --noEmit",
+      "build": "tsc --project tsconfig.build.json",
+      "lint": "eslint .",
+      "test": "vitest run"
+    },
+    "devDependencies": {
+      "@genshin/eslint-config": "workspace:*",
+      "eslint": "10.4.0",
+      "typescript": "6.0.3"
+    }
+  }
+  ```
+
+  Add `test` only once tests exist, along with the `vitest` and
+  `@vitest/coverage-v8` dev dependencies and a `vitest.config.ts`.
+
+- [ ] `tsconfig.json`: compiler options plus `include: ["src/**/*"]`. This is
+      the typechecking config, with no shared base to extend.
+- [ ] `tsconfig.build.json`: extends `./tsconfig.json` and adds
+      `"exclude": ["src/**/*.test.ts"]`. The `build` script points here so test
+      files stay out of `dist`.
+- [ ] `eslint.config.js`: delegate to the shared config:
+
+  ```js
+  import genshinConfig from '@genshin/eslint-config';
+
+  export default genshinConfig(import.meta.dirname);
+  ```
+
+- [ ] SPDX headers on every source file. For files without comment syntax,
+      declare them in `.reuse/dep5`. See [Add SPDX headers](./add-spdx-headers.md).
+
+## 2) Wire it into the workspace
+
+- [ ] The `packages/*` glob in `pnpm-workspace.yaml` already covers a new
+      `packages/<name>`. Only a new top-level directory needs a new glob.
+- [ ] In each consuming package, add `"@genshin/<name>": "workspace:*"` under
+      `dependencies`, not `devDependencies`. A runtime import belongs there, and
+      the Docker prune in step 4 keeps `dependencies` and drops everything else.
+- [ ] Run `pnpm install` and commit the updated `pnpm-lock.yaml`.
+
+## 3) Add it to continuous integration
+
+- [ ] Add a matrix entry under `strategy.matrix.include` in
+      `.github/workflows/ci.yml`:
+
+  ```yaml
+  - display: <Display Name>
+    filter: '@genshin/<name>'
+    path-prefix: packages/<name>
+    flag: <name>
+  ```
+
+  Every entry runs the same `node-ci` composite action, which runs
+  typechecking, tests with coverage, and the build. A package with no `test`
+  script fails that step, so add tests before adding the matrix entry (or the
+  entry once the tests land).
+
+- [ ] In `codecov.yml`, add both a flag and a component:
+
+  ```yaml
+  # under flag_management.individual_flags
+  - name: <name>
+    paths:
+      - packages/<name>/src/**
+
+  # under component_management.individual_components
+  - component_id: <name>
+    name: <Display Name>
+    paths:
+      - packages/<name>/src/**
+    flag_regexes:
+      - <name>
+  ```
+
+## 4) Update the Dockerfile (runtime dependency of a containerised app only)
+
+`apps/api` is the only containerised app. Skip this section if the new package
+is build- or test-only, or is consumed only by `apps/web`.
+
+- [ ] In the builder stage of `apps/api/Dockerfile`, add the manifest copy
+      alongside the other `packages/*/package.json` lines:
+
+  ```dockerfile
+  COPY packages/<name>/package.json ./packages/<name>/
+  ```
+
+- [ ] In the production stage, copy the built package:
+
+  ```dockerfile
+  COPY --from=builder /app/packages/<name> ./packages/<name>
+  ```
+
+- [ ] Confirm `.dockerignore` doesn't exclude the package. The `packages/`
+      tree is copied wholesale, so no change is needed unless you add a top-level
+      path.
+
+## 5) Verify
+
+- [ ] `pnpm turbo run typecheck`
+- [ ] `pnpm turbo run test` (if the package has tests)
+- [ ] `pnpm turbo run build`
+- [ ] `pnpm reuse:check`
+- [ ] `docker build -f apps/api/Dockerfile .` (if you touched the Dockerfile)

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -54,8 +54,8 @@ closest template.
   Add `test` only once tests exist, along with the `vitest` and
   `@vitest/coverage-v8` dev dependencies and a `vitest.config.ts`.
 
-- [ ] `tsconfig.json`: compiler options plus `include: ["src/**/*"]`. This is
-      the typechecking config, with no shared base to extend.
+- [ ] `tsconfig.json`: compiler options plus `include: ["src/**/*"]` (no shared
+      base to extend).
 - [ ] `tsconfig.build.json`: extends `./tsconfig.json` and adds
       `"exclude": ["src/**/*.test.ts"]`. The `build` script points here so test
       files stay out of `dist`.
@@ -75,8 +75,8 @@ closest template.
 - [ ] The `packages/*` glob in `pnpm-workspace.yaml` already covers a new
       `packages/<name>`. Only a new top-level directory needs a new glob.
 - [ ] In each consuming package, add `"@genshin/<name>": "workspace:*"` under
-      `dependencies`, not `devDependencies`. A runtime import belongs there, and
-      the Docker prune in step 4 keeps `dependencies` and drops everything else.
+      `dependencies`, not `devDependencies` (the Docker prune in step 4 drops
+      `devDependencies`).
 - [ ] Run `pnpm install` and commit the updated `pnpm-lock.yaml`.
 
 ## 3) Add it to continuous integration
@@ -91,10 +91,8 @@ closest template.
     flag: <name>
   ```
 
-  Every entry runs the same `node-ci` composite action, which runs
-  typechecking, tests with coverage, and the build. A package with no `test`
-  script fails that step, so add tests before adding the matrix entry (or the
-  entry once the tests land).
+  Every entry runs the `typecheck`, `test`, and `build` tasks. Add the entry
+  only once the package has a `test` script, or the `test` task fails.
 
 - [ ] In `codecov.yml`, add both a flag and a component:
 


### PR DESCRIPTION
## Summary

Adding a package to the monorepo touches integration points that fail in two unhelpful ways when missed: a forgotten CI matrix entry or Codecov flag leaves the package uncovered with CI still green, and a missing COPY in `apps/api/Dockerfile` fails the Docker workflow's image build (the gap PR #591 hit). Adds `docs/how-tos/add-workspace-package.md` as an ordered checklist, plus a thin `/add-workspace-package` command that references it so the checklist is actually invocable when an agent adds a package.

Closes #592

## Gotchas

- Two artifacts, one source of truth: the how-to holds the content; the command is a thin pointer (trigger + package-name input + the Dockerfile reminder), mirroring the existing `update-game-data` command → `update-game-*.md` how-tos pattern. Review the doc for substance and the command only for the pointer.
- The checklist is written against current HEAD, not transcribed from the issue draft — I corrected where the issue had drifted: two tsconfigs (`tsconfig.build.json` drives the build and excludes tests), `eslint.config.js` delegates to the `@genshin/eslint-config` workspace package, CI is one matrix feeding the `node-ci` composite action rather than per-job build/typecheck, and Codecov needs both a flag and a component.
- No central how-to index exists (siblings like `add-terraform-environment.md` aren't linked from a list either), so nothing links to the new page — matching repo precedent rather than introducing an index.

## Additional context

Follow-up #938 tracks codifying the deterministic parts of this checklist as a `turbo gen` generator, which would later slim the how-to's scaffolding sections.