### PR TITLE
style(docs): reformat vale toggles for prettier 3.9.x

### DIFF
--- a/docs/explanation/dsgep-003-json-schema-strategy.md
+++ b/docs/explanation/dsgep-003-json-schema-strategy.md
@@ -312,6 +312,7 @@ app.get('/schemas/:module/:name.json', async (c) => {
 
 - [`rest-api-conventions.md`](../reference/rest-api-conventions.md): Principle 4, predictable representation shapes
 - [JSON Schema 2020-12](https://json-schema.org/draft/2020-12): Schema vocabulary
+
 <!-- vale alex.Condescending = NO -->
 
 - [RFC 5829: Link Relation Types for Simple Version Navigation](https://www.rfc-editor.org/rfc/rfc5829): `successor-version` relation type for major version transitions

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -158,7 +158,9 @@ These principles guide route design, method semantics, status code usage, error 
 <!-- vale Vale.Spelling = NO -->
 
 - [Masse2011] Mark Masse. _REST API Design Rulebook_. O'Reilly Media, 2011. ISBN 978-1-4493-1050-9. <https://www.amazon.co.uk/REST-Design-Rulebook-Mark-Masse/dp/1449310508>
+
 <!-- vale Vale.Spelling = YES -->
+
 - [RFC9110] Nottingham, M., et al. _RFC 9110: HTTP Semantics_. IETF, 2022. Status codes: Section 15. <https://www.rfc-editor.org/rfc/rfc9110>
 - [RFC6838] Freed, N., et al. _RFC 6838: Media Type Specifications and Registration Procedures_. IETF, 2013. <https://www.rfc-editor.org/rfc/rfc6838>
 - [RFC9457] Nottingham, M., Wilde, E., and Dalal, S. _RFC 9457: Problem Details for HTTP APIs_. IETF, 2023. <https://www.rfc-editor.org/rfc/rfc9457>


### PR DESCRIPTION
## Summary

Prettier 3.9.x enforces blank lines around HTML comments that interrupt a Markdown list. The `<!-- vale ... -->` toggles in `dsgep-003-json-schema-strategy.md` and `rest-api-conventions.md` were formatted under 3.8.3 and are non-conforming under 3.9.x. Renovate's prettier 3.8.3 → 3.9.5 bump (#900) installs the new prettier, so the `--all-files` prettier hook in the `Local Hooks` job rewrites these two docs and fails — which is why #900 can never go green. This applies the 3.9.x formatting ahead of the bump so #900 lands clean on its next rebase.

## Gotchas

Reformatting under 3.9.5 while develop still pins 3.8.3 is safe: 3.8.3 leaves these blank lines untouched (verified), so this passes `Local Hooks` on the current pin. `Local Hooks`' `--all-files` prettier flagged exactly these two files, so this is the complete set.

## Verification

Ran prettier 3.9.5 in a clean install — the output blobs match the exact hashes `Local Hooks` produced on #900 (`55b510f`, `72fa6f4`). Full `pre-commit run --files` on both docs passes under the current 3.8.3 pin.
