### PR TITLE
docs: extract reference material out of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,8 @@ For step-by-step instructions and technical details:
 
 - [Manual Setup Guide](docs/how-tos/manual-setup.md): Development environment setup without DevContainers
 - [Build the API Docker image](docs/how-tos/build-api-docker-image.md): Build and run the `apps/api` container locally
-- [Add Terraform Environment](docs/how-tos/add-terraform-environment.md): Infrastructure branch flow plus bootstrap, scaffold, lock file, and workflow updates for new environments
+- [Add Terraform Environment](docs/how-tos/add-terraform-environment.md): Bootstrap, scaffold, lock file, and workflow updates for new environments
+- [Infrastructure branch flow](docs/reference/infrastructure-branch-flow.md): How branches map to environments and Terraform actions
 - [Code conventions](docs/reference/code-conventions.md): Naming, shared types, test utilities, documentation strategy, and platform compatibility
 - [REST API conventions](docs/reference/rest-api-conventions.md): Route design, method semantics, status codes, error shape, and pagination
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,7 @@ Pre-commit hooks automatically enforce key checks, including:
 - Documentation and config linting for Markdown, YAML, and prose
 - Safety and repository hygiene checks for merge conflict markers, large files, trailing whitespace, line endings, and YAML/JSON validation
 - Exact dependency versions via [syncpack](https://jamiemason.github.io/syncpack/): `package.json` dependencies stay pinned with no `^` or `~` ranges. Run `pnpm exec syncpack fix` to pin offenders
+- SPDX license headers via [REUSE](https://reuse.software/): every source file needs one—see [Add SPDX headers](docs/how-tos/add-spdx-headers.md)
 
 Pull requests must pass type checks in [ci.yml](.github/workflows/ci.yml). Run type checks locally before committing when your change affects TypeScript code:
 
@@ -115,7 +116,7 @@ Pull requests must pass type checks in [ci.yml](.github/workflows/ci.yml). Run t
 pnpm typecheck
 ```
 
-For code conventions—source file headers, comments, documentation strategy, naming, shared types, test utilities, and platform compatibility—see [Code conventions](docs/reference/code-conventions.md).
+For code conventions—comments, documentation strategy, naming, shared types, test utilities, and platform compatibility—see [Code conventions](docs/reference/code-conventions.md).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,25 +65,9 @@ pnpm dev
 > [Configure Firestore credentials](docs/how-tos/configure-firestore-credentials.md)
 > for setup instructions.
 
-### Building and running the Docker image
-
-To build the API Docker image locally:
-
-```bash
-docker build -f apps/api/Dockerfile -t genshin-api:local .
-```
-
-To run it:
-
-```bash
-docker run -p 8080:8080 genshin-api:local
-```
-
-The API is available at `http://localhost:8080`. See [apps/api/Dockerfile](apps/api/Dockerfile) for build details and [.github/workflows/](.github/workflows/) for CI/CD pipeline information.
-
 ### Quality checks overview
 
-Pre-commit enforces formatting, linting, documentation, and hygiene checks on every commit and on pull requests. If checks fail, fix the issues—see the Code quality section below for guidance.
+Pre-commit enforces formatting, linting, documentation, and hygiene checks on every commit and on pull requests. If checks fail, fix the issues—see [Code quality](#code-quality) for the tools involved.
 
 ### Quality gate ownership
 
@@ -131,42 +115,7 @@ Pull requests must pass type checks in [ci.yml](.github/workflows/ci.yml). Run t
 pnpm typecheck
 ```
 
-### Source file headers
-
-All source files require SPDX headers per the [REUSE Specification](https://reuse.software/). Use `reuse addheader` or check [REUSE docs](https://reuse.software/tutorial/) for details.
-
-### Code comments
-
-For complex logic, decisions, or subtle patterns:
-
-- Decisions and trade-offs—why you chose this approach
-- Workarounds—temporary fixes with issue references
-- Performance-sensitive code—explain the optimization
-- External dependencies—integration quirks or API specifics
-
-### Documentation strategy
-
-When documenting decisions or conventions, prefer the highest-priority location that fits:
-
-1. **Inline comments**: explain _why_ code works a certain way.
-2. **Documentation strings**: explain module or function purpose when the name isn't sufficient.
-3. **`docs/`**: task-specific how-tos, references, and explanations following the [Diátaxis](https://diataxis.fr/) framework.
-4. **`CONTRIBUTING.md`**: high-level human workflow guidance and project conventions.
-5. **`.github/copilot-instructions.md`**: AI-specific decision rules.
-
-Avoid duplicating the same guidance across multiple locations. Place it once at the most appropriate level and link to it from others.
-
-### Naming conventions
-
-Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`.
-
-### Shared types
-
-Branded types in `packages/domain/` each get their own file (for example, `uuid.ts`, `iso-timestamp.ts`). Export both the type and any related validation functions from the same file.
-
-### Test utilities
-
-Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The build excludes this directory via `tsconfig.build.json`.
+For code conventions—source file headers, comments, documentation strategy, naming, shared types, test utilities, and platform compatibility—see [Code conventions](docs/reference/code-conventions.md).
 
 ---
 
@@ -182,24 +131,6 @@ Shared API test utilities live in `apps/api/src/test/` with descriptive file nam
 ---
 
 ## Pull request workflow
-
-### Branch flow for infrastructure
-
-Infrastructure automation follows this branch strategy:
-
-- `develop`: integration branch
-- `release/*`: release-train branches cut from `develop`
-- `main`: long-term release target branch, used when production flow is active
-
-Current Terraform workflow routing:
-
-- push to `develop`: applies `core` then `dev`
-- push to `release/*`: applies `core` then `staging`
-- pull requests to `develop`, `release/*`, and `main`: run Terraform plan checks
-
-When creating release branches, derive the name from the root `package.json` version using SemVer2 context and always include both the release date and short hash token, for example:
-
-- `release/0.1.0-20260221.d24af0f`
 
 ### Branch naming
 
@@ -241,20 +172,14 @@ When your pull request changes something a user of the deployed app would notice
 
 ---
 
-## Platform compatibility
-
-This project runs on Windows, macOS, and Linux.
-
-- Use Node.js `path` module for paths, not hardcoded `/` or `\`
-- Use cross-platform approaches for file operations
-- Avoid OS-specific environment variables
-
-### Detailed guides
+## Detailed guides
 
 For step-by-step instructions and technical details:
 
 - [Manual Setup Guide](docs/how-tos/manual-setup.md): Development environment setup without DevContainers
-- [Add Terraform Environment](docs/how-tos/add-terraform-environment.md): Bootstrap, scaffold, lock file, and workflow updates for new environments
+- [Build the API Docker image](docs/how-tos/build-api-docker-image.md): Build and run the `apps/api` container locally
+- [Add Terraform Environment](docs/how-tos/add-terraform-environment.md): Infrastructure branch flow plus bootstrap, scaffold, lock file, and workflow updates for new environments
+- [Code conventions](docs/reference/code-conventions.md): Naming, shared types, test utilities, documentation strategy, and platform compatibility
 - [REST API conventions](docs/reference/rest-api-conventions.md): Route design, method semantics, status codes, error shape, and pagination
 
 ---

--- a/docs/how-tos/add-terraform-environment.md
+++ b/docs/how-tos/add-terraform-environment.md
@@ -7,25 +7,7 @@ SPDX-License-Identifier: MIT
 
 This guide explains how to add a new infrastructure environment such as `staging` to this repository.
 
----
-
-## Infrastructure branch flow
-
-Infrastructure automation follows this branch strategy:
-
-- `develop`: integration branch
-- `release/*`: release-train branches cut from `develop`
-- `main`: long-term release target branch, used when production flow is active
-
-Terraform workflow routing:
-
-- push to `develop`: applies `core` then `dev`
-- push to `release/*`: applies `core` then `staging`
-- pull requests to `develop`, `release/*`, and `main`: run Terraform plan checks
-
-When creating release branches, derive the name from the root `package.json` version using SemVer2 context and always include both the release date and short hash token, for example:
-
-- `release/0.1.0-20260221.d24af0f`
+For how branches map to environments and Terraform actions, see [Infrastructure branch flow](../reference/infrastructure-branch-flow.md).
 
 ---
 
@@ -93,7 +75,7 @@ Don't commit `.terraform/` directories.
 ## 5) Align GitHub workflows
 
 - In `.github/workflows/terraform-plan.yml`, copy one matrix entry and set `<environment>` + RO secret.
-- In `.github/workflows/terraform-apply.yml`, copy one job and set job id, `with.environment`, and RW secret.
+- In `.github/workflows/terraform-apply.yml`, copy one job and set job id, `with.environment`, and RW secret. Match the routing in [Infrastructure branch flow](../reference/infrastructure-branch-flow.md).
 - Keep `.github/workflows/terraform-apply-reusable.yml` unchanged.
 
 ---

--- a/docs/how-tos/add-terraform-environment.md
+++ b/docs/how-tos/add-terraform-environment.md
@@ -9,6 +9,26 @@ This guide explains how to add a new infrastructure environment such as `staging
 
 ---
 
+## Infrastructure branch flow
+
+Infrastructure automation follows this branch strategy:
+
+- `develop`: integration branch
+- `release/*`: release-train branches cut from `develop`
+- `main`: long-term release target branch, used when production flow is active
+
+Terraform workflow routing:
+
+- push to `develop`: applies `core` then `dev`
+- push to `release/*`: applies `core` then `staging`
+- pull requests to `develop`, `release/*`, and `main`: run Terraform plan checks
+
+When creating release branches, derive the name from the root `package.json` version using SemVer2 context and always include both the release date and short hash token, for example:
+
+- `release/0.1.0-20260221.d24af0f`
+
+---
+
 ## 1) Add bootstrap configuration
 
 Copy `infrastructure/terraform/bootstrap/dev.tf` to `infrastructure/terraform/bootstrap/<environment>.tf`, then update names and references.

--- a/docs/how-tos/build-api-docker-image.md
+++ b/docs/how-tos/build-api-docker-image.md
@@ -1,0 +1,24 @@
+<!--
+SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Build the API Docker image
+
+This guide covers building and running the `apps/api` Docker image locally.
+
+---
+
+## Build
+
+```bash
+docker build -f apps/api/Dockerfile -t genshin-api:local .
+```
+
+## Run
+
+```bash
+docker run -p 8080:8080 genshin-api:local
+```
+
+The API is available at `http://localhost:8080`. See [`apps/api/Dockerfile`](../../apps/api/Dockerfile) for build details and [`.github/workflows/`](../../.github/workflows/) for CI/CD pipeline information.

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -11,12 +11,18 @@ Conventions for how code in this repository is named, organized, and documented.
 
 ## Code comments
 
-For complex logic, decisions, or subtle patterns:
+Comments are the exception, not the rule. Don't restate what the code does—the reader can read it. Earn each comment by capturing what the code can't show: the _why_ behind it.
+
+Warranted cases:
 
 - Decisions and trade-offs—why you chose this approach
 - Workarounds—temporary fixes with issue references
 - Performance-sensitive code—explain the optimization
 - External dependencies—integration quirks or API specifics
+
+## Documentation strings
+
+Reach for a documentation string when a name alone can't convey a module or function's purpose or contract. State what it's for and when to use it over an alternative. Inline comments explain _why_ a line works. A documentation string explains _what_ an interface is for.
 
 ## Documentation strategy
 

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Code conventions
+
+Conventions for how code in this repository is named, organized, and documented. For the contribution workflow itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+---
+
+## Source file headers
+
+All source files require SPDX headers per the [REUSE Specification](https://reuse.software/). Use `reuse addheader` or check [REUSE docs](https://reuse.software/tutorial/) for details. For files without comment syntax, see [Add SPDX headers](../how-tos/add-spdx-headers.md).
+
+## Code comments
+
+For complex logic, decisions, or subtle patterns:
+
+- Decisions and trade-offs—why you chose this approach
+- Workarounds—temporary fixes with issue references
+- Performance-sensitive code—explain the optimization
+- External dependencies—integration quirks or API specifics
+
+## Documentation strategy
+
+When documenting decisions or conventions, prefer the highest-priority location that fits:
+
+1. **Inline comments**: explain _why_ code works a certain way.
+2. **Documentation strings**: explain module or function purpose when the name isn't sufficient.
+3. **`docs/`**: task-specific how-tos, references, and explanations following the [Diátaxis](https://diataxis.fr/) framework.
+4. **`CONTRIBUTING.md`**: high-level human workflow guidance and project conventions.
+5. **`.github/copilot-instructions.md`**: AI-specific decision rules.
+
+Avoid duplicating the same guidance across multiple locations. Place it once at the most appropriate level and link to it from others.
+
+## Naming conventions
+
+Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`.
+
+## Shared types
+
+Branded types in `packages/domain/` each get their own file (for example, `uuid.ts`, `iso-timestamp.ts`). Export both the type and any related validation functions from the same file.
+
+## Test utilities
+
+Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The build excludes this directory via `tsconfig.build.json`.
+
+---
+
+## Platform compatibility
+
+This project runs on Windows, macOS, and Linux.
+
+- Use Node.js `path` module for paths, not hardcoded `/` or `\`
+- Use cross-platform approaches for file operations
+- Avoid OS-specific environment variables

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -9,10 +9,6 @@ Conventions for how code in this repository is named, organized, and documented.
 
 ---
 
-## Source file headers
-
-All source files require SPDX headers per the [REUSE Specification](https://reuse.software/). Use `reuse addheader` or check [REUSE docs](https://reuse.software/tutorial/) for details. For files without comment syntax, see [Add SPDX headers](../how-tos/add-spdx-headers.md).
-
 ## Code comments
 
 For complex logic, decisions, or subtle patterns:

--- a/docs/reference/infrastructure-branch-flow.md
+++ b/docs/reference/infrastructure-branch-flow.md
@@ -9,6 +9,8 @@ How infrastructure automation maps branches to environments and Terraform action
 
 ## Branch strategy
 
+The long-lived branches follow a [git-flow](https://nvie.com/posts/a-successful-git-branching-model/)-style release model; how each maps to an environment deployment is specific to this project.
+
 - `develop`: integration branch
 - `release/*`: release-train branches cut from `develop`
 - `main`: long-term release target branch, used when production flow is active

--- a/docs/reference/infrastructure-branch-flow.md
+++ b/docs/reference/infrastructure-branch-flow.md
@@ -1,0 +1,30 @@
+<!--
+SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Infrastructure branch flow
+
+How infrastructure automation maps branches to environments and Terraform actions.
+
+## Branch strategy
+
+- `develop`: integration branch
+- `release/*`: release-train branches cut from `develop`
+- `main`: long-term release target branch, used when production flow is active
+
+## Terraform workflow routing
+
+| Trigger                                             | Action                        |
+| --------------------------------------------------- | ----------------------------- |
+| push to `develop`                                   | applies `core` then `dev`     |
+| push to `release/*`                                 | applies `core` then `staging` |
+| pull requests to `develop`, `release/*`, and `main` | run Terraform plan checks     |
+
+## Release-branch naming
+
+Derive the name from the root `package.json` version using SemVer2 context, and include both the release date and short hash token:
+
+```text
+release/0.1.0-20260221.d24af0f
+```


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` now answers "how do I contribute?" and links out for how the code is organized and how to build things, per #513. Reference material that made readers scan past workflow guidance moves to `docs/`, each in the Diátaxis mode that fits it:

- Code conventions → new `docs/reference/code-conventions.md`
- Docker build/run → new `docs/how-tos/build-api-docker-image.md`
- Infrastructure branch flow, Terraform routing, release-branch naming → new `docs/reference/infrastructure-branch-flow.md`, linked from the `add-terraform-environment` how-to

## Gotchas

- This closes a "move" issue but adds two conventions of its own to `code-conventions.md`: the "don't restate what the code does" default the comment guidance was missing, and a documentation-string trigger distinct from inline comments. The ladder dedup (shared with `.github/copilot-instructions.md`) and fuller docstring work it exposed are deferred to #877.
- The infra branch flow went to a reference doc, not the `add-terraform-environment` how-to #513 named — it's a lookup table of branch→environment→action, not steps. Its rationale and implications for infra and apps are deferred to a DSGEP, #954.
- SPDX is absent from the conventions doc on purpose: `reuse lint` enforces it and it has a how-to, so `CONTRIBUTING.md` notes it as a gate instead of restating the rule. The rest of the enforced-vs-judgment audit is #950.
- The Testing section stays in `CONTRIBUTING.md`: #875 codified it there and `CLAUDE.md` points contributors at it there, so moving it would dangle that pointer.

Closes #513