### PR TITLE
refactor(api): derive request body types from JSON Schema

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,6 +35,7 @@
     "eslint": "10.4.0",
     "fast-check": "4.8.0",
     "globals": "17.6.0",
+    "json-schema-to-ts": "3.1.1",
     "jsoncompat": "0.4.1",
     "tsc-alias": "1.8.17",
     "tsx": "4.22.3",

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -6,6 +6,7 @@ import { characterItemHref, characterRepresentation, serialiseCharacter } from '
 import { getCharacterById } from '@genshin/game-data';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import type { FromSchema } from 'json-schema-to-ts';
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
@@ -30,9 +31,7 @@ characters.use('*', auth);
 
 characters.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: characterItemV1 }]));
 
-interface SaveCharacterBody {
-  constellationLevel: number;
-}
+type SaveCharacterBody = FromSchema<typeof characterPutRequestV1.schema>;
 
 // GET /api/characters — List user's character collection
 characters.get('/', async (c) => {

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -7,6 +7,7 @@ import { serialiseWeapon, weaponItemHref, weaponRepresentation } from '@genshin/
 import { getWeaponById } from '@genshin/game-data';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import type { FromSchema } from 'json-schema-to-ts';
 
 import type { AuthVariables } from '@/middleware/auth.js';
 import { auth } from '@/middleware/auth.js';
@@ -32,14 +33,8 @@ weapons.use('*', auth);
 
 weapons.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: weaponItemV1 }]));
 
-interface CreateWeaponBody {
-  weaponId: string;
-  refinementLevel: number;
-}
-
-interface UpdateWeaponBody {
-  refinementLevel: number;
-}
+type CreateWeaponBody = FromSchema<typeof weaponPostRequestV1.schema>;
+type UpdateWeaponBody = FromSchema<typeof weaponPatchRequestV1.schema>;
 
 // GET /api/weapons — List all weapon instances, optionally filtered by weaponId
 weapons.get('/', async (c) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       globals:
         specifier: 17.6.0
         version: 17.6.0
+      json-schema-to-ts:
+        specifier: 3.1.1
+        version: 3.1.1
       jsoncompat:
         specifier: 0.4.1
         version: 0.4.1
@@ -4378,6 +4381,10 @@ packages:
     resolution: {integrity: sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -5986,6 +5993,9 @@ packages:
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -10765,6 +10775,11 @@ snapshots:
 
   json-ptr@3.1.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -12518,6 +12533,8 @@ snapshots:
   tree-kill@1.2.2: {}
 
   triple-beam@1.4.1: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Summary

Request-body types in the characters and weapons handlers now derive from the served JSON Schema (`json-schema-to-ts`'s `FromSchema` over the existing `as const satisfies JsonSchemaProfile` objects) instead of hand-written interfaces. The schema stays the single source of truth per DSGEP-003, so an edit to the schema and its cast can no longer silently drift.

Closes #566

## Gotchas

- Teams is deliberately not migrated. Its body feeds domain functions expecting the `CollectionTeamMembers` tuple with branded `characterId`/`weaponInstanceId`/`ArtifactPlan`, which `FromSchema` can't express (no tuple from `minItems`/`maxItems`, no brands) — forcing it would break typecheck and push worse casts into the handler. That schema⇄domain bridge is tracked in #941.
- `json-schema-to-ts` is a type-only dev dependency; it contributes no runtime code.

## Verification

- `pnpm turbo run typecheck --filter=@genshin/api` passes — confirms `FromSchema` resolves the derived types at each call site.
- `pnpm turbo run test --filter=@genshin/api` passes (191 tests).