### PR TITLE
feat(domain): validate artifact plan element types and cardinalities

### DIFF
--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { Item } from '@genshin/collection-json';
 import { describe, expect, it } from 'vitest';
 
 import { deserialiseTeam, serialiseTeam } from './teams.js';
@@ -88,5 +89,62 @@ describe('team serialisation round-trip', () => {
     const item = serialiseTeam(team, BASE_URL);
     const result = deserialiseTeam(item);
     expect(result.members[0]?.artifactPlan).toEqual(team.members[0]?.artifactPlan);
+  });
+});
+
+describe('deserialiseTeam artifact plan validation', () => {
+  const VALID_PLAN = {
+    sands: 'ATK Percentage',
+    goblet: 'Hydro DMG Bonus',
+    circlet: 'CRIT Rate',
+    sets: ['aubade-of-morningstar-and-moon'],
+    priorityMinorAffixes: ['CRIT Rate'],
+    secondaryMinorAffixes: ['ATK Percentage'],
+  };
+
+  function itemWithArtifactPlan(artifactPlan: unknown): Item {
+    const members = [{ characterId: 'columbina', artifactPlan }, null, null, null];
+    return {
+      href: `${BASE_URL}/api/teams/1`,
+      data: [
+        { name: 'slot', value: 1 },
+        { name: 'name', value: 'Team 1' },
+        { name: 'members', value: JSON.stringify(members) },
+        { name: 'createdAt', value: VALID_TIMESTAMP },
+        { name: 'updatedAt', value: VALID_TIMESTAMP },
+      ],
+    };
+  }
+
+  it('rejects a non-string element in sets', () => {
+    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: [42] });
+    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets\[0\] must be a string/);
+  });
+
+  it('rejects a non-string element in a minor affix array', () => {
+    const item = itemWithArtifactPlan({ ...VALID_PLAN, priorityMinorAffixes: [null] });
+    expect(() => deserialiseTeam(item)).toThrow(
+      /artifactPlan\.priorityMinorAffixes\[0\] must be a string/,
+    );
+  });
+
+  it('rejects sets with fewer than 1 element', () => {
+    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: [] });
+    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets must have between 1 and 2/);
+  });
+
+  it('rejects sets with more than 2 elements', () => {
+    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: ['a', 'b', 'c'] });
+    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets must have between 1 and 2/);
+  });
+
+  it('rejects a minor affix array with more than 3 elements', () => {
+    const item = itemWithArtifactPlan({
+      ...VALID_PLAN,
+      secondaryMinorAffixes: ['a', 'b', 'c', 'd'],
+    });
+    expect(() => deserialiseTeam(item)).toThrow(
+      /artifactPlan\.secondaryMinorAffixes must have between 0 and 3/,
+    );
   });
 });

--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -116,6 +116,21 @@ describe('deserialiseTeam artifact plan validation', () => {
     };
   }
 
+  it('rejects an artifact plan that is not an object', () => {
+    const item = itemWithArtifactPlan('not-an-object');
+    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan must be a non-null object/);
+  });
+
+  it('rejects a non-string main affix field', () => {
+    const item = itemWithArtifactPlan({ ...VALID_PLAN, sands: 42 });
+    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sands must be a string/);
+  });
+
+  it('rejects a set field that is not an array', () => {
+    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: 'aubade-of-morningstar-and-moon' });
+    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets must be an array/);
+  });
+
   it('rejects a non-string element in sets', () => {
     const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: [42] });
     expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets\[0\] must be a string/);

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -78,12 +78,29 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
       );
     }
   }
+  const cardinalities = {
+    sets: { min: 1, max: 2 },
+    priorityMinorAffixes: { min: 0, max: 3 },
+    secondaryMinorAffixes: { min: 0, max: 3 },
+  } as const;
   for (const field of ['sets', 'priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
-    if (!Array.isArray(plan[field])) {
+    const arr = plan[field];
+    if (!Array.isArray(arr)) {
+      throw new TypeError(`artifactPlan.${field} must be an array, got: ${JSON.stringify(arr)}`);
+    }
+    const { min, max } = cardinalities[field];
+    if (arr.length < min || arr.length > max) {
       throw new TypeError(
-        `artifactPlan.${field} must be an array, got: ${JSON.stringify(plan[field])}`,
+        `artifactPlan.${field} must have between ${min} and ${max} elements, got: ${arr.length}`,
       );
     }
+    arr.forEach((element, index) => {
+      if (typeof element !== 'string') {
+        throw new TypeError(
+          `artifactPlan.${field}[${index}] must be a string, got: ${JSON.stringify(element)}`,
+        );
+      }
+    });
   }
   return value as ArtifactPlan;
 }

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -66,42 +66,49 @@ export function teamItemDocument(team: CollectionTeam, baseUrl: string): Collect
   });
 }
 
