### PR TITLE
feat(game-data): sort characters by exact release date

### DIFF
--- a/apps/web/src/components/summaries/character-summary.test.tsx
+++ b/apps/web/src/components/summaries/character-summary.test.tsx
@@ -14,6 +14,7 @@ const AMBER = {
   rarity: 4 as const,
   region: 'Mondstadt',
   version: '1.0',
+  releaseDate: '2020-09-28',
 };
 
 describe('CharacterSummary', () => {

--- a/apps/web/src/features/collection/characters/filtering.test.ts
+++ b/apps/web/src/features/collection/characters/filtering.test.ts
@@ -15,6 +15,7 @@ const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'ganyu',
@@ -24,6 +25,7 @@ const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.2',
+    releaseDate: '2021-01-12',
   },
   {
     id: 'xiangling',
@@ -33,6 +35,7 @@ const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'zhongli',
@@ -42,6 +45,7 @@ const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.1',
+    releaseDate: '2020-12-01',
   },
 ];
 
@@ -142,5 +146,39 @@ describe('filterCharacters', () => {
 
     // Version 1.0 characters should come first
     expect(result[0].version).toBe('1.0');
+  });
+
+  it('orders same-version characters by their release date', () => {
+    const sameVersion: Character[] = [
+      {
+        id: 'wriothesley',
+        name: 'Wriothesley',
+        element: 'Cryo',
+        weaponType: 'Catalyst',
+        rarity: 5,
+        region: 'Fontaine',
+        version: '4.1',
+        releaseDate: '2023-10-17',
+      },
+      {
+        id: 'neuvillette',
+        name: 'Neuvillette',
+        element: 'Hydro',
+        weaponType: 'Catalyst',
+        rarity: 5,
+        region: 'Fontaine',
+        version: '4.1',
+        releaseDate: '2023-09-27',
+      },
+    ];
+    const filters = {
+      ...initialFilterState(),
+      sortField: 'release' as const,
+      sortDirection: 'asc' as const,
+    };
+
+    const result = filterCharacters(sameVersion, filters, new Set<string>());
+
+    expect(result.map((c) => c.id)).toEqual(['neuvillette', 'wriothesley']);
   });
 });

--- a/apps/web/src/features/collection/characters/filtering.ts
+++ b/apps/web/src/features/collection/characters/filtering.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import type { Character, Element, Rarity } from '@genshin/game-data';
-import { compareVersions } from '@genshin/game-data';
 
 export type OwnershipFilter = 'all' | 'owned' | 'unowned';
 export type SortField = 'release' | 'name';
