### PR TITLE
docs(domain): drop resolved issue refs from ProblemDetail

### DIFF
--- a/packages/domain/src/problem-detail.ts
+++ b/packages/domain/src/problem-detail.ts
@@ -6,7 +6,7 @@
  *
  * This interface requires fields that RFC 9457 leaves optional. The shape
  * will be reassessed when content negotiation and representation parsing
- * are implemented (see #518, #520).
+ * are implemented (see #518).
  *
  * @see https://www.rfc-editor.org/rfc/rfc9457
  */
@@ -21,4 +21,6 @@ export interface ProblemDetail {
   detail: string;
   /** A URI reference identifying the specific occurrence. */
   instance?: string;
+  /** Extension members (RFC 9457 §3.2): additional problem-specific fields. */
+  [key: string]: unknown;
 }

--- a/packages/domain/src/problem-detail.ts
+++ b/packages/domain/src/problem-detail.ts
@@ -6,7 +6,7 @@
  *
  * This interface requires fields that RFC 9457 leaves optional. The shape
  * will be reassessed when content negotiation and representation parsing
- * are implemented (see #518).
+ * are implemented.
  *
  * @see https://www.rfc-editor.org/rfc/rfc9457
  */
@@ -21,6 +21,4 @@ export interface ProblemDetail {
   detail: string;
   /** A URI reference identifying the specific occurrence. */
   instance?: string;
-  /** Extension members (RFC 9457 §3.2): additional problem-specific fields. */
-  [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary

The `ProblemDetail` docstring pointed at #518 and #520 as future "reassessment" issues. #518 closed with a keep-the-in-house-type decision and #520 closed not-planned, so both refs now dangle. Drop the issue numbers and keep the standalone condition (reassess when content negotiation and representation parsing land).

## Gotchas

- Started life as the #520 extension-members change; that was dropped after #518's investigation concluded the minimal in-house type should stand and no consumer needs extension members yet. Net diff is now a single docstring line.