### PR TITLE
fix: make pnpm dev work on a fresh checkout

### DIFF
--- a/.github/actions/node-ci/action.yml
+++ b/.github/actions/node-ci/action.yml
@@ -82,8 +82,20 @@ runs:
         report_type: test_results
         fail_ci_if_error: false
 
+    # apps/web fails the build when its Firebase config is missing, so that a
+    # deployed bundle can never fall back to the local-emulator placeholders in
+    # lib/firebase.ts. This build only proves the app compiles and its output is
+    # discarded, so any non-empty value satisfies it. Deployed bundles come from
+    # the separate build step in deploy.yml, which injects the real config.
     - name: Build
       shell: bash
       env:
         FILTER: ${{ inputs.filter }}
+        VITE_API_BASE_URL: https://api.invalid
+        VITE_FIREBASE_API_KEY: ci
+        VITE_FIREBASE_AUTH_DOMAIN: ci.invalid
+        VITE_FIREBASE_PROJECT_ID: ci
+        VITE_FIREBASE_STORAGE_BUCKET: ci.invalid
+        VITE_FIREBASE_MESSAGING_SENDER_ID: ci
+        VITE_FIREBASE_APP_ID: ci
       run: pnpm turbo run build --filter="$FILTER"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Build
         run: pnpm turbo run build --filter=@genshin/web
         env:
-          VERIFY_ENV: 'true'
           VITE_API_BASE_URL: https://api.develop.genshin.dungeon.studio
           VITE_FIREBASE_API_KEY: ${{ steps.firebase-config.outputs.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ steps.firebase-config.outputs.VITE_FIREBASE_AUTH_DOMAIN }}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,10 +7,9 @@ import { auth } from '@/lib/firebase';
 
 export type { ProblemDetail };
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-if (!API_BASE_URL) {
-  throw new Error('Missing required environment variable: VITE_API_BASE_URL');
-}
+// Defaults to the local API server so `pnpm dev` works without any .env file;
+// see the same treatment of the Firebase config in @/lib/firebase.
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
 export class ApiError extends Error {
   readonly problem: ProblemDetail;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,8 +7,8 @@ import { auth } from '@/lib/firebase';
 
 export type { ProblemDetail };
 
-// Defaults to the local API server so `pnpm dev` works without any .env file;
-// see the same treatment of the Firebase config in @/lib/firebase.
+// `pnpm dev` needs no .env file; vite.config.ts fails deployed builds on a
+// missing variable.
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
 export class ApiError extends Error {

--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -4,36 +4,30 @@
 import { getApp, getApps, initializeApp } from 'firebase/app';
 import { connectAuthEmulator, getAuth } from 'firebase/auth';
 
-const requiredEnvVars = [
-  'VITE_FIREBASE_API_KEY',
-  'VITE_FIREBASE_AUTH_DOMAIN',
-  'VITE_FIREBASE_PROJECT_ID',
-  'VITE_FIREBASE_STORAGE_BUCKET',
-  'VITE_FIREBASE_MESSAGING_SENDER_ID',
-  'VITE_FIREBASE_APP_ID',
-] as const;
+const DEV_PROJECT_ID = 'demo-dungeon-studio-genshin-dev';
 
-for (const key of requiredEnvVars) {
-  if (!import.meta.env[key]) {
-    throw new Error(`Missing required environment variable: ${key}`);
-  }
-}
-
+// Fallbacks let `pnpm dev` run without any .env file; the Auth emulator
+// validates none of these. This mirrors the API supplying its own emulator
+// defaults in apps/api/src/lib/firebase/app.ts. A .env.local value still wins,
+// so pointing dev at real GCP stays possible. Deployed builds cannot reach the
+// fallbacks — vite.config.ts fails the build when a variable is missing.
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'demo-api-key',
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || `${DEV_PROJECT_ID}.firebaseapp.com`,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || DEV_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || `${DEV_PROJECT_ID}.appspot.com`,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '000000000000',
+  appId: import.meta.env.VITE_FIREBASE_APP_ID || '1:000000000000:web:0000000000000000000000',
 };
 
 // Safety: In dev mode, force the project ID to match the local Firebase
 // Emulators (started at the repository root with --project demo-dungeon-studio-genshin-dev).
+// This overrides rather than defaults, so a real project ID in .env.local still
+// cannot reach real Firestore from a dev server.
 // This mirrors the API's forced project ID in apps/api/src/lib/firebase/app.ts.
 // Dead-code-eliminated during production builds.
 if (import.meta.env.DEV) {
-  firebaseConfig.projectId = 'demo-dungeon-studio-genshin-dev';
+  firebaseConfig.projectId = DEV_PROJECT_ID;
 }
 
 const app = getApps().length > 0 ? getApp() : initializeApp(firebaseConfig);

--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -4,27 +4,29 @@
 import { getApp, getApps, initializeApp } from 'firebase/app';
 import { connectAuthEmulator, getAuth } from 'firebase/auth';
 
-const DEV_PROJECT_ID = 'demo-dungeon-studio-genshin-dev';
+const EMULATOR_PROJECT_ID = 'demo-dungeon-studio-genshin-dev';
 
 // The Auth emulator validates none of these, so `pnpm dev` needs no .env file.
 // Deployed bundles never carry the fallbacks: vite.config.ts fails the build on
-// a missing variable.
+// a missing variable, so dev, staging, and prod all run on injected config.
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'demo-api-key',
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || `${DEV_PROJECT_ID}.firebaseapp.com`,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || DEV_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || `${DEV_PROJECT_ID}.appspot.com`,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || `${EMULATOR_PROJECT_ID}.firebaseapp.com`,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || EMULATOR_PROJECT_ID,
+  storageBucket:
+    import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || `${EMULATOR_PROJECT_ID}.appspot.com`,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '000000000000',
   appId: import.meta.env.VITE_FIREBASE_APP_ID || '1:000000000000:web:0000000000000000000000',
 };
 
-// Safety: In dev mode, force the project ID to match the local Firebase
-// Emulators (started at the repository root with --project demo-dungeon-studio-genshin-dev).
-// A real project ID in .env.local cannot reach real Firestore from a dev server.
+// Safety: On the local dev server, force the project ID to match the Firebase
+// Emulators, started at the repository root with the matching --project flag.
+// A real project ID in .env.local cannot reach real Firestore from there. The
+// deployed dev environment is a different, real project and is unaffected.
 // This mirrors the API's forced project ID in apps/api/src/lib/firebase/app.ts.
 // Dead-code-eliminated during production builds.
 if (import.meta.env.DEV) {
-  firebaseConfig.projectId = DEV_PROJECT_ID;
+  firebaseConfig.projectId = EMULATOR_PROJECT_ID;
 }
 
 const app = getApps().length > 0 ? getApp() : initializeApp(firebaseConfig);

--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -6,11 +6,9 @@ import { connectAuthEmulator, getAuth } from 'firebase/auth';
 
 const DEV_PROJECT_ID = 'demo-dungeon-studio-genshin-dev';
 
-// Fallbacks let `pnpm dev` run without any .env file; the Auth emulator
-// validates none of these. This mirrors the API supplying its own emulator
-// defaults in apps/api/src/lib/firebase/app.ts. A .env.local value still wins,
-// so pointing dev at real GCP stays possible. Deployed builds cannot reach the
-// fallbacks — vite.config.ts fails the build when a variable is missing.
+// The Auth emulator validates none of these, so `pnpm dev` needs no .env file.
+// Deployed bundles never carry the fallbacks: vite.config.ts fails the build on
+// a missing variable.
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'demo-api-key',
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || `${DEV_PROJECT_ID}.firebaseapp.com`,
@@ -22,8 +20,7 @@ const firebaseConfig = {
 
 // Safety: In dev mode, force the project ID to match the local Firebase
 // Emulators (started at the repository root with --project demo-dungeon-studio-genshin-dev).
-// This overrides rather than defaults, so a real project ID in .env.local still
-// cannot reach real Firestore from a dev server.
+// A real project ID in .env.local cannot reach real Firestore from a dev server.
 // This mirrors the API's forced project ID in apps/api/src/lib/firebase/app.ts.
 // Dead-code-eliminated during production builds.
 if (import.meta.env.DEV) {

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -7,9 +7,9 @@ import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 
 import { server } from './msw/server';
 
-// @/lib/firebase throws at import unless the Firebase env vars are present, and
-// the API client reads auth.currentUser for bearer tokens. Stub it globally so
-// any module in the transitive import graph resolves without real Firebase.
+// @/lib/firebase initialises the SDK and connects the Auth emulator at import,
+// and the API client reads auth.currentUser for bearer tokens. Stub it globally
+// so any module in the transitive import graph resolves without real Firebase.
 vi.mock('@/lib/firebase', () => ({
   auth: { currentUser: null },
 }));

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -38,9 +38,9 @@ export default defineConfig({
     react(),
     {
       name: 'validate-env',
-      // Deployed builds get these injected by .github/workflows/deploy.yml.
-      // Failing here keeps placeholder defaults, which dev relies on, out of
-      // any bundle that ships.
+      // .github/workflows/deploy.yml injects these for deployed builds. Failing
+      // here keeps the dev fallbacks in lib/firebase.ts and lib/api.ts out of
+      // any shipped bundle.
       configResolved(config) {
         if (config.command !== 'build') return;
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -38,8 +38,11 @@ export default defineConfig({
     react(),
     {
       name: 'validate-env',
+      // Deployed builds get these injected by .github/workflows/deploy.yml.
+      // Failing here keeps placeholder defaults, which dev relies on, out of
+      // any bundle that ships.
       configResolved(config) {
-        if (config.command !== 'build' || process.env.VERIFY_ENV !== 'true') return;
+        if (config.command !== 'build') return;
 
         const missing = requiredEnvVars.filter((key) => !config.env[key]);
         if (missing.length > 0) {

--- a/docs/how-tos/manual-setup.md
+++ b/docs/how-tos/manual-setup.md
@@ -60,17 +60,15 @@ cd genshin.dungeon.studio
 # NOTE: The script assumes Debian/Ubuntu for the Google Cloud SDK install step.
 # On macOS or Fedora, install gcloud separately and run the remaining steps manually.
 .devcontainer/postCreateCommand.sh
-
-# Configure the web app for local emulators
-cp apps/web/.env.example apps/web/.env.local
 ```
 
 The script prints a verification summary at the end. If any tools fail
 verification, fix them and re-run the script.
 
-Edit `apps/web/.env.local` and fill in the Firebase client config. For local
-emulator development, any non-empty placeholder values work because the emulator
-doesn't validate them. See `apps/web/.env.example` for the full list.
+The web app needs no environment file for local development. It falls back to
+emulator-compatible defaults, which the emulators don't validate. To point it at
+real Firebase instead, copy `apps/web/.env.example` to `apps/web/.env.local` and
+fill in the values.
 
 ```bash
 # Start development servers

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,7 @@
       "outputs": ["dist/**", ".next/**", "build/**"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Summary

`pnpm dev` now starts and renders on a fresh checkout. It previously failed
twice: turbo started vite before workspace packages were built, so
`@genshin/game-data` did not resolve; past that, the app rendered a blank page
because `lib/firebase.ts` and `lib/api.ts` throw at module scope when a `VITE_`
variable is missing and nothing supplied one.

## Gotchas

- The dev fallbacks are only safe because `vite.config.ts` now validates on
  every build rather than behind `VERIFY_ENV` — review those together. Dropping
  the opt-in is the point: a future staging or prod job can't omit a flag that
  no longer exists and ship placeholder config.
- That gate is also why `.github/actions/node-ci` now passes throwaway `VITE_`
  values. CI builds every package to prove it compiles and discards the output;
  deployed bundles come from the separate build step in `deploy.yml`, and deploy
  restores no turbo cache.
- `EMULATOR_PROJECT_ID` is the emulators' fake project. The deployed dev
  environment is a different, real project whose ID differs only by the `demo-`
  prefix.
- Static `import.meta.env.X` access is load-bearing. Dynamic key lookup defeats
  Vite's replacement and would ship the fallbacks in deployed bundles.
- `codecov/patch` reads 0.00%: the diff reduces to one partial line (the `||` in
  `lib/api.ts`, whose env branch tests never take). Project coverage rises
  83.39% → 83.44%.

## Verification

- Deleted `packages/game-data/dist`, confirmed turbo rebuilds it before vite
  starts.
- Rendered `localhost:5173` headlessly with no env file: 0 console errors. This
  caught `VITE_API_BASE_URL`, which throws from a different module than the six
  Firebase names.
- `vite build` with no env now fails naming all seven; the same command
  succeeded before this change.
- Built with workflow-style injection and inspected `dist/assets`: real values
  present, exact placeholder strings absent.