### PR TITLE
feat(ci): reuse Turborepo cache across CI runs

### DIFF
--- a/.github/actions/node-ci/action.yml
+++ b/.github/actions/node-ci/action.yml
@@ -28,6 +28,22 @@ runs:
   steps:
     - uses: ./.github/actions/setup-node-pnpm
 
+    # Persist Turborepo's local cache so unchanged workspace packages (most
+    # visibly the shared `^build` deps @genshin/domain and @genshin/game-data)
+    # skip redundant rebuilds across runs. Turbo content-addresses each task by
+    # hashed inputs, so a per-commit key with a prefix restore-key gives the
+    # "restore newest, always save fresh" pattern: the exact key only hits on a
+    # re-run of the same commit, otherwise restore-keys warms the cache from the
+    # leg's previous run. Scoped per matrix leg (flag) to avoid parallel jobs
+    # racing on one key.
+    - name: Cache Turborepo
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ inputs.flag }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-${{ inputs.flag }}-
+
     - name: Typecheck
       shell: bash
       env:

--- a/.github/actions/node-ci/action.yml
+++ b/.github/actions/node-ci/action.yml
@@ -28,14 +28,11 @@ runs:
   steps:
     - uses: ./.github/actions/setup-node-pnpm
 
-    # Persist Turborepo's local cache so unchanged workspace packages (most
-    # visibly the shared `^build` deps @genshin/domain and @genshin/game-data)
-    # skip redundant rebuilds across runs. Turbo content-addresses each task by
-    # hashed inputs, so a per-commit key with a prefix restore-key gives the
-    # "restore newest, always save fresh" pattern: the exact key only hits on a
-    # re-run of the same commit, otherwise restore-keys warms the cache from the
-    # leg's previous run. Scoped per matrix leg (flag) to avoid parallel jobs
-    # racing on one key.
+    # Persist turbo's local cache so unchanged packages skip rebuilds across
+    # runs. GitHub cache entries are write-once per key, so a stable key would
+    # freeze after the first save; the per-commit key saves a fresh entry each
+    # run while the prefix restore-key restores the leg's most recent one.
+    # Per-leg scoping keeps parallel legs from racing a shared key.
     - name: Cache Turborepo
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:


### PR DESCRIPTION
## Summary

CI legs no longer rebuild unchanged workspace packages on every run. The
`node-ci` composite restores turbo's local `.turbo` cache with
`actions/cache`, reusing the shared `^build` outputs every leg pulls in.
Closes #759.

## Gotchas

- Cache sits on `node-ci`, not the broader `setup-node-pnpm`. That action's
  other consumers (pre-commit, schema-compat, deploy) don't run the matrix
  build, so caching there would be pure overhead.
- The per-commit cache key looks redundant but is deliberate: GitHub cache
  entries are write-once per key, so a stable key would freeze after the
  first save. The restore-key restores the leg's most recent entry each run.
- Cross-run cache hits only appear once two runs of the same leg land —
  nothing observable in this PR's own CI beyond continued correctness.
- Chose `actions/cache` over Turborepo Remote Caching: no Vercel account or
  self-hosted server to stand up.

## Verification

- Confirmed turbo writes content-addressed tarballs to `.turbo/cache`, which
  sits at the repo root in CI's plain checkout and is captured by
  `path: .turbo`. (Locally it resolves to the primary worktree's cache — a
  shared-worktree behavior that doesn't apply to CI's single clone.)