### PR TITLE
fix(domain): validate ArtifactPlan.sets length at boundaries

### DIFF
--- a/apps/api/src/repositories/teams/document.test.ts
+++ b/apps/api/src/repositories/teams/document.test.ts
@@ -119,6 +119,40 @@ describe('fromDocument', () => {
     const team = fromDocument(1, makeV1Document({ description: 'My best team' }));
     expect(team.description).toBe('My best team');
   });
+
+  it('narrows an artifact plan with 2 sets to a tuple', () => {
+    const team = fromDocument(
+      1,
+      makeV1Document({
+        members: [
+          {
+            characterId: 'columbina',
+            artifactPlan: { sets: ['golden-troupe', 'marechaussee-hunter'] },
+          },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.sets).toEqual(['golden-troupe', 'marechaussee-hunter']);
+  });
+
+  it('rejects an artifact plan with more than 2 sets', () => {
+    expect(() =>
+      fromDocument(
+        1,
+        makeV1Document({
+          members: [
+            { characterId: 'columbina', artifactPlan: { sets: ['a', 'b', 'c'] } },
+            null,
+            null,
+            null,
+          ],
+        }),
+      ),
+    ).toThrow(TypeError);
+  });
 });
 
 describe('toDocument', () => {

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  ArtifactPlan,
   CollectionTeam,
   CollectionTeamMember,
   CollectionTeamMembers,
   ISOTimestamp,
   TeamSlot,
+  UUID,
 } from '@genshin/domain';
-import { assertCollectionTeam } from '@genshin/domain';
+import { asArtifactSets, assertCollectionTeam } from '@genshin/domain';
 
 import {
   entity,
@@ -20,12 +22,22 @@ import {
 
 export { CURRENT_VERSION, type V1Team, type V0Team };
 
+function artifactPlanFromDocument(plan: NonNullable<V1Member['artifactPlan']>): ArtifactPlan {
+  const { sets, ...rest } = plan;
+  return {
+    ...rest,
+    ...(sets !== undefined ? { sets: asArtifactSets(sets) } : {}),
+  } as ArtifactPlan;
+}
+
 function memberFromDocument(m: V1Member): CollectionTeamMember {
   return {
     characterId: m.characterId,
-    ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
-    ...(m.artifactPlan !== undefined ? { artifactPlan: m.artifactPlan } : {}),
-  } as CollectionTeamMember;
+    ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId as UUID } : {}),
+    ...(m.artifactPlan !== undefined
+      ? { artifactPlan: artifactPlanFromDocument(m.artifactPlan) }
+      : {}),
+  };
 }
 
 function memberToDocument(m: CollectionTeamMember): V1Member {

--- a/packages/domain/src/artifact/artifact-plan.ts
+++ b/packages/domain/src/artifact/artifact-plan.ts
@@ -32,3 +32,22 @@ export interface ArtifactPlan {
   /** 0–3 secondary minor affixes (must be disjoint from priorityMinorAffixes) */
   secondaryMinorAffixes?: ArtifactMinorAffix[];
 }
+
+/**
+ * Narrow a boundary array of set IDs into the 1–2 tuple {@link ArtifactPlan.sets}
+ * requires. The Firestore document model, Collection+JSON wire format, and JSON
+ * Schema all carry `sets` as a plain array; this is the single place the 1–2
+ * length invariant is enforced when that array crosses into the domain model.
+ * Throws {@link TypeError} for anything that is not an array of 1 or 2 strings.
+ */
+export function asArtifactSets(value: unknown): NonNullable<ArtifactPlan['sets']> {
+  const ids: readonly unknown[] = Array.isArray(value) ? value : [];
+  if (ids.length < 1 || ids.length > 2 || !ids.every((id) => typeof id === 'string')) {
+    throw new TypeError(
+      `artifactPlan.sets must be an array of 1-2 string IDs, got: ${JSON.stringify(value)}`,
+    );
+  }
+  return ids.length === 1
+    ? [ids[0] as ArtifactSet['id']]
+    : [ids[0] as ArtifactSet['id'], ids[1] as ArtifactSet['id']];
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 export { issue, isValid, prefixPaths, type ValidationIssue } from '@genshin/validation';
-export { type ArtifactPlan } from './artifact/artifact-plan.js';
+export { type ArtifactPlan, asArtifactSets } from './artifact/artifact-plan.js';
 export { validateArtifactPlan } from './artifact/artifact-plan-validation.js';
 export type { AuthIdentity } from './profile/auth-identity.js';
 export {

--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -65,6 +65,33 @@ describe('team serialisation round-trip', () => {
     expect(result.members[0]?.weaponInstanceId).toBe('wep-001');
   });
 
+  it('rejects a member artifact plan with more than 2 sets', () => {
+    const badMembers = [
+      {
+        characterId: 'columbina',
+        artifactPlan: {
+          sands: 'ATK Percentage',
+          goblet: 'Hydro DMG Bonus',
+          circlet: 'CRIT Rate',
+          sets: ['aubade-of-morningstar-and-moon', 'golden-troupe', 'gilded-dreams'],
+          priorityMinorAffixes: [],
+          secondaryMinorAffixes: [],
+        },
+      },
+      null,
+      null,
+      null,
+    ];
+    const item = serialiseTeam(VALID_TEAM, BASE_URL);
+    const tampered = {
+      ...item,
+      data: item.data.map((d) =>
+        d.name === 'members' ? { ...d, value: JSON.stringify(badMembers) } : d,
+      ),
+    };
+    expect(() => deserialiseTeam(tampered)).toThrow(TypeError);
+  });
+
   it('preserves artifact plans on members through round-trip', () => {
     const team: CollectionTeam = {
       ...VALID_TEAM,

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -21,7 +21,7 @@ import {
   type Template,
 } from '@genshin/collection-json';
 
-import type { ArtifactPlan } from '../../artifact/artifact-plan.js';
+import { asArtifactSets, type ArtifactPlan } from '../../artifact/artifact-plan.js';
 import type { CollectionTeamMember } from '../../team/collection-team-member.js';
 import type { CollectionTeam, CollectionTeamMembers } from '../../team/collection-team.js';
 import { assertCollectionTeam, MAX_TEAM_MEMBERS } from '../../team/collection-team.js';
@@ -78,13 +78,14 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
       );
     }
   }
-  for (const field of ['sets', 'priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
+  for (const field of ['priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
     if (!Array.isArray(plan[field])) {
       throw new TypeError(
         `artifactPlan.${field} must be an array, got: ${JSON.stringify(plan[field])}`,
       );
     }
   }
+  plan.sets = asArtifactSets(plan.sets);
   return value as ArtifactPlan;
 }
 


### PR DESCRIPTION
**Superseded by #935 / #601** — closed unmerged. #505 is closed as superseded; the named-fields refactor removes the mismatch this PR validated around.

---

## Summary

`ArtifactPlan.sets` is a 1–2 tuple in the domain but a plain array everywhere it's stored or transmitted (Firestore, Collection+JSON, JSON Schema). Blanket `as` casts at the document and wire deserialisers papered over that gap, so a persisted document or payload carrying 0 or 3+ sets reached the domain unchecked. It now throws at the boundary.

Closes #505

## Gotchas

- AC #1 ("no `as` casts") reads broader than the fix warrants. The boundary casts also narrow branded types (`weaponInstanceId → UUID`, main affixes → `SandsMainAffix`), which is the house pattern (`as UUID` recurs across the repo) and unrelated to the `sets` mismatch. What's gone is the blanket `as CollectionTeamMember` that *masked* structural and length validation; the remaining `as UUID` / `as ArtifactPlan` are brand-narrowing only.
- Kept the tuple type rather than weakening `sets` to `id[]` (the fork the issue posed) — the web planner relies on the tuple to index `sets[0]`/`sets[1]`. The 1–2 invariant now lives in one narrower, `asArtifactSets`.
- The request-body write path was already covered by `validateArtifactPlan`, so it's untouched.

## Verification

- `turbo run typecheck test lint` across domain + api (197 api tests, domain green); web typecheck clean.
- New tests at both boundaries reject a 3-set plan and preserve a valid 2-set plan.