+function assertString(plan: Record<string, unknown>, field: string): void {
+  if (typeof plan[field] !== 'string') {
+    throw new TypeError(
+      `artifactPlan.${field} must be a string, got: ${JSON.stringify(plan[field])}`,
+    );
+  }
+}
+
+function assertStringArray(
+  plan: Record<string, unknown>,
+  field: string,
+  min: number,
+  max: number,
+): void {
+  const arr = plan[field];
+  if (!Array.isArray(arr)) {
+    throw new TypeError(`artifactPlan.${field} must be an array, got: ${JSON.stringify(arr)}`);
+  }
+  if (arr.length < min || arr.length > max) {
+    throw new TypeError(
+      `artifactPlan.${field} must have between ${min} and ${max} elements, got: ${arr.length}`,
+    );
+  }
+  arr.forEach((element, index) => {
+    if (typeof element !== 'string') {
+      throw new TypeError(
+        `artifactPlan.${field}[${index}] must be a string, got: ${JSON.stringify(element)}`,
+      );
+    }
+  });
+}
+
 function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
   if (value === null || typeof value !== 'object') {
     throw new TypeError(`artifactPlan must be a non-null object, got: ${JSON.stringify(value)}`);
   }
   const plan = value as Record<string, unknown>;
-  for (const field of ['sands', 'goblet', 'circlet'] as const) {
-    if (typeof plan[field] !== 'string') {
-      throw new TypeError(
-        `artifactPlan.${field} must be a string, got: ${JSON.stringify(plan[field])}`,
-      );
-    }
-  }
-  const cardinalities = {
-    sets: { min: 1, max: 2 },
-    priorityMinorAffixes: { min: 0, max: 3 },
-    secondaryMinorAffixes: { min: 0, max: 3 },
-  } as const;
-  for (const field of ['sets', 'priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
-    const arr = plan[field];
-    if (!Array.isArray(arr)) {
-      throw new TypeError(`artifactPlan.${field} must be an array, got: ${JSON.stringify(arr)}`);
-    }
-    const { min, max } = cardinalities[field];
-    if (arr.length < min || arr.length > max) {
-      throw new TypeError(
-        `artifactPlan.${field} must have between ${min} and ${max} elements, got: ${arr.length}`,
-      );
-    }
-    arr.forEach((element, index) => {
-      if (typeof element !== 'string') {
-        throw new TypeError(
-          `artifactPlan.${field}[${index}] must be a string, got: ${JSON.stringify(element)}`,
-        );
-      }
-    });
-  }
+  assertString(plan, 'sands');
+  assertString(plan, 'goblet');
+  assertString(plan, 'circlet');
+  assertStringArray(plan, 'sets', 1, 2);
+  assertStringArray(plan, 'priorityMinorAffixes', 0, 3);
+  assertStringArray(plan, 'secondaryMinorAffixes', 0, 3);
   return value as ArtifactPlan;
 }
 


### PR DESCRIPTION
## Summary

`deserialiseArtifactPlan` now rejects malformed artifact-plan wire data instead of casting it to `ArtifactPlan` unchecked: array elements must be strings, `sets` must hold 1-2 entries, and each minor-affix array at most 3. The route handler's `validateArtifactPlan` already catches these on write, but the deserialiser is shared by API and web and should enforce shape on its own.

Closes #506

## Gotchas

- Textual overlap with open PR #964, which rewrites the same function for #510 (property stripping) and explicitly defers this validation here. Whichever merges second resolves a small conflict in this one loop.
- The issue's field names (`primaryStats`/`secondaryStats`) predate a rename; the real fields are `priorityMinorAffixes`/`secondaryMinorAffixes`. Cardinalities follow the `ArtifactPlan` interface docs and `validateArtifactPlan`.
- Existing require-present behaviour is preserved — this PR adds element/length checks on top, it doesn't relax the fields to optional.