### PR TITLE
docs(api): clarify members wire encoding in team ALPS profile

### DIFF
--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -31,7 +31,7 @@ export const teamItemV1 = {
           type: 'semantic',
           doc: {
             value:
-              'Team members, transported as a JSON-encoded string value in the Collection+JSON data element; clients parse it into an array of exactly 4 character positions (null represents an empty position). The nested descriptors below document the logical structure of each parsed member, not separate wire data elements.',
+              'Team members, JSON-encoded as a string: an array of exactly 4 positions (null represents an empty position). The nested descriptors below describe each decoded member.',
           },
           descriptor: [
             {

--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -31,7 +31,7 @@ export const teamItemV1 = {
           type: 'semantic',
           doc: {
             value:
-              'Team members (exactly 4 character positions; null represents an empty position)',
+              'Team members, transported as a JSON-encoded string value in the Collection+JSON data element; clients parse it into an array of exactly 4 character positions (null represents an empty position). The nested descriptors below document the logical structure of each parsed member, not separate wire data elements.',
           },
           descriptor: [
             {

--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -31,7 +31,7 @@ export const teamItemV1 = {
           type: 'semantic',
           doc: {
             value:
-              'Team members, JSON-encoded as a string: an array of exactly 4 positions (null represents an empty position). The nested descriptors below describe each decoded member.',
+              'Team members: a JSON string holding an array of exactly 4 positions (null represents an empty position). Clients parse it to recover the array; the nested descriptors below describe each member.',
           },
           descriptor: [
             {


### PR DESCRIPTION
## Summary

The team ALPS profile (`apps/api/src/profiles/alps/team/item-v1.ts`) documented `members` with nested descriptors as if it were structured Collection+JSON data, but `serialiseTeam` in `@genshin/domain` emits `members` as a single JSON-encoded string datum. ALPS-aware clients would expect structured items and instead hit a string to parse. This documents the encoding on the `members` descriptor and reframes the nested descriptors as the logical structure of each parsed member.

## Gotchas

- The issue names `apps/api/src/profiles/teams/1.0.0.json`; that file no longer exists — #571 converted profiles to typed TS modules under `alps/team/`. The wire mismatch it describes is still real, so this fixes it at the new location.
- Doc-only change: descriptor ids are untouched, so no new `-v2` profile is warranted under the immutable-published-profile rule.
- This documents the JSON-string escape hatch rather than fixing it. Whether Collection+JSON's flat data model is the right transport for nested resources is the deeper question, tracked in #966.

## Verification

- `pnpm turbo run typecheck lint test --filter=@genshin/api` — all pass (195 tests), including the profile-serving route.

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvgL3EzReKnhoTwSdzbHvT