### PR TITLE
refactor(api): rename NegotiatedContentVariables for response direction

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,7 +12,7 @@ import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 
 import type { AuthVariables } from '@/middleware/auth.js';
-import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
 import { firestoreErrorToHttpException } from '@/repositories/firestore-error.js';
 import { alpsProfiles } from '@/routes/alps-profiles.js';
 import { characters } from '@/routes/characters.js';
@@ -27,7 +27,9 @@ const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.me
 
 export const PROBLEM_JSON = { 'Content-Type': 'application/problem+json' };
 
-export const app = new Hono<{ Variables: Partial<AuthVariables> & NegotiatedContentVariables }>();
+export const app = new Hono<{
+  Variables: Partial<AuthVariables> & NegotiatedResponseContentVariables;
+}>();
 
 // Request logging middleware
 app.use('*', logger());

--- a/apps/api/src/middleware/negotiate-content.test.ts
+++ b/apps/api/src/middleware/negotiate-content.test.ts
@@ -4,7 +4,10 @@
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
-import type { NegotiatedContentVariables, SupportedRepresentation } from './negotiate-content.js';
+import type {
+  NegotiatedResponseContentVariables,
+  SupportedRepresentation,
+} from './negotiate-content.js';
 import { negotiateContent, toMediaTypeString } from './negotiate-content.js';
 
 const ORIGIN = 'http://localhost';
@@ -42,7 +45,7 @@ describe('negotiateContent middleware', () => {
   ];
 
   function createApp() {
-    const app = new Hono<{ Variables: NegotiatedContentVariables }>();
+    const app = new Hono<{ Variables: NegotiatedResponseContentVariables }>();
     app.use('*', negotiateContent(supported));
     app.get('/', (c) => c.body(null, 200, { 'Content-Type': c.get('negotiatedMediaType') }));
     return app;

--- a/apps/api/src/middleware/negotiate-content.ts
+++ b/apps/api/src/middleware/negotiate-content.ts
@@ -25,7 +25,7 @@ export interface SupportedRepresentation {
   profile?: ProfileLink;
 }
 
-export type NegotiatedContentVariables = {
+export type NegotiatedResponseContentVariables = {
   negotiatedMediaType: string;
 };
 

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -9,7 +9,7 @@ import { HTTPException } from 'hono/http-exception';
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
-import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
 import { negotiateContent } from '@/middleware/negotiate-content.js';
 import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
 import { negotiateRequestSchema } from '@/middleware/negotiate-request-schema.js';
@@ -21,7 +21,7 @@ import * as Characters from '@/repositories/characters/index.js';
 
 export const characters = new Hono<{
   Variables: AuthVariables &
-    NegotiatedContentVariables &
+    NegotiatedResponseContentVariables &
     NegotiatedRequestSchemaVariables &
     ValidatedRequestBodyVariables;
 }>();

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -5,7 +5,7 @@ import type { Env, Hono as HonoApp } from 'hono';
 import { Hono } from 'hono';
 import { findTargetHandler, isMiddleware } from 'hono/utils/handler';
 
-import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
 import { negotiateContent } from '@/middleware/negotiate-content.js';
 import { rootGetResponseV1 } from '@/profiles/json-schema/root/get-response-v1.js';
 
@@ -44,9 +44,9 @@ function discoverLinks<E extends Env>(app: HonoApp<E>): Record<string, { href: s
 
 export function root<E extends Env>(
   app: HonoApp<E>,
-): Hono<{ Variables: NegotiatedContentVariables }> {
+): Hono<{ Variables: NegotiatedResponseContentVariables }> {
   const links = discoverLinks(app);
-  const router = new Hono<{ Variables: NegotiatedContentVariables }>();
+  const router = new Hono<{ Variables: NegotiatedResponseContentVariables }>();
 
   router.get(
     '/',

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -15,7 +15,7 @@ import { HTTPException } from 'hono/http-exception';
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
-import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
 import { negotiateContent } from '@/middleware/negotiate-content.js';
 import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
 import { negotiateRequestSchema } from '@/middleware/negotiate-request-schema.js';
@@ -29,7 +29,7 @@ import * as Weapons from '@/repositories/weapons/index.js';
 
 export const teams = new Hono<{
   Variables: AuthVariables &
-    NegotiatedContentVariables &
+    NegotiatedResponseContentVariables &
     NegotiatedRequestSchemaVariables &
     ValidatedRequestBodyVariables;
 }>();

--- a/apps/api/src/routes/user-profile.ts
+++ b/apps/api/src/routes/user-profile.ts
@@ -8,7 +8,7 @@ import { HTTPException } from 'hono/http-exception';
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
-import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
 import { negotiateContent } from '@/middleware/negotiate-content.js';
 import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
 import { negotiateRequestSchema } from '@/middleware/negotiate-request-schema.js';
@@ -24,7 +24,7 @@ function toAuthIdentity({ uid, email, email_verified, picture }: DecodedIdToken)
 
 export const userProfile = new Hono<{
   Variables: AuthVariables &
-    NegotiatedContentVariables &
+    NegotiatedResponseContentVariables &
     NegotiatedRequestSchemaVariables &
     ValidatedRequestBodyVariables;
 }>();

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -10,7 +10,7 @@ import { HTTPException } from 'hono/http-exception';
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
-import type { NegotiatedContentVariables } from '@/middleware/negotiate-content.js';
+import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
 import { negotiateContent } from '@/middleware/negotiate-content.js';
 import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
 import { negotiateRequestSchema } from '@/middleware/negotiate-request-schema.js';
@@ -23,7 +23,7 @@ import * as Weapons from '@/repositories/weapons/index.js';
 
 export const weapons = new Hono<{
   Variables: AuthVariables &
-    NegotiatedContentVariables &
+    NegotiatedResponseContentVariables &
     NegotiatedRequestSchemaVariables &
     ValidatedRequestBodyVariables;
 }>();


### PR DESCRIPTION
## Summary

Renames the response-side content negotiation context type
`NegotiatedContentVariables` → `NegotiatedResponseContentVariables` so it
parallels the request-side `NegotiatedRequestSchemaVariables` introduced in
#476. The `Response` direction segment makes route type declarations easier to
scan. Pure mechanical rename, no behavior change.

Closes #567