@@ -48,7 +47,7 @@ export function filterCharacters(
     let cmp = 0;
     switch (filters.sortField) {
       case 'release':
-        cmp = compareVersions(a.version, b.version);
+        cmp = a.releaseDate.localeCompare(b.releaseDate);
         if (cmp === 0) {
           cmp = a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
         }

--- a/docs/how-tos/update-game-characters.md
+++ b/docs/how-tos/update-game-characters.md
@@ -27,6 +27,7 @@ From the wiki, collect:
 - Character name
 - Element, type, rarity, and region
 - Release version, for example, "1.0," "3.1," "5.2"
+- Release date, as an ISO 8601 date (`YYYY-MM-DD`) --- the day the character's debut banner opened
 
 ### 2. Update `packages/game-data/src/characters.ts`
 
@@ -41,6 +42,7 @@ interface Character {
   rarity: Rarity; // 4 or 5
   region: string; // Character's home region
   version: string; // Release version (for example, "1.0", "3.1", "5.2")
+  releaseDate: string; // ISO 8601 debut date (for example, "2022-11-02")
 }
 ```
 
@@ -55,6 +57,7 @@ interface Character {
   rarity: 5,
   region: 'Sumeru',
   version: '3.2',
+  releaseDate: '2022-11-02',
 }
 ```
 

--- a/packages/game-data/src/characters.ts
+++ b/packages/game-data/src/characters.ts
@@ -16,6 +16,7 @@ export interface Character {
   rarity: Rarity;
   region: string;
   version: string; // Release version (e.g., "1.0", "3.1", "5.2")
+  releaseDate: string; // ISO 8601 release date (e.g., "2020-09-28"); exact ordering within a version
 }
 
 /**
@@ -42,6 +43,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Nod-Krai',
     version: 'Luna IV',
+    releaseDate: '2026-01-14',
   },
 
   // Luna III
@@ -53,6 +55,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: 'Luna III',
+    releaseDate: '2025-12-03',
   },
 
   // Luna II
@@ -64,6 +67,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Nod-Krai',
     version: 'Luna II',
+    releaseDate: '2025-10-22',
   },
 
   // Luna I
@@ -75,6 +79,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Nod-Krai',
     version: 'Luna I',
+    releaseDate: '2025-09-30',
   },
   {
     id: 'lauma',
@@ -84,6 +89,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Nod-Krai',
     version: 'Luna I',
+    releaseDate: '2025-09-10',
   },
 
   // 5.8
@@ -95,6 +101,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Nod-Krai',
     version: '5.8',
+    releaseDate: '2025-07-30',
   },
 
   // 5.7
@@ -106,6 +113,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Unknown',
     version: '5.7',
+    releaseDate: '2025-06-18',
   },
 
   // 5.6
@@ -117,6 +125,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '5.6',
+    releaseDate: '2025-05-07',
   },
 
   // 5.5
@@ -128,6 +137,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Natlan',
     version: '5.5',
+    releaseDate: '2025-03-26',
   },
 
   // 5.4
@@ -139,6 +149,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '5.4',
+    releaseDate: '2025-02-12',
   },
 
   // 5.3
@@ -150,6 +161,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Natlan',
     version: '5.3',
+    releaseDate: '2025-01-01',
   },
   {
     id: 'mavuika',
@@ -159,6 +171,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Natlan',
     version: '5.3',
+    releaseDate: '2025-01-01',
   },
 
   // 5.2
@@ -170,6 +183,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Natlan',
     version: '5.2',
+    releaseDate: '2024-11-20',
   },
 
   // 5.1
@@ -181,6 +195,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Natlan',
     version: '5.1',
+    releaseDate: '2024-10-09',
   },
 
   // 5.0
@@ -192,6 +207,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Natlan',
     version: '5.0',
+    releaseDate: '2024-09-17',
   },
   {
     id: 'mualani',
@@ -201,6 +217,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Natlan',
     version: '5.0',
+    releaseDate: '2024-08-28',
   },
 
   // 4.8
@@ -212,6 +229,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.8',
+    releaseDate: '2024-08-06',
   },
 
   // 4.7
@@ -223,6 +241,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.7',
+    releaseDate: '2024-06-05',
   },
   {
     id: 'sigewinne',
@@ -232,6 +251,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.7',
+    releaseDate: '2024-06-25',
   },
 
   // 4.6
@@ -243,6 +263,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Snezhnaya',
     version: '4.6',
+    releaseDate: '2024-04-24',
   },
 
   // 4.5
@@ -254,6 +275,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '4.5',
+    releaseDate: '2024-03-13',
   },
 
   // 4.4
@@ -265,6 +287,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '4.4',
+    releaseDate: '2024-01-31',
   },
 
   // 4.3
@@ -276,6 +299,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.3',
+    releaseDate: '2023-12-20',
   },
 
   // 4.2
@@ -287,6 +311,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.2',
+    releaseDate: '2023-11-08',
   },
 
   // 4.1
@@ -298,6 +323,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.1',
+    releaseDate: '2023-09-27',
   },
   {
     id: 'wriothesley',
@@ -307,6 +333,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.1',
+    releaseDate: '2023-10-17',
   },
 
   // 4.0
@@ -318,6 +345,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Fontaine',
     version: '4.0',
+    releaseDate: '2023-08-16',
   },
 
   // 3.7
@@ -331,6 +359,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '3.6',
+    releaseDate: '2023-05-02',
   },
 
   // 3.5
@@ -342,6 +371,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Sumeru',
     version: '3.5',
+    releaseDate: '2023-03-01',
   },
 
   // 3.4
@@ -353,6 +383,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Sumeru',
     version: '3.4',
+    releaseDate: '2023-01-18',
   },
 
   // 3.3
@@ -364,6 +395,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Sumeru',
     version: '3.3',
+    releaseDate: '2022-12-07',
   },
 
   // 3.2
@@ -375,6 +407,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Sumeru',
     version: '3.2',
+    releaseDate: '2022-11-02',
   },
 
   // 3.1
@@ -386,6 +419,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Sumeru',
     version: '3.1',
+    releaseDate: '2022-09-28',
   },
   {
     id: 'nilou',
@@ -395,6 +429,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Sumeru',
     version: '3.1',
+    releaseDate: '2022-10-14',
   },
 
   // 3.0
@@ -406,6 +441,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Sumeru',
     version: '3.0',
+    releaseDate: '2022-08-24',
   },
 
   // 2.8
@@ -419,6 +455,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '2.7',
+    releaseDate: '2022-05-31',
   },
 
   // 2.6
@@ -430,6 +467,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '2.6',
+    releaseDate: '2022-03-30',
   },
 
   // 2.5
@@ -441,6 +479,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '2.5',
+    releaseDate: '2022-02-16',
   },
 
   // 2.4
@@ -452,6 +491,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '2.4',
+    releaseDate: '2022-01-05',
   },
 
   // 2.3
@@ -463,6 +503,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '2.3',
+    releaseDate: '2021-12-14',
   },
 
   // 2.2
@@ -476,6 +517,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '2.1',
+    releaseDate: '2021-09-01',
   },
   {
     id: 'sangonomiya-kokomi',
@@ -485,6 +527,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '2.1',
+    releaseDate: '2021-09-21',
   },
 
   // 2.0
@@ -496,6 +539,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '2.0',
+    releaseDate: '2021-07-21',
   },
   {
     id: 'yoimiya',
@@ -505,6 +549,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '2.0',
+    releaseDate: '2021-08-10',
   },
 
   // 1.6
@@ -516,6 +561,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Inazuma',
     version: '1.6',
+    releaseDate: '2021-06-29',
   },
 
   // 1.5
@@ -527,6 +573,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: '1.5',
+    releaseDate: '2021-05-18',
   },
 
   // 1.4
@@ -540,6 +587,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.3',
+    releaseDate: '2021-03-02',
   },
   {
     id: 'xiao',
@@ -549,6 +597,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.3',
+    releaseDate: '2021-02-03',
   },
 
   // 1.2
@@ -560,6 +609,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: '1.2',
+    releaseDate: '2020-12-23',
   },
   {
     id: 'ganyu',
@@ -569,6 +619,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.2',
+    releaseDate: '2021-01-12',
   },
 
   // 1.1
@@ -580,6 +631,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Snezhnaya',
     version: '1.1',
+    releaseDate: '2020-11-11',
   },
   {
     id: 'zhongli',
@@ -589,6 +641,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.1',
+    releaseDate: '2020-12-01',
   },
 
   // 1.0
@@ -600,6 +653,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'jean',
@@ -609,6 +663,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'keqing',
@@ -618,6 +673,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'klee',
@@ -627,6 +683,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'mona',
@@ -636,6 +693,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'qiqi',
@@ -645,6 +703,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'venti',
@@ -654,6 +713,7 @@ export const CHARACTERS: Character[] = [
     rarity: 5,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
 
   // 4-star characters (sorted by version descending)
@@ -667,6 +727,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Nod-Krai',
     version: 'Luna III',
+    releaseDate: '2025-12-03',
   },
 
   // Luna I
@@ -678,6 +739,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Nod-Krai',
     version: 'Luna I',
+    releaseDate: '2025-09-30',
   },
 
   // 5.7
@@ -689,6 +751,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '5.7',
+    releaseDate: '2025-06-18',
   },
 
   // 5.6
@@ -700,6 +763,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Natlan',
     version: '5.6',
+    releaseDate: '2025-05-07',
   },
 
   // 5.5
@@ -711,6 +775,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Natlan',
     version: '5.5',
+    releaseDate: '2025-03-26',
   },
 
   // 5.3
@@ -722,6 +787,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '5.3',
+    releaseDate: '2025-01-21',
   },
 
   // 5.2
@@ -733,6 +799,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Natlan',
     version: '5.2',
+    releaseDate: '2024-11-20',
   },
 
   // 5.0
@@ -744,6 +811,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Natlan',
     version: '5.0',
+    releaseDate: '2024-08-28',
   },
 
   // 4.7
@@ -755,6 +823,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Sumeru',
     version: '4.7',
+    releaseDate: '2024-06-05',
   },
 
   // 4.4
@@ -766,6 +835,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '4.4',
+    releaseDate: '2024-01-31',
   },
 
   // 4.3
@@ -777,6 +847,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Fontaine',
     version: '4.3',
+    releaseDate: '2024-01-09',
   },
 
   // 4.2
@@ -788,6 +859,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Fontaine',
     version: '4.2',
+    releaseDate: '2023-11-08',
   },
 
   // 4.0
@@ -799,6 +871,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Fontaine',
     version: '4.0',
+    releaseDate: '2023-09-05',
   },
   {
     id: 'lynette',
@@ -808,6 +881,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Fontaine',
     version: '4.0',
+    releaseDate: '2023-08-16',
   },
 
   // 3.7
@@ -819,6 +893,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Inazuma',
     version: '3.7',
+    releaseDate: '2023-05-24',
   },
 
   // 3.6
@@ -830,6 +905,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Sumeru',
     version: '3.6',
+    releaseDate: '2023-05-02',
   },
 
   // 3.5
@@ -841,6 +917,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '3.5',
+    releaseDate: '2023-03-21',
   },
 
   // 3.4
@@ -852,6 +929,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '3.4',
+    releaseDate: '2023-01-18',
   },
 
   // 3.3
@@ -863,6 +941,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Sumeru',
     version: '3.3',
+    releaseDate: '2022-12-07',
   },
 
   // 3.2
@@ -874,6 +953,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Sumeru',
     version: '3.2',
+    releaseDate: '2022-11-18',
   },
 
   // 3.1
@@ -885,6 +965,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Sumeru',
     version: '3.1',
+    releaseDate: '2022-09-28',
   },
 
   // 3.0
@@ -896,6 +977,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Sumeru',
     version: '3.0',
+    releaseDate: '2022-08-24',
   },
   {
     id: 'dori',
@@ -905,6 +987,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Sumeru',
     version: '3.0',
+    releaseDate: '2022-09-09',
   },
 
   // 2.8
@@ -916,6 +999,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Inazuma',
     version: '2.8',
+    releaseDate: '2022-07-13',
   },
 
   // 2.7
@@ -927,6 +1011,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Inazuma',
     version: '2.7',
+    releaseDate: '2022-06-21',
   },
 
   // 2.6
@@ -942,6 +1027,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '2.4',
+    releaseDate: '2022-01-05',
   },
 
   // 2.3
@@ -953,6 +1039,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Inazuma',
     version: '2.3',
+    releaseDate: '2021-12-14',
   },
 
   // 2.2
@@ -964,6 +1051,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Inazuma',
     version: '2.2',
+    releaseDate: '2021-11-02',
   },
 
   // 2.1
@@ -975,6 +1063,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Inazuma',
     version: '2.1',
+    releaseDate: '2021-09-01',
   },
 
   // 2.0
@@ -986,6 +1075,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Inazuma',
     version: '2.0',
+    releaseDate: '2021-08-10',
   },
 
   // 1.6
@@ -999,6 +1089,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.5',
+    releaseDate: '2021-04-28',
   },
 
   // 1.4
@@ -1010,6 +1101,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.4',
+    releaseDate: '2021-04-06',
   },
 
   // 1.3
@@ -1025,6 +1117,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.1',
+    releaseDate: '2020-11-11',
   },
   {
     id: 'xinyan',
@@ -1034,6 +1127,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.1',
+    releaseDate: '2020-12-01',
   },
 
   // 1.0
@@ -1045,6 +1139,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'barbara',
@@ -1054,6 +1149,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'beidou',
@@ -1063,6 +1159,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'bennett',
@@ -1072,6 +1169,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'chongyun',
@@ -1081,6 +1179,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'fischl',
@@ -1090,6 +1189,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'kaeya',
@@ -1099,6 +1199,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'lisa',
@@ -1108,6 +1209,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'ningguang',
@@ -1117,6 +1219,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'noelle',
@@ -1126,6 +1229,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'razor',
@@ -1135,6 +1239,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'sucrose',
@@ -1144,6 +1249,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Mondstadt',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'xiangling',
@@ -1153,6 +1259,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
   {
     id: 'xingqiu',
@@ -1162,6 +1269,7 @@ export const CHARACTERS: Character[] = [
     rarity: 4,
     region: 'Liyue',
     version: '1.0',
+    releaseDate: '2020-09-28',
   },
 ];
 


### PR DESCRIPTION
## Summary

The collection list's release sort now orders same-patch characters by their actual release date instead of collapsing them to a name sort. `Character` gains a `releaseDate` field (ISO 8601), populated for every entry, and the web release sort compares it directly. `version` stays for display and grouping.

## Gotchas

- Release dates are each character's debut-banner start, sourced from paimon-moe's `banners.js` (the wiki blocks automated fetches). 1.0 characters — including the standard-pool ones with no debut banner — are pinned to launch day, 2020-09-28.
- `compareVersions` is untouched; weapons filtering still uses it. Only the character release sort switched to date comparison. ISO dates compare lexicographically, so `localeCompare` gives chronological order, with the existing name/id tie-break kept for same-day releases.

## Verification

- Cross-checked every non-1.0 entry: the debut-banner version from the source matched the version already stored in `characters.ts` (the only "mismatches" were the project's Luna I–IV ↔ 6.0–6.3 aliasing, which is correct).
- Added a filtering test asserting two 4.1 characters (Neuvillette 2023-09-27, Wriothesley 2023-10-17) sort by date within the version.

Closes #534