### PR TITLE
fix(ci): exempt pin/digest updates from release-age bake

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
   },
   "packageRules": [
     {
+      "description": "Exempt update types that carry no release timestamp from the minimum release-age bake, so their renovate/stability-days check can resolve under internalChecksFilter:strict",
+      "matchUpdateTypes": ["pin", "pinDigest", "digest", "lockFileMaintenance"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "description": "Group all npm dependencies in a single PR",
       "matchManagers": ["npm"],
       "groupName": "npm dependencies",


### PR DESCRIPTION
## Summary

`rangeStrategy: pin` (#854) and the supply-chain bake (`minimumReleaseAge` + `internalChecksFilter: strict`, #793) are individually fine but mutually incompatible: `pin`, `pinDigest`, `digest`, and `lockFileMaintenance` updates carry no release timestamp, so Renovate treats them as never old enough and their `renovate/stability-days` check stays `pending` forever. Under `internalChecksFilter: strict` the PR is parked behind that unsatisfiable check indefinitely. A `packageRules` carve-out sets `minimumReleaseAge: 0` for those update types so the gate resolves; the tag/digest is already SHA-pinned to a release that baked on its own, so the zero-day gate loses nothing.

Verified live on the current queue: `renovate/stability-days` is `pending — Updates have not met minimum release age requirement` on #898 (node `pinDigest`), #819 (actions `pin`), #899 (terraform `pin`), and #904/#905 (`lockFileMaintenance`), while ordinary version bumps (#901 already green, #900 aging) are unaffected.

Mirrors the fix alunduil-chezmoi landed in its #279; the shared renovate skill still teaches the trap, tracked in its #406.

## Gotchas

- `lockFileMaintenance` is in the carve-out on the same root cause (no timestamp; #904/#905 stuck identically). This is orthogonal to the OOM-driven Renovate stall in #960 — that freezes `stability-days` a different way and is not addressed here.
- Takes effect only once merged to `develop` and Renovate re-runs on its own schedule. Don't tick "rebase all open PRs" on dashboard #416 to force it — that can re-trigger the #960 stall.

## Verification

- `pre-commit run renovate-config-validator` (the repo's `--strict --no-global` hook) passed.
- Read the live `renovate/stability-days` commit status on each affected branch via `gh api` to confirm which PRs are stuck by this mechanism vs. baking normally.