### PR TITLE
ci: align CI Terraform with pinned required_version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.9.0'
+          terraform_version: '1.15.8'
           terraform_wrapper: false
 
       - name: Read Firebase Config from Terraform

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.9.0'
+          terraform_version: '1.15.8'
 
       - name: Run ESLint hook
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.9.0'
+          terraform_version: '1.15.8'
 
       # Each environment maps to an explicit secret to avoid dynamic secret
       # indexing, which fixes CodeQL actions/excessive-secrets-exposure.

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.9.0'
+          terraform_version: '1.15.8'
 
       # Authenticate to GCP using Workload Identity.
       # Each environment maps to an explicit secret reference so this step

--- a/infrastructure/terraform/bootstrap/.terraform.lock.hcl
+++ b/infrastructure/terraform/bootstrap/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "7.33.0"
-  constraints = "~> 7.19"
+  constraints = "7.33.0"
   hashes = [
     "h1:5h9YX0qkxVIa9WL5J1+g6gIUBkFLlN+SfXZdYvXNSBw=",
     "h1:AtuVYxtxBEHMS9o/9HR2bg9Z/Ta4MLckXhSOwX8PWFs=",

--- a/infrastructure/terraform/bootstrap/main.tf
+++ b/infrastructure/terraform/bootstrap/main.tf
@@ -3,11 +3,11 @@
 # Bootstrap environment: creates GCP projects with foundational setup
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "1.15.8"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.19"
+      version = "7.33.0"
     }
   }
 }

--- a/infrastructure/terraform/bootstrap/modules/github_oidc_bindings/main.tf
+++ b/infrastructure/terraform/bootstrap/modules/github_oidc_bindings/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.19"
+      version = "7.33.0"
     }
   }
 }

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/main.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.19"
+      version = "7.33.0"
     }
   }
 }

--- a/infrastructure/terraform/environments/core/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/core/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "7.33.0"
-  constraints = "~> 7.19"
+  constraints = "7.33.0"
   hashes = [
     "h1:5h9YX0qkxVIa9WL5J1+g6gIUBkFLlN+SfXZdYvXNSBw=",
     "h1:AtuVYxtxBEHMS9o/9HR2bg9Z/Ta4MLckXhSOwX8PWFs=",

--- a/infrastructure/terraform/environments/core/main.tf
+++ b/infrastructure/terraform/environments/core/main.tf
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "1.15.8"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.19"
+      version = "7.33.0"
     }
   }
 }

--- a/infrastructure/terraform/environments/dev/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/dev/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "7.33.0"
-  constraints = "~> 7.19"
+  constraints = "7.33.0"
   hashes = [
     "h1:5h9YX0qkxVIa9WL5J1+g6gIUBkFLlN+SfXZdYvXNSBw=",
     "h1:AtuVYxtxBEHMS9o/9HR2bg9Z/Ta4MLckXhSOwX8PWFs=",
@@ -33,7 +33,7 @@ provider "registry.terraform.io/hashicorp/google" {
 
 provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "7.33.0"
-  constraints = "~> 7.19"
+  constraints = "7.33.0"
   hashes = [
     "h1:+ebuSrWdqlPdWN8CmuhMqU5/mCCY3I/c/sTlXDLGsCM=",
     "h1:7Tw1WnPcx+oG6sNwkNx5hfRaa0JfTJF16lMnxQ4LiCk=",

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: MIT
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "1.15.8"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.19"
+      version = "7.33.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 7.19"
+      version = "7.33.0"
     }
   }
 }

--- a/infrastructure/terraform/environments/staging/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/staging/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "7.33.0"
-  constraints = "~> 7.19"
+  constraints = "7.33.0"
   hashes = [
     "h1:5h9YX0qkxVIa9WL5J1+g6gIUBkFLlN+SfXZdYvXNSBw=",
     "h1:AtuVYxtxBEHMS9o/9HR2bg9Z/Ta4MLckXhSOwX8PWFs=",

--- a/infrastructure/terraform/environments/staging/main.tf
+++ b/infrastructure/terraform/environments/staging/main.tf
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "1.15.8"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.19"
+      version = "7.33.0"
     }
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,13 @@
       "addLabels": ["terraform", "infrastructure"]
     },
     {
+      "description": "Bump the Terraform CLI version in lockstep across the infrastructure required_version constraint and the CI workflow terraform_version pins",
+      "matchDepNames": ["hashicorp/terraform"],
+      "groupName": "terraform dependencies",
+      "groupSlug": "terraform",
+      "addLabels": ["terraform", "infrastructure"]
+    },
+    {
       "description": "Group all GitHub Actions updates in a single PR",
       "matchManagers": ["github-actions"],
       "groupName": "github actions",
@@ -93,6 +100,15 @@
       "matchStrings": ["REUSE_VERSION=\"\\$\\{REUSE_VERSION:-(?<currentValue>[^}]+)\\}\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "fsfe/reuse-tool",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Track terraform_version in the CI workflows against hashicorp/terraform releases",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": ["terraform_version: ['\"](?<currentValue>[^'\"]+)['\"]"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "hashicorp/terraform",
       "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ]


### PR DESCRIPTION
## Summary

Renovate's dependency pin (#899) raised the Terraform `required_version`
constraint to an exact `1.15.8`, but the CI workflows still installed
`1.9.0` via `setup-terraform`, so every `terraform` plan job failed at
init with "Unsupported Terraform Core version." This carries #899's
provider/version pins, bumps the four workflow `terraform_version` pins
to `1.15.8`, and adds a Renovate custom manager so the CLI version and
`required_version` bump together from here on. Supersedes #899.

## Gotchas

- The `terraform_version` pin lives in four workflows (`deploy`,
  `pre-commit`, `terraform-apply-reusable`, `terraform-plan`); all four
  must match `required_version` or plan/apply init fails again.
- The new custom manager's `matchStrings` regex is unverified against a
  live Renovate run — worth confirming it extracts `terraform_version:
  '1.15.8'` so future CLI bumps actually group with the terraform PR.