### PR TITLE
chore: align renovate config with house conventions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.+)$
+  TERRAFORM_VERSION: '1.15.8'
+
 # Only one deploy per ref at a time. Cloud Run and the `:develop` image tag
 # are single mutable targets, so concurrent runs race: an older run's health
 # verification sees a newer run's SHA and fails with sha_mismatch. Cancelling
@@ -52,7 +56,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.15.8'
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
       - name: Read Firebase Config from Terraform

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.+)$
+  TERRAFORM_VERSION: '1.15.8'
+  # renovate: datasource=github-releases depName=hadolint/hadolint
+  HADOLINT_VERSION: 'v2.12.0'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main' }}
@@ -37,7 +43,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.15.8'
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: Run ESLint hook
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
@@ -81,7 +87,6 @@ jobs:
       - name: Install hadolint
         run: |
           set -euo pipefail
-          HADOLINT_VERSION=v2.12.0
           sudo curl -fsSL \
             "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
             -o /usr/local/bin/hadolint

--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.+)$
+  TERRAFORM_VERSION: '1.15.8'
+
 jobs:
   terraform-apply:
     runs-on: ubuntu-latest
@@ -37,7 +41,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.15.8'
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       # Each environment maps to an explicit secret to avoid dynamic secret
       # indexing, which fixes CodeQL actions/excessive-secrets-exposure.

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.+)$
+  TERRAFORM_VERSION: '1.15.8'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -43,7 +47,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: '1.15.8'
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       # Authenticate to GCP using Workload Identity.
       # Each environment maps to an explicit secret reference so this step

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     "security:openssf-scorecard",
     "customManagers:githubActionsVersions"
   ],
-  "schedule": ["before 6pm on friday"],
   "timezone": "Europe/London",
   "labels": ["dependencies", "automated"],
   "reviewers": ["alunduil"],
@@ -14,10 +13,6 @@
   "osvVulnerabilityAlerts": true,
   "pre-commit": {
     "enabled": true
-  },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["* 0-17 1-7 * 5"]
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "baseBranchPatterns": ["develop"],
+  "extends": [
+    "config:best-practices",
+    "security:openssf-scorecard",
+    "customManagers:githubActionsVersions"
+  ],
   "schedule": ["before 6pm on friday"],
   "timezone": "Europe/London",
   "labels": ["dependencies", "automated"],
   "reviewers": ["alunduil"],
-  "branchPrefix": "renovate/",
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",
-  "internalChecksFilter": "strict",
   "osvVulnerabilityAlerts": true,
-  "vulnerabilityAlerts": {
-    "minimumReleaseAge": "0 days"
-  },
   "pre-commit": {
     "enabled": true
   },
@@ -24,8 +22,17 @@
   "packageRules": [
     {
       "description": "Exempt update types that carry no release timestamp from the minimum release-age bake, so their renovate/stability-days check can resolve under internalChecksFilter:strict",
-      "matchUpdateTypes": ["pin", "pinDigest", "digest", "lockFileMaintenance"],
-      "minimumReleaseAge": "0 days"
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "lockfileUpdate",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
+      "minimumReleaseAge": null
     },
     {
       "description": "Group all npm dependencies in a single PR",
@@ -42,7 +49,7 @@
       "addLabels": ["terraform", "infrastructure"]
     },
     {
-      "description": "Bump the Terraform CLI version in lockstep across the infrastructure required_version constraint and the CI workflow terraform_version pins",
+      "description": "Bump the Terraform CLI version in lockstep across the infrastructure required_version constraint and the CI workflow TERRAFORM_VERSION pins",
       "matchDepNames": ["hashicorp/terraform"],
       "groupName": "terraform dependencies",
       "groupSlug": "terraform",
@@ -100,15 +107,6 @@
       "matchStrings": ["REUSE_VERSION=\"\\$\\{REUSE_VERSION:-(?<currentValue>[^}]+)\\}\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "fsfe/reuse-tool",
-      "extractVersionTemplate": "^v(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "description": "Track terraform_version in the CI workflows against hashicorp/terraform releases",
-      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
-      "matchStrings": ["terraform_version: ['\"](?<currentValue>[^'\"]+)['\"]"],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "hashicorp/terraform",
       "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ]


### PR DESCRIPTION
## Summary

Renovate can now see two version pins that no manager reached — hadolint,
frozen at v2.12.0 with the workflow line as its only version source, and the
Terraform CLI — and update types that carry no release timestamp no longer
stall behind a permanently pending `renovate/stability-days` check. Also drops
four config fields that only restated Renovate defaults, and both scheduling
overrides.

## Gotchas

- **Lock file maintenance goes from monthly to weekly.** Removing the
  `lockFileMaintenance` block leaves the manager enabled —
  `:maintainLockFilesWeekly` (via `config:best-practices`) sets
  `{ enabled: true, extends: ['schedule:weekly'] }` — so it returns to early
  Monday. The monthly window was a hedge against the kernel-OOM stall in #960,
  and this removes that hedge. If the stall recurs, the fix belongs in #960
  rather than in a narrower window here.
- **Not a fix for #960.** The widened no-timestamp carve-out addresses a
  *different* cause of the same symptom (PRs pending on stability-days).
- **hadolint starts moving again.** It has been pinned at v2.12.0 with nothing
  able to propose a bump; expect an update PR once this lands.
- **`lockfileUpdate` is in the carve-out but absent from the
  `matchUpdateTypes` `allowedValues` list** in Renovate's `options/index.ts`.
  It *is* a member of the `UpdateType` union in `types.ts`, and the config
  validator accepts it — matching is a runtime string comparison, so the
  metadata list is what is stale. Omitting it would reintroduce exactly the
  stall the rule exists to prevent.
- **`baseBranchPatterns` removal is correct only while `develop` is the
  default branch.** It is auto-detected today; it becomes load-bearing again
  when `main` and `release/*` land, and should return then as a deliberate
  addition rather than as leftovers.

## Verification

- Extracted the `matchStrings` regex from Renovate's
  `custom-managers.preset.ts` and ran it over the whole `.github/workflows/`
  tree: 5 matches, expected `depName`/`currentValue`/`extractVersion` on each,
  nothing unintended caught. This is what lets the preset replace the deleted
  bespoke `terraform_version` manager.
- Confirmed every deleted field against Renovate source rather than the docs —
  `internalChecksFilter` default `strict`, `branchPrefix` default `renovate/`,
  the built-in `vulnerabilityAlerts` default object already carrying
  `minimumReleaseAge: null`, `prHourlyLimit` default `2` (which is what makes
  the batching schedule redundant), and the `:maintainLockFilesWeekly` body.