### PR TITLE
feat: display elemental resonance per team

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-dialog": "1.1.23",
     "@radix-ui/react-popover": "1.1.23",
     "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-tooltip": "1.2.16",
     "@tanstack/react-query": "5.101.4",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-64 rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/apps/web/src/features/teams/team-planner.tsx
+++ b/apps/web/src/features/teams/team-planner.tsx
@@ -17,6 +17,7 @@ import { useRef, useState } from 'react';
 import { Input } from '@/components/ui/input';
 
 import { TeamMemberPlanner } from './team-member-planner';
+import { TeamResonance } from './team-resonance';
 
 interface TeamPlannerProps {
   slot: TeamSlot;
@@ -95,6 +96,8 @@ export function TeamPlanner({
             </button>
           )}
         </h2>
+
+        <TeamResonance members={members} />
 
         {onEdit && (
           <button

--- a/apps/web/src/features/teams/team-resonance.test.tsx
+++ b/apps/web/src/features/teams/team-resonance.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionTeam } from '@genshin/domain';
+import type { Element } from '@genshin/game-data';
+import { CHARACTERS, ELEMENTAL_RESONANCES } from '@genshin/game-data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { TeamResonance } from './team-resonance';
+
+// Elements are resolved from real game data, so fixtures have to be real characters.
+function partyOf(...elements: (Element | null)[]): CollectionTeam['members'] {
+  const taken = new Set<string>();
+
+  return elements.map((element) => {
+    if (element === null) return null;
+
+    const character = CHARACTERS.find((c) => c.element === element && !taken.has(c.id));
+    if (!character) throw new Error(`no unused ${element} character in game data`);
+    taken.add(character.id);
+
+    return { characterId: character.id };
+  }) as CollectionTeam['members'];
+}
+
+describe('TeamResonance', () => {
+  it('names the resonances a filled party triggers', () => {
+    render(<TeamResonance members={partyOf('Pyro', 'Pyro', 'Hydro', 'Hydro')} />);
+
+    expect(screen.getByText(ELEMENTAL_RESONANCES.FERVENT_FLAMES.name)).toBeInTheDocument();
+    expect(screen.getByText(ELEMENTAL_RESONANCES.SOOTHING_WATER.name)).toBeInTheDocument();
+  });
+
+  it('renders nothing while the party is still filling', () => {
+    const { container } = render(
+      <TeamResonance members={partyOf('Pyro', 'Pyro', 'Hydro', null)} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('describes the bonus when a badge is focused', async () => {
+    const user = userEvent.setup();
+    render(<TeamResonance members={partyOf('Pyro', 'Pyro', 'Hydro', 'Hydro')} />);
+
+    await user.tab();
+
+    expect(
+      await screen.findByText(ELEMENTAL_RESONANCES.FERVENT_FLAMES.description),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/teams/team-resonance.tsx
+++ b/apps/web/src/features/teams/team-resonance.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionTeam } from '@genshin/domain';
+import type { Element, ElementalResonance } from '@genshin/game-data';
+import { getActiveResonances, getCharacterById, RESONANCE_TRIGGERS } from '@genshin/game-data';
+import type { JSX } from 'react';
+
+import { ThemedIcon } from '@/components/ui/themed-icon';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { ELEMENT_BG_COLORS } from '@/lib/element-styles';
+import { getElementIconPath } from '@/lib/elements';
+import { cn } from '@/lib/utils';
+
+interface TeamResonanceProps {
+  members: CollectionTeam['members'];
+}
+
+/** Protective Canopy is the whole party's doing, so it wears the party's elements. */
+function badgeElements(resonance: ElementalResonance, teamElements: Element[]): Element[] {
+  return resonance.condition.trigger === RESONANCE_TRIGGERS.PAIR
+    ? [resonance.condition.element]
+    : [...new Set(teamElements)];
+}
+
+export function TeamResonance({ members }: TeamResonanceProps): JSX.Element | null {
+  const elements = members
+    .filter((member) => member !== null)
+    .map((member) => getCharacterById(member.characterId)?.element)
+    .filter((element) => element !== undefined);
+
+  const resonances = getActiveResonances(elements);
+  if (resonances.length === 0) return null;
+
+  return (
+    <TooltipProvider>
+      <ul className="flex flex-wrap items-center gap-1.5">
+        {resonances.map((resonance) => {
+          const icons = badgeElements(resonance, elements);
+
+          return (
+            <li key={resonance.name}>
+              <Tooltip>
+                <TooltipTrigger
+                  className={cn(
+                    'inline-flex cursor-help items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium',
+                    icons.length === 1
+                      ? ELEMENT_BG_COLORS[icons[0]]
+                      : 'bg-muted text-muted-foreground',
+                  )}
+                >
+                  {icons.map((element) => (
+                    <ThemedIcon
+                      key={element}
+                      lightSrc={getElementIconPath(element, 'light')}
+                      darkSrc={getElementIconPath(element, 'dark')}
+                      alt=""
+                      className="h-3.5 w-3.5"
+                    />
+                  ))}
+                  {resonance.name}
+                </TooltipTrigger>
+                <TooltipContent>{resonance.description}</TooltipContent>
+              </Tooltip>
+            </li>
+          );
+        })}
+      </ul>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/pages/teams-page.tsx
+++ b/apps/web/src/pages/teams-page.tsx
@@ -14,6 +14,7 @@ import { useCollection } from '@/features/collection/characters/use-character-co
 import { useWeaponCollection } from '@/features/collection/weapons/use-weapon-collection';
 import { CharacterPool } from '@/features/teams/character-pool';
 import { TeamPlanner } from '@/features/teams/team-planner';
+import { TeamResonance } from '@/features/teams/team-resonance';
 import { TeamStrip } from '@/features/teams/team-strip';
 import { usePendingWeapon } from '@/features/teams/use-pending-weapon';
 import { useTeams } from '@/features/teams/use-teams';
@@ -166,6 +167,8 @@ export function TeamsPage(): JSX.Element {
           {selectedSlot !== null && selectedTeam && (
             <>
               <SheetHeader className="pt-6">
+                <TeamResonance members={selectedTeam.members} />
+
                 <TeamStrip
                   members={selectedTeam.members}
                   selectedMemberIndex={selectedMemberIndex}

--- a/packages/game-data/src/index.ts
+++ b/packages/game-data/src/index.ts
@@ -18,6 +18,16 @@ export {
   type ReactionType,
 } from './elements.js';
 
+// Resonances
+export {
+  ELEMENTAL_RESONANCES,
+  getActiveResonances,
+  RESONANCE_TRIGGERS,
+  type ElementalResonance,
+  type ResonanceCondition,
+  type ResonanceTrigger,
+} from './resonances.js';
+
 // Rarities
 export type { Rarity } from './rarities.js';
 

--- a/packages/game-data/src/resonances.test.ts
+++ b/packages/game-data/src/resonances.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { ELEMENTAL_RESONANCES, getActiveResonances } from './resonances.js';
+
+describe('getActiveResonances', () => {
+  it('activates a resonance for a duplicated element', () => {
+    expect(getActiveResonances(['Pyro', 'Pyro', 'Geo', 'Anemo'])).toStrictEqual([
+      ELEMENTAL_RESONANCES.FERVENT_FLAMES,
+    ]);
+  });
+
+  it('activates every resonance a party qualifies for', () => {
+    expect(getActiveResonances(['Pyro', 'Pyro', 'Hydro', 'Hydro'])).toStrictEqual([
+      ELEMENTAL_RESONANCES.FERVENT_FLAMES,
+      ELEMENTAL_RESONANCES.SOOTHING_WATER,
+    ]);
+  });
+
+  it('activates a resonance past its second copy of the element', () => {
+    expect(getActiveResonances(['Cryo', 'Cryo', 'Cryo', 'Cryo'])).toStrictEqual([
+      ELEMENTAL_RESONANCES.SHATTERING_ICE,
+    ]);
+  });
+
+  it('ignores the order elements arrive in', () => {
+    expect(getActiveResonances(['Pyro', 'Geo', 'Anemo', 'Pyro'])).toStrictEqual(
+      getActiveResonances(['Pyro', 'Pyro', 'Geo', 'Anemo']),
+    );
+  });
+
+  it('activates Protective Canopy only when all four elements differ', () => {
+    expect(getActiveResonances(['Pyro', 'Hydro', 'Electro', 'Cryo'])).toStrictEqual([
+      ELEMENTAL_RESONANCES.PROTECTIVE_CANOPY,
+    ]);
+  });
+
+  it('resonates with nothing on an incomplete party', () => {
+    expect(getActiveResonances(['Pyro', 'Pyro', 'Hydro'])).toStrictEqual([]);
+  });
+});

--- a/packages/game-data/src/resonances.ts
+++ b/packages/game-data/src/resonances.ts
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Element } from './elements.js';
+
+/**
+ * Party size at which elemental resonance activates. Resonance is inert in an
+ * incomplete party no matter how the elements line up.
+ */
+const RESONANCE_PARTY_SIZE = 4;
+
+/**
+ * How a resonance's element requirement is expressed
+ */
+export const RESONANCE_TRIGGERS = {
+  PAIR: 'PAIR',
+  UNIQUE_ELEMENTS: 'UNIQUE_ELEMENTS',
+} as const;
+
+export type ResonanceTrigger = (typeof RESONANCE_TRIGGERS)[keyof typeof RESONANCE_TRIGGERS];
+
+export type ResonanceCondition =
+  | { trigger: typeof RESONANCE_TRIGGERS.PAIR; element: Element }
+  | { trigger: typeof RESONANCE_TRIGGERS.UNIQUE_ELEMENTS };
+
+export interface ElementalResonance {
+  name: string;
+  condition: ResonanceCondition;
+  description: string;
+}
+
+/**
+ * Elemental resonance definitions
+ *
+ * MAINTENANCE NOTE: Update this file when resonance effects are rebalanced.
+ * Reference: https://genshin-impact.fandom.com/wiki/Elemental_Resonance
+ */
+export const ELEMENTAL_RESONANCES = {
+  FERVENT_FLAMES: {
+    name: 'Fervent Flames',
+    condition: { trigger: RESONANCE_TRIGGERS.PAIR, element: 'Pyro' },
+    description: 'ATK +25%. Affected by Cryo for 40% less time.',
+  },
+  SOOTHING_WATER: {
+    name: 'Soothing Water',
+    condition: { trigger: RESONANCE_TRIGGERS.PAIR, element: 'Hydro' },
+    description: 'HP +25%. Affected by Pyro for 40% less time.',
+  },
+  HIGH_VOLTAGE: {
+    name: 'High Voltage',
+    condition: { trigger: RESONANCE_TRIGGERS.PAIR, element: 'Electro' },
+    description:
+      'Superconduct, Overloaded, Electro-Charged, Quicken, Hyperbloom, and Aggravate generate an Electro Particle, once every 5s. Affected by Hydro for 40% less time.',
+  },
+  SHATTERING_ICE: {
+    name: 'Shattering Ice',
+    condition: { trigger: RESONANCE_TRIGGERS.PAIR, element: 'Cryo' },
+    description:
+      'CRIT Rate +15% against enemies that are Frozen or affected by Cryo. Affected by Electro for 40% less time.',
+  },
+  IMPETUOUS_WINDS: {
+    name: 'Impetuous Winds',
+    condition: { trigger: RESONANCE_TRIGGERS.PAIR, element: 'Anemo' },
+    description: 'Stamina consumption −15%. Movement SPD +10%. Skill CD −5%.',
+  },
+  ENDURING_ROCK: {
+    name: 'Enduring Rock',
+    condition: { trigger: RESONANCE_TRIGGERS.PAIR, element: 'Geo' },
+    description:
+      'Shield strength +15%. While shielded, DMG +15% and hitting an enemy reduces its Geo RES by 20% for 15s.',
+  },
+  SPRAWLING_GREENERY: {
+    name: 'Sprawling Greenery',
+    condition: { trigger: RESONANCE_TRIGGERS.PAIR, element: 'Dendro' },
+    description:
+      'EM +50. Triggering Burning, Quicken, or Bloom grants a further +30 EM; triggering Aggravate, Spread, Hyperbloom, or Burgeon grants +20 EM. Each lasts 6s and stacks with the others.',
+  },
+  PROTECTIVE_CANOPY: {
+    name: 'Protective Canopy',
+    condition: { trigger: RESONANCE_TRIGGERS.UNIQUE_ELEMENTS },
+    description: 'All Elemental RES +15%. Physical RES +15%.',
+  },
+} as const satisfies Record<string, ElementalResonance>;
+
+/**
+ * Resonances active for a party's elements
+ *
+ * Elements may repeat and arrive in any order; a party short of
+ * {@link RESONANCE_PARTY_SIZE} members resonates with nothing.
+ */
+export function getActiveResonances(elements: Element[]): ElementalResonance[] {
+  if (elements.length !== RESONANCE_PARTY_SIZE) return [];
+
+  const counts = new Map<Element, number>();
+  for (const element of elements) {
+    counts.set(element, (counts.get(element) ?? 0) + 1);
+  }
+
+  return Object.values(ELEMENTAL_RESONANCES).filter((resonance) =>
+    resonance.condition.trigger === RESONANCE_TRIGGERS.PAIR
+      ? (counts.get(resonance.condition.element) ?? 0) >= 2
+      : counts.size === RESONANCE_PARTY_SIZE,
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: 1.3.3
         version: 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-tooltip':
+        specifier: 1.2.16
+        version: 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-query':
         specifier: 5.101.4
         version: 5.101.4(react@19.2.8)
@@ -1889,6 +1892,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tooltip@1.2.16':
+    resolution: {integrity: sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.4':
     resolution: {integrity: sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==}
     peerDependencies:
@@ -1941,6 +1957,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.11':
+    resolution: {integrity: sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.3':
@@ -8145,6 +8174,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-use-callback-ref@1.1.4(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -8186,6 +8236,15 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@radix-ui/react-visually-hidden@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/rect@1.1.3': {}
 


### PR DESCRIPTION
## Summary

Each team now shows the elemental resonances its party triggers, as element-coloured badges beside the team name and above the member strip in the edit sheet. Hovering or focusing a badge describes the bonus it grants.

Closes #602
Closes #72

## Gotchas

- Closes two issues. #72, "Add elemental resonance data to game-data", specified the `packages/game-data` half; #602, "Display elemental resonance per team", restated it alongside the UI. Two departures from #72 as written: it asked for `ELEMENTAL_RESONANCE` inside `elements.ts`, and this adds a separate `resonances.ts`; and it asked for a per-record `version` field following the `ELEMENT_REACTION_TYPES` pattern, which this omits — #1036 proposes retiring that pattern rather than extending it.
- Resonance is gated on a full party of four, matching the game. Two Pyro in a three-member draft shows nothing — deliberate, so the app never advertises a bonus the player will not actually have.
- The badges also render inside the edit sheet, slightly past #602's wording. That sheet covers the team rows while a party is being assembled, which is the only moment the information can inform the next pick.
- Adds `@radix-ui/react-tooltip` and a shadcn tooltip primitive; the UI kit had none. The bonus text is too long to sit unabbreviated in the row, and a native `title` would have hidden it from keyboard and touch.
- `ELEMENTAL_RESONANCES.condition` is a discriminated union rather than an optional element field, because Protective Canopy keys off distinct-element count while the other seven key off a duplicated element.
- Nobody has seen these badges in a browser. `vite build` and `pnpm dev` need Firebase env vars this session did not have, so layout and colour contrast are unverified.

## Verification

- `pnpm turbo run test` — 160 web tests and 27 game-data tests pass, including new coverage for resonance resolution, the empty-party case, and the tooltip wiring.
- `pnpm turbo run typecheck lint` clean across the monorepo; `tsc -b` for web passes (only `vite build` fails, on the missing env vars above).