### PR TITLE
feat(web): make toasts visible and auth prompts actionable

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'react';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 
 import { Layout } from './components/chrome/layout';
+import { ThemeProvider } from './components/chrome/theme-provider';
 import { Toaster } from './components/ui/sonner';
 import { AuthProvider } from './features/auth';
 import { CharactersPage } from './pages/characters-page';
@@ -20,21 +21,23 @@ const queryClient = new QueryClient();
 export function App(): JSX.Element {
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <Router>
-          <Routes>
-            <Route element={<Layout />}>
-              <Route path="/" element={<TeamsPage />} />
-              <Route path="/characters" element={<CharactersPage />} />
-              <Route path="/weapons" element={<WeaponsPage />} />
-              <Route path="/privacy" element={<PrivacyPolicyPage />} />
-              <Route path="/terms" element={<TermsOfServicePage />} />
-              <Route path="*" element={<NotFoundPage />} />
-            </Route>
-          </Routes>
-        </Router>
-      </AuthProvider>
-      <Toaster />
+      <ThemeProvider>
+        <AuthProvider>
+          <Router>
+            <Routes>
+              <Route element={<Layout />}>
+                <Route path="/" element={<TeamsPage />} />
+                <Route path="/characters" element={<CharactersPage />} />
+                <Route path="/weapons" element={<WeaponsPage />} />
+                <Route path="/privacy" element={<PrivacyPolicyPage />} />
+                <Route path="/terms" element={<TermsOfServicePage />} />
+                <Route path="*" element={<NotFoundPage />} />
+              </Route>
+            </Routes>
+          </Router>
+        </AuthProvider>
+        <Toaster />
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/web/src/components/chrome/theme-context.ts
+++ b/apps/web/src/components/chrome/theme-context.ts
@@ -8,7 +8,7 @@ export type Theme = 'light' | 'dark' | 'system';
 export interface ThemeContextValue {
   theme: Theme;
   setTheme: (theme: Theme) => void;
-  /** `theme` resolved against the OS preference, for consumers that can't read the `dark` class. */
+  /** `theme` resolved against the OS preference. */
   isDark: boolean;
 }
 

--- a/apps/web/src/components/chrome/theme-context.ts
+++ b/apps/web/src/components/chrome/theme-context.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { createContext } from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
+
+export interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  /** `theme` resolved against the OS preference, for consumers that can't read the `dark` class. */
+  isDark: boolean;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);

--- a/apps/web/src/components/chrome/theme-provider.tsx
+++ b/apps/web/src/components/chrome/theme-provider.tsx
@@ -8,10 +8,11 @@ import type { Theme } from './theme-context';
 import { ThemeContext } from './theme-context';
 
 const DARK_QUERY = '(prefers-color-scheme: dark)';
+const STORAGE_KEY = 'theme';
 
-function getStoredTheme(): Theme {
+function readStoredTheme(): Theme {
   try {
-    const stored = localStorage.getItem('theme');
+    const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === 'light' || stored === 'dark') return stored;
   } catch {
     // Storage access blocked (privacy mode / sandboxed iframe)
@@ -19,8 +20,20 @@ function getStoredTheme(): Theme {
   return 'system';
 }
 
+function writeStoredTheme(theme: Theme): void {
+  try {
+    if (theme === 'system') {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, theme);
+    }
+  } catch {
+    // Storage access blocked (privacy mode / sandboxed iframe)
+  }
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }): JSX.Element {
-  const [theme, setTheme] = useState<Theme>(getStoredTheme);
+  const [theme, setTheme] = useState<Theme>(readStoredTheme);
   const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(
     () => window.matchMedia(DARK_QUERY).matches,
   );
@@ -39,15 +52,7 @@ export function ThemeProvider({ children }: { children: ReactNode }): JSX.Elemen
   }, [isDark]);
 
   useEffect(() => {
-    try {
-      if (theme === 'system') {
-        localStorage.removeItem('theme');
-      } else {
-        localStorage.setItem('theme', theme);
-      }
-    } catch {
-      // Ignore storage errors (e.g. access blocked in privacy mode)
-    }
+    writeStoredTheme(theme);
   }, [theme]);
 
   return <ThemeContext value={{ theme, setTheme, isDark }}>{children}</ThemeContext>;

--- a/apps/web/src/components/chrome/theme-provider.tsx
+++ b/apps/web/src/components/chrome/theme-provider.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { JSX, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+
+import type { Theme } from './theme-context';
+import { ThemeContext } from './theme-context';
+
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+function getStoredTheme(): Theme {
+  try {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // Storage access blocked (privacy mode / sandboxed iframe)
+  }
+  return 'system';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [theme, setTheme] = useState<Theme>(getStoredTheme);
+  const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(
+    () => window.matchMedia(DARK_QUERY).matches,
+  );
+
+  const isDark = theme === 'dark' || (theme === 'system' && systemPrefersDark);
+
+  useEffect(() => {
+    const mq = window.matchMedia(DARK_QUERY);
+    const handler = (event: MediaQueryListEvent) => setSystemPrefersDark(event.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDark);
+  }, [isDark]);
+
+  useEffect(() => {
+    try {
+      if (theme === 'system') {
+        localStorage.removeItem('theme');
+      } else {
+        localStorage.setItem('theme', theme);
+      }
+    } catch {
+      // Ignore storage errors (e.g. access blocked in privacy mode)
+    }
+  }, [theme]);
+
+  return <ThemeContext value={{ theme, setTheme, isDark }}>{children}</ThemeContext>;
+}

--- a/apps/web/src/components/chrome/theme-toggle.test.tsx
+++ b/apps/web/src/components/chrome/theme-toggle.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider } from './theme-provider';
 import { ThemeToggle } from './theme-toggle';
 
-// jsdom has no media query engine, so the OS preference has to be supplied.
+// jsdom implements no matchMedia at all, so the OS preference has to be stubbed.
 function stubPrefersDark(prefersDark: boolean) {
   vi.stubGlobal('matchMedia', (query: string) => ({
     matches: prefersDark,

--- a/apps/web/src/components/chrome/theme-toggle.test.tsx
+++ b/apps/web/src/components/chrome/theme-toggle.test.tsx
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ThemeProvider } from './theme-provider';
+import { ThemeToggle } from './theme-toggle';
+
+// jsdom has no media query engine, so the OS preference has to be supplied.
+function stubPrefersDark(prefersDark: boolean) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: prefersDark,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function renderToggle() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>,
+  );
+}
+
+function isDark() {
+  return document.documentElement.classList.contains('dark');
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('follows the OS preference until the user picks a theme', () => {
+    stubPrefersDark(true);
+    renderToggle();
+
+    expect(screen.getByRole('button', { name: 'System theme' })).toBeInTheDocument();
+    expect(isDark()).toBe(true);
+    expect(localStorage.getItem('theme')).toBeNull();
+  });
+
+  it('overrides a dark OS preference once light is chosen', async () => {
+    stubPrefersDark(true);
+    renderToggle();
+
+    await userEvent.click(screen.getByRole('button', { name: 'System theme' }));
+
+    expect(screen.getByRole('button', { name: 'Light mode' })).toBeInTheDocument();
+    expect(isDark()).toBe(false);
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('overrides a light OS preference once dark is chosen', async () => {
+    stubPrefersDark(false);
+    renderToggle();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'System theme' }));
+    await user.click(screen.getByRole('button', { name: 'Light mode' }));
+
+    expect(screen.getByRole('button', { name: 'Dark mode' })).toBeInTheDocument();
+    expect(isDark()).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('drops the stored override when cycling back to system', async () => {
+    stubPrefersDark(false);
+    renderToggle();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'System theme' }));
+    await user.click(screen.getByRole('button', { name: 'Light mode' }));
+    await user.click(screen.getByRole('button', { name: 'Dark mode' }));
+
+    expect(screen.getByRole('button', { name: 'System theme' })).toBeInTheDocument();
+    expect(isDark()).toBe(false);
+    expect(localStorage.getItem('theme')).toBeNull();
+  });
+
+  it('restores a stored theme over the OS preference on mount', () => {
+    localStorage.setItem('theme', 'dark');
+    stubPrefersDark(false);
+    renderToggle();
+
+    expect(screen.getByRole('button', { name: 'Dark mode' })).toBeInTheDocument();
+    expect(isDark()).toBe(true);
+  });
+});

--- a/apps/web/src/components/chrome/theme-toggle.tsx
+++ b/apps/web/src/components/chrome/theme-toggle.tsx
@@ -10,24 +10,26 @@ import type { Theme } from './theme-context';
 import { useTheme } from './use-theme';
 
 const CYCLE: Theme[] = ['system', 'light', 'dark'];
-const ICONS: Record<Theme, typeof Sun> = { light: Sun, dark: Moon, system: Monitor };
-const LABELS: Record<Theme, string> = {
-  light: 'Light mode',
-  dark: 'Dark mode',
-  system: 'System theme',
+
+// Keyed by Theme so the compiler catches a theme added to the union without a
+// button face to go with it.
+const FACES: Record<Theme, { icon: typeof Sun; label: string }> = {
+  light: { icon: Sun, label: 'Light mode' },
+  dark: { icon: Moon, label: 'Dark mode' },
+  system: { icon: Monitor, label: 'System theme' },
 };
 
 export function ThemeToggle(): JSX.Element {
   const { theme, setTheme } = useTheme();
 
-  const Icon = ICONS[theme];
+  const { icon: Icon, label } = FACES[theme];
 
   function cycle() {
     setTheme(CYCLE[(CYCLE.indexOf(theme) + 1) % CYCLE.length]);
   }
 
   return (
-    <Button variant="ghost" size="icon" onClick={cycle} aria-label={LABELS[theme]}>
+    <Button variant="ghost" size="icon" onClick={cycle} aria-label={label}>
       <Icon className="h-4 w-4" />
     </Button>
   );

--- a/apps/web/src/components/chrome/theme-toggle.tsx
+++ b/apps/web/src/components/chrome/theme-toggle.tsx
@@ -11,8 +11,6 @@ import { useTheme } from './use-theme';
 
 const CYCLE: Theme[] = ['system', 'light', 'dark'];
 
-// Keyed by Theme so the compiler catches a theme added to the union without a
-// button face to go with it.
 const FACES: Record<Theme, { icon: typeof Sun; label: string }> = {
   light: { icon: Sun, label: 'Light mode' },
   dark: { icon: Moon, label: 'Dark mode' },

--- a/apps/web/src/components/chrome/theme-toggle.tsx
+++ b/apps/web/src/components/chrome/theme-toggle.tsx
@@ -3,28 +3,11 @@
 
 import { Monitor, Moon, Sun } from 'lucide-react';
 import type { JSX } from 'react';
-import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 
-type Theme = 'light' | 'dark' | 'system';
-
-function getStoredTheme(): Theme {
-  try {
-    const stored = localStorage.getItem('theme');
-    if (stored === 'light' || stored === 'dark') return stored;
-  } catch {
-    // Storage access blocked (privacy mode / sandboxed iframe)
-  }
-  return 'system';
-}
-
-function applyTheme(theme: Theme) {
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const isDark = theme === 'dark' || (theme === 'system' && prefersDark);
-
-  document.documentElement.classList.toggle('dark', isDark);
-}
+import type { Theme } from './theme-context';
+import { useTheme } from './use-theme';
 
 const CYCLE: Theme[] = ['system', 'light', 'dark'];
 const ICONS: Record<Theme, typeof Sun> = { light: Sun, dark: Moon, system: Monitor };
@@ -35,38 +18,12 @@ const LABELS: Record<Theme, string> = {
 };
 
 export function ThemeToggle(): JSX.Element {
-  const [theme, setTheme] = useState<Theme>(getStoredTheme);
-
-  useEffect(() => {
-    applyTheme(theme);
-
-    try {
-      if (theme === 'system') {
-        localStorage.removeItem('theme');
-      } else {
-        localStorage.setItem('theme', theme);
-      }
-    } catch {
-      // Ignore storage errors (e.g. access blocked in privacy mode)
-    }
-  }, [theme]);
-
-  useEffect(() => {
-    if (theme !== 'system') return;
-
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = () => applyTheme('system');
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, [theme]);
+  const { theme, setTheme } = useTheme();
 
   const Icon = ICONS[theme];
 
   function cycle() {
-    setTheme((current) => {
-      const next = CYCLE[(CYCLE.indexOf(current) + 1) % CYCLE.length];
-      return next;
-    });
+    setTheme(CYCLE[(CYCLE.indexOf(theme) + 1) % CYCLE.length]);
   }
 
   return (

--- a/apps/web/src/components/chrome/use-theme.ts
+++ b/apps/web/src/components/chrome/use-theme.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { useContext } from 'react';
+
+import type { ThemeContextValue } from './theme-context';
+import { ThemeContext } from './theme-context';
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -4,19 +4,27 @@
 import type { ComponentProps, JSX } from 'react';
 import { Toaster as Sonner } from 'sonner';
 
+import { useTheme } from '@/components/chrome/use-theme';
+
 type ToasterProps = ComponentProps<typeof Sonner>;
 
 export function Toaster(props: ToasterProps): JSX.Element {
+  const { isDark } = useTheme();
+
   return (
     <Sonner
       className="toaster group"
+      // Sonner keys its own palettes off this prop, not the `dark` class, and
+      // defaults to light. Rich colors would stay light-themed without it.
+      theme={isDark ? 'dark' : 'light'}
+      // Cards fill the content area, so some overlap is unavoidable; the
+      // bottom edge is the only one clear of both the sticky filter bar and
+      // the right-hand instance sheet.
+      position="bottom-center"
+      richColors
       toastOptions={{
         classNames: {
-          toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-          description: 'group-[.toast]:text-muted-foreground',
-          actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+          toast: 'group toast group-[.toaster]:shadow-lg',
         },
       }}
       {...props}

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -14,12 +14,9 @@ export function Toaster(props: ToasterProps): JSX.Element {
   return (
     <Sonner
       className="toaster group"
-      // Sonner keys its own palettes off this prop, not the `dark` class, and
-      // defaults to light. Rich colors would stay light-themed without it.
+      // Sonner keys its palettes off this prop, not the `dark` class, and defaults to light.
       theme={isDark ? 'dark' : 'light'}
-      // Cards fill the content area, so some overlap is unavoidable; the
-      // bottom edge is the only one clear of both the sticky filter bar and
-      // the right-hand instance sheet.
+      // The only edge clear of both the sticky filter bar and the right-hand instance sheet.
       position="bottom-center"
       richColors
       toastOptions={{

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -5,4 +5,5 @@ export { AuthProvider } from './auth-provider';
 export { LoginButton } from './login-button';
 export { LogoutButton } from './logout-button';
 export { ProtectedRoute } from './protected-route';
+export { signInWithGoogle } from './sign-in';
 export { useAuth } from './use-auth';

--- a/apps/web/src/features/auth/login-button.tsx
+++ b/apps/web/src/features/auth/login-button.tsx
@@ -1,26 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 import { LogIn } from 'lucide-react';
 import type { JSX } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { auth } from '@/lib/firebase';
 
-const googleProvider = new GoogleAuthProvider();
+import { signInWithGoogle } from './sign-in';
 
 export function LoginButton(): JSX.Element {
-  async function handleLogin() {
-    try {
-      await signInWithPopup(auth, googleProvider);
-    } catch (error) {
-      console.error('Sign-in failed:', error);
-    }
-  }
-
   return (
-    <Button type="button" onClick={handleLogin} variant="outline">
+    <Button type="button" onClick={signInWithGoogle} variant="outline">
       <LogIn aria-hidden="true" focusable={false} className="h-4 w-4" />
       Sign in
     </Button>

--- a/apps/web/src/features/auth/sign-in.ts
+++ b/apps/web/src/features/auth/sign-in.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+
+import { auth } from '@/lib/firebase';
+
+const googleProvider = new GoogleAuthProvider();
+
+export async function signInWithGoogle(): Promise<void> {
+  try {
+    await signInWithPopup(auth, googleProvider);
+  } catch (error) {
+    console.error('Sign-in failed:', error);
+  }
+}

--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -21,6 +21,13 @@ import { WeaponInstanceSidebar } from '@/features/collection/weapons/weapon-inst
 /** Longer than the 4s default: the toast asks the user to act, not just to read. */
 const AUTH_TOAST_DURATION_MS = 10_000;
 
+function promptSignIn() {
+  toast.info('Sign in to manage your weapon collection.', {
+    action: { label: 'Sign in', onClick: () => void signInWithGoogle() },
+    duration: AUTH_TOAST_DURATION_MS,
+  });
+}
+
 export function WeaponsPage(): JSX.Element {
   const {
     weapons,
@@ -88,10 +95,7 @@ export function WeaponsPage(): JSX.Element {
       }
 
       if (!isAuthenticated) {
-        toast.info('Sign in to manage your weapon collection.', {
-          action: { label: 'Sign in', onClick: () => void signInWithGoogle() },
-          duration: AUTH_TOAST_DURATION_MS,
-        });
+        promptSignIn();
         return;
       }
 

--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -18,7 +18,7 @@ import { WeaponCard } from '@/features/collection/weapons/weapon-card';
 import { WeaponFilters } from '@/features/collection/weapons/weapon-filters';
 import { WeaponInstanceSidebar } from '@/features/collection/weapons/weapon-instance-sidebar';
 
-/** Longer than the 4s default: the toast asks the user to act, not just to read. */
+/** The toast asks the user to act, not just to read. */
 const AUTH_TOAST_DURATION_MS = 10_000;
 
 function promptSignIn() {

--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -10,12 +10,16 @@ import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { Container } from '@/components/chrome/container';
+import { signInWithGoogle } from '@/features/auth';
 import type { WeaponFilterState } from '@/features/collection/weapons/filtering';
 import { filterWeapons, initialFilterState } from '@/features/collection/weapons/filtering';
 import { useWeaponCollection } from '@/features/collection/weapons/use-weapon-collection';
 import { WeaponCard } from '@/features/collection/weapons/weapon-card';
 import { WeaponFilters } from '@/features/collection/weapons/weapon-filters';
 import { WeaponInstanceSidebar } from '@/features/collection/weapons/weapon-instance-sidebar';
+
+/** Longer than the 4s default: the toast asks the user to act, not just to read. */
+const AUTH_TOAST_DURATION_MS = 10_000;
 
 export function WeaponsPage(): JSX.Element {
   const {
@@ -84,7 +88,10 @@ export function WeaponsPage(): JSX.Element {
       }
 
       if (!isAuthenticated) {
-        toast.info('Sign in to manage your weapon collection.');
+        toast.info('Sign in to manage your weapon collection.', {
+          action: { label: 'Sign in', onClick: () => void signInWithGoogle() },
+          duration: AUTH_TOAST_DURATION_MS,
+        });
         return;
       }
 


### PR DESCRIPTION
## Summary

The sign-in prompt on the weapons page was easy to miss. Sonner's default position is bottom-right, which is where the weapon instance sheet opens, so the toast landed on top of the sheet the click had just been aimed at. It's now bottom-center, `richColors` is on so info and error read as different things, and the auth toast gets a "Sign in" action with ten seconds to act on it.

Closes #597

## Gotchas

- **The `ThemeProvider` is load-bearing, not a drive-by.** The `bg-background`/`text-foreground` overrides on the Toaster were the only reason toasts tracked dark mode. Sonner keys its palettes off the `theme` prop, not the `dark` class, and [defaults to `'light'`](https://github.com/emilkowalski/sonner/blob/main/src/styles.css) — so dropping those overrides for `richColors` meant wiring the resolved theme in. `ThemeToggle` had it in local state and published it only as a class, which Tailwind can read but JavaScript can't.
- **The characters page is untouched, contrary to the issue.** It has no auth gate — it takes edits anonymously and merges on login (#551) — so there is no prompt there to make visible. Adding one would remove anonymous editing, a product decision rather than a visibility fix.