### PR TITLE
feat(web): align theme palette with brand mark

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@
 - API: Hono + Node.js, Firestore, Firebase Auth.
 - Testing: Vitest (API integration tests).
 - Not yet implemented: Claude MCP, React Testing Library, Bun.
-- `shadcn/ui` setup: New York style, neutral base color, CSS variables, and ESM Tailwind plugin imports.
+- `shadcn/ui` setup: New York style, CSS variables, and ESM Tailwind plugin imports. `components.json` names the `neutral` base color, but `apps/web/src/index.css` carries a brand-derived palette.
 
 ## Repository map
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,7 +6,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Plan your Genshin Impact teams and manage your collection." />
-    <meta name="theme-color" content="#1a1a2e" />
+    <meta name="theme-color" content="#1f514e" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link
       rel="icon"

--- a/apps/web/src/components/chrome/nav.test.tsx
+++ b/apps/web/src/components/chrome/nav.test.tsx
@@ -20,14 +20,14 @@ describe('Nav', () => {
     renderNav('/');
 
     const teamsLink = screen.getByRole('link', { name: 'Teams' });
-    expect(teamsLink.className).toContain('border-blue-500');
+    expect(teamsLink.className).toContain('border-primary');
   });
 
   it('marks the Characters link as active on /characters', () => {
     renderNav('/characters');
 
     const charactersLink = screen.getByRole('link', { name: 'Characters' });
-    expect(charactersLink.className).toContain('border-blue-500');
+    expect(charactersLink.className).toContain('border-primary');
 
     const teamsLink = screen.getByRole('link', { name: 'Teams' });
     expect(teamsLink.className).toContain('border-transparent');
@@ -37,6 +37,6 @@ describe('Nav', () => {
     renderNav('/weapons');
 
     const weaponsLink = screen.getByRole('link', { name: 'Weapons' });
-    expect(weaponsLink.className).toContain('border-blue-500');
+    expect(weaponsLink.className).toContain('border-primary');
   });
 });

--- a/apps/web/src/components/chrome/nav.tsx
+++ b/apps/web/src/components/chrome/nav.tsx
@@ -25,8 +25,8 @@ export function Nav(): JSX.Element {
               className={({ isActive }) =>
                 `inline-block border-b-2 px-1 py-4 text-sm font-medium transition-colors ${
                   isActive
-                    ? 'border-blue-500 text-foreground'
-                    : 'border-transparent text-muted-foreground hover:border-blue-500 hover:text-foreground'
+                    ? 'border-primary text-foreground'
+                    : 'border-transparent text-muted-foreground hover:border-primary hover:text-foreground'
                 }`
               }
             >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22,27 +22,36 @@ body {
   min-height: 100vh;
 }
 
+/* Palette derived from the app icon (see public/icon-source.md): a dark
+   teal-green shield field with a copper border and constellation. Teal-green
+   carries the primary role and tints every neutral; copper stays an accent so
+   the two brand tones never compete for the same job. Every text-on-background
+   pair here is asserted against WCAG AA in theme-contrast.test.ts. */
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 180 20% 99%;
+    --foreground: 180 20% 10%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 180 20% 10%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
+    --popover-foreground: 180 20% 10%;
+    --primary: 176 45% 22%;
+    --primary-foreground: 176 25% 98%;
+    --secondary: 180 14% 94%;
+    --secondary-foreground: 180 20% 14%;
+    --muted: 180 14% 95%;
+    --muted-foreground: 180 12% 36%;
+    --accent: 26 45% 90%;
+    --accent-foreground: 24 55% 18%;
+    --destructive: 0 72% 42%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --success: 150 55% 26%;
+    --success-foreground: 0 0% 98%;
+    --warning: 32 75% 32%;
+    --warning-foreground: 0 0% 98%;
+    --border: 180 12% 87%;
+    --input: 180 12% 87%;
+    --ring: 176 45% 22%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -52,25 +61,29 @@ body {
   }
 
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 25%;
-    --input: 0 0% 25%;
-    --ring: 0 0% 83.1%;
+    --background: 180 26% 8%;
+    --foreground: 180 12% 96%;
+    --card: 180 24% 11%;
+    --card-foreground: 180 12% 96%;
+    --popover: 180 24% 11%;
+    --popover-foreground: 180 12% 96%;
+    --primary: 172 40% 55%;
+    --primary-foreground: 176 40% 10%;
+    --secondary: 176 18% 18%;
+    --secondary-foreground: 180 12% 96%;
+    --muted: 176 18% 18%;
+    --muted-foreground: 180 10% 68%;
+    --accent: 30 30% 22%;
+    --accent-foreground: 30 40% 90%;
+    --destructive: 0 70% 62%;
+    --destructive-foreground: 0 60% 10%;
+    --success: 150 45% 55%;
+    --success-foreground: 150 45% 8%;
+    --warning: 38 65% 60%;
+    --warning-foreground: 36 50% 10%;
+    --border: 178 14% 26%;
+    --input: 178 14% 26%;
+    --ring: 172 40% 55%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22,11 +22,10 @@ body {
   min-height: 100vh;
 }
 
-/* Palette derived from the app icon (see public/icon-source.md): a dark
-   teal-green shield field with a copper border and constellation. Teal-green
-   carries the primary role and tints every neutral; copper stays an accent so
-   the two brand tones never compete for the same job. Every text-on-background
-   pair here is asserted against WCAG AA in theme-contrast.test.ts. */
+/* Palette derived from the app icon; see public/icon-source.md. Teal-green
+   takes the primary role and tints the neutrals, copper stays an accent, so the
+   two brand tones never compete for the same job. theme-contrast.test.ts holds
+   every pair here to WCAG AA. */
 @layer base {
   :root {
     --background: 180 20% 99%;

--- a/apps/web/src/test/theme-css.d.ts
+++ b/apps/web/src/test/theme-css.d.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/** Text of `src/index.css`, injected by `vitest.config.ts`. Test builds only. */
+declare const __THEME_CSS__: string;

--- a/apps/web/src/theme-contrast.test.ts
+++ b/apps/web/src/theme-contrast.test.ts
@@ -7,17 +7,17 @@ import { describe, expect, it } from 'vitest';
 const AA_TEXT = 4.5;
 const AA_NON_TEXT = 3;
 
-/** Surfaces that arbitrary content sits on top of. */
+/** Every surface content sits on. */
 const SURFACES = ['background', 'card', 'popover', 'muted', 'secondary', 'accent'];
 
-/** Tokens Tailwind exposes as a text colour over any of those surfaces. */
+/** Text colors that can land on any of those surfaces. */
 const TEXT_TOKENS = ['foreground', 'muted-foreground'];
 
-/** Roles whose own colour reads as text or as a border rather than as a fill. */
+/** Roles whose own color reads as text or a border, not only as a fill. */
 const SIGNALS = ['primary', 'destructive', 'success', 'warning'];
 
-/** Plain surfaces a signal colour or a focus ring lands on. */
-const PLAIN_SURFACES = ['background', 'card', 'popover'];
+/** The untinted backdrops a signal color or focus ring appears against. */
+const NEUTRAL_SURFACES = ['background', 'card', 'popover'];
 
 type Hsl = readonly [hue: number, saturation: number, lightness: number];
 
@@ -32,9 +32,9 @@ interface Pairing {
 const css = __THEME_CSS__;
 
 /**
- * Custom properties declared under a selector, keyed without the `--` prefix.
- * A selector can appear more than once — `:root` also carries the base
- * typography rule — so every matching block contributes.
+ * Custom properties under a selector, keyed without the `--` prefix. A selector
+ * can appear more than once — `:root` also carries the typography rule — so
+ * every matching block contributes.
  */
 function themeTokens(selector: string): Map<string, string> {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -54,7 +54,7 @@ function themeTokens(selector: string): Map<string, string> {
   return tokens;
 }
 
-/** Parses the space-separated `H S% L%` triple Tailwind wraps in `hsl(var(--token))`. */
+/** The bare `H S% L%` triple Tailwind wraps in `hsl(var(--token))`. */
 function parseHsl(value: string): Hsl {
   const parts = value.split(/\s+/).map((part) => Number.parseFloat(part));
   if (parts.length !== 3 || !parts.every((part) => Number.isFinite(part))) {
@@ -102,8 +102,8 @@ function contrast(tokens: Map<string, string>, foreground: string, background: s
 }
 
 /**
- * Every contrast requirement the palette owes, keyed by pair so that overlapping
- * rules collapse to the strictest minimum rather than to duplicate cases.
+ * Every contrast requirement the palette owes. Keyed by pair, so overlapping
+ * rules collapse to the strictest minimum instead of duplicating cases.
  */
 function requiredPairings(tokenNames: string[]): Pairing[] {
   // `--x-foreground` exists to sit on `--x`; bare `--foreground` sits on `--background`.
@@ -121,10 +121,10 @@ function requiredPairings(tokenNames: string[]): Pairing[] {
   );
 
   const signals = SIGNALS.flatMap((foreground) =>
-    PLAIN_SURFACES.map((background) => ({ foreground, background, minimum: AA_TEXT })),
+    NEUTRAL_SURFACES.map((background) => ({ foreground, background, minimum: AA_TEXT })),
   );
 
-  const rings = PLAIN_SURFACES.map((background) => ({
+  const rings = NEUTRAL_SURFACES.map((background) => ({
     foreground: 'ring',
     background,
     minimum: AA_NON_TEXT,

--- a/apps/web/src/theme-contrast.test.ts
+++ b/apps/web/src/theme-contrast.test.ts
@@ -3,21 +3,45 @@
 
 import { describe, expect, it } from 'vitest';
 
+/** WCAG 2.1 AA minimums: 1.4.3 for body text, 1.4.11 for interface elements. */
 const AA_TEXT = 4.5;
 const AA_NON_TEXT = 3;
+
+/** Surfaces that arbitrary content sits on top of. */
+const SURFACES = ['background', 'card', 'popover', 'muted', 'secondary', 'accent'];
+
+/** Tokens Tailwind exposes as a text colour over any of those surfaces. */
+const TEXT_TOKENS = ['foreground', 'muted-foreground'];
+
+/** Roles whose own colour reads as text or as a border rather than as a fill. */
+const SIGNALS = ['primary', 'destructive', 'success', 'warning'];
+
+/** Plain surfaces a signal colour or a focus ring lands on. */
+const PLAIN_SURFACES = ['background', 'card', 'popover'];
+
+type Hsl = readonly [hue: number, saturation: number, lightness: number];
+
+type Rgb = readonly [red: number, green: number, blue: number];
+
+interface Pairing {
+  foreground: string;
+  background: string;
+  minimum: number;
+}
 
 const css = __THEME_CSS__;
 
 /**
- * Custom properties declared under a `:root` or `.dark` selector, keyed without
- * the `--` prefix. The selector appears more than once (`:root` also carries the
- * base typography rule), so every matching block contributes.
+ * Custom properties declared under a selector, keyed without the `--` prefix.
+ * A selector can appear more than once — `:root` also carries the base
+ * typography rule — so every matching block contributes.
  */
 function themeTokens(selector: string): Map<string, string> {
-  const blocks = [...css.matchAll(new RegExp(`${selector}\\s*\\{([^}]*)\\}`, 'g'))];
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const blocks = css.matchAll(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 'g'));
 
   const tokens = new Map(
-    blocks.flatMap(([, body]) =>
+    [...blocks].flatMap(([, body]) =>
       [...body.matchAll(/--([\w-]+):\s*([^;]+);/g)].map(([, name, value]): [string, string] => [
         name,
         value.trim(),
@@ -30,88 +54,102 @@ function themeTokens(selector: string): Map<string, string> {
   return tokens;
 }
 
-/**
- * Relative luminance per WCAG 2.1 for a space-separated `H S% L%` triple, the
- * shape Tailwind wraps in `hsl(var(--token))`.
- */
-function luminance(hsl: string): number {
-  const [h, s, l] = hsl.split(/\s+/).map((part) => Number.parseFloat(part));
-  if ([h, s, l].some(Number.isNaN)) throw new Error(`unparseable HSL triple: ${hsl}`);
+/** Parses the space-separated `H S% L%` triple Tailwind wraps in `hsl(var(--token))`. */
+function parseHsl(value: string): Hsl {
+  const parts = value.split(/\s+/).map((part) => Number.parseFloat(part));
+  if (parts.length !== 3 || !parts.every((part) => Number.isFinite(part))) {
+    throw new Error(`expected an "H S% L%" triple, got: ${value}`);
+  }
 
-  const chroma = (1 - Math.abs((2 * l) / 100 - 1)) * (s / 100);
-  const secondary = chroma * (1 - Math.abs(((h / 60) % 2) - 1));
-  const match = l / 100 - chroma / 2;
+  const [hue, saturation, lightness] = parts;
+  return [hue, saturation, lightness];
+}
 
-  const sextant = Math.floor(h / 60) % 6;
-  const [r, g, b] = (
-    [
-      [chroma, secondary, 0],
-      [secondary, chroma, 0],
-      [0, chroma, secondary],
-      [0, secondary, chroma],
-      [secondary, 0, chroma],
-      [chroma, 0, secondary],
-    ] as const
-  )[sextant].map((channel) => channel + match);
+/** HSL to sRGB channels in 0–1, per the CSS Color Module Level 4 conversion. */
+function hslToRgb([hue, saturation, lightness]: Hsl): Rgb {
+  const level = lightness / 100;
+  const chroma = (saturation / 100) * Math.min(level, 1 - level);
 
+  const channel = (offset: number): number => {
+    const position = (offset + hue / 30) % 12;
+    return level - chroma * Math.max(-1, Math.min(position - 3, 9 - position, 1));
+  };
+
+  return [channel(0), channel(8), channel(4)];
+}
+
+/** Relative luminance per WCAG 2.1. */
+function relativeLuminance([red, green, blue]: Rgb): number {
   const linear = (channel: number): number =>
     channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
 
-  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+  return 0.2126 * linear(red) + 0.7152 * linear(green) + 0.0722 * linear(blue);
+}
+
+function tokenValue(tokens: Map<string, string>, name: string): string {
+  const value = tokens.get(name);
+  if (value === undefined) throw new Error(`missing --${name}`);
+  return value;
 }
 
 function contrast(tokens: Map<string, string>, foreground: string, background: string): number {
-  const read = (name: string): string => {
-    const value = tokens.get(name);
-    if (value === undefined) throw new Error(`missing --${name}`);
-    return value;
-  };
+  const luminance = (name: string): number =>
+    relativeLuminance(hslToRgb(parseHsl(tokenValue(tokens, name))));
 
-  const [lighter, darker] = [luminance(read(foreground)), luminance(read(background))].sort(
-    (a, b) => b - a,
-  );
-
-  return (lighter + 0.05) / (darker + 0.05);
+  const front = luminance(foreground);
+  const back = luminance(background);
+  return (Math.max(front, back) + 0.05) / (Math.min(front, back) + 0.05);
 }
 
-/** Surfaces that `--foreground` and `--muted-foreground` are rendered on top of. */
-const SURFACES = ['background', 'card', 'popover', 'muted', 'secondary', 'accent'];
-
-/** Roles whose colour is also used as text or as a border on a plain surface. */
-const SIGNALS = ['primary', 'destructive', 'success', 'warning'];
-
-describe.each([
-  ['light', ':root'],
-  ['dark', '\\.dark'],
-])('%s theme', (_name, selector) => {
-  const tokens = themeTokens(selector);
-
-  // Every `--x-foreground` exists to sit on `--x`; `--foreground` sits on `--background`.
-  const pairings = [...tokens.keys()]
+/**
+ * Every contrast requirement the palette owes, keyed by pair so that overlapping
+ * rules collapse to the strictest minimum rather than to duplicate cases.
+ */
+function requiredPairings(tokenNames: string[]): Pairing[] {
+  // `--x-foreground` exists to sit on `--x`; bare `--foreground` sits on `--background`.
+  const ownRole = tokenNames
     .filter((name) => name.endsWith('foreground'))
     .map((foreground) => ({
       foreground,
       background:
         foreground === 'foreground' ? 'background' : foreground.replace(/-foreground$/, ''),
+      minimum: AA_TEXT,
     }));
 
-  it.each(pairings)('$foreground meets AA on $background', ({ foreground, background }) => {
-    expect(contrast(tokens, foreground, background)).toBeGreaterThanOrEqual(AA_TEXT);
-  });
+  const bodyText = TEXT_TOKENS.flatMap((foreground) =>
+    SURFACES.map((background) => ({ foreground, background, minimum: AA_TEXT })),
+  );
 
-  it.each(SURFACES)('foreground and muted-foreground meet AA on %s', (surface) => {
-    expect(contrast(tokens, 'foreground', surface)).toBeGreaterThanOrEqual(AA_TEXT);
-    expect(contrast(tokens, 'muted-foreground', surface)).toBeGreaterThanOrEqual(AA_TEXT);
-  });
+  const signals = SIGNALS.flatMap((foreground) =>
+    PLAIN_SURFACES.map((background) => ({ foreground, background, minimum: AA_TEXT })),
+  );
 
-  it.each(SIGNALS)('%s meets AA as text on background and card', (signal) => {
-    expect(contrast(tokens, signal, 'background')).toBeGreaterThanOrEqual(AA_TEXT);
-    expect(contrast(tokens, signal, 'card')).toBeGreaterThanOrEqual(AA_TEXT);
-  });
+  const rings = PLAIN_SURFACES.map((background) => ({
+    foreground: 'ring',
+    background,
+    minimum: AA_NON_TEXT,
+  }));
 
-  it('ring meets the non-text minimum against every surface it focuses', () => {
-    for (const surface of ['background', 'card', 'popover']) {
-      expect(contrast(tokens, 'ring', surface)).toBeGreaterThanOrEqual(AA_NON_TEXT);
-    }
-  });
+  const strictest = new Map<string, Pairing>();
+  for (const pairing of [...ownRole, ...bodyText, ...signals, ...rings]) {
+    const key = `${pairing.foreground} on ${pairing.background}`;
+    const seen = strictest.get(key);
+    if (seen === undefined || pairing.minimum > seen.minimum) strictest.set(key, pairing);
+  }
+
+  return [...strictest.values()];
+}
+
+describe.each([
+  { mode: 'light', selector: ':root' },
+  { mode: 'dark', selector: '.dark' },
+])('$mode theme', ({ selector }) => {
+  const tokens = themeTokens(selector);
+
+  it.each(requiredPairings([...tokens.keys()]))(
+    '$foreground on $background clears $minimum:1',
+    ({ foreground, background, minimum }) => {
+      expect(contrast(tokens, foreground, background)).toBeGreaterThanOrEqual(minimum);
+    },
+  );
 });

--- a/apps/web/src/theme-contrast.test.ts
+++ b/apps/web/src/theme-contrast.test.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+const AA_TEXT = 4.5;
+const AA_NON_TEXT = 3;
+
+const css = __THEME_CSS__;
+
+/**
+ * Custom properties declared under a `:root` or `.dark` selector, keyed without
+ * the `--` prefix. The selector appears more than once (`:root` also carries the
+ * base typography rule), so every matching block contributes.
+ */
+function themeTokens(selector: string): Map<string, string> {
+  const blocks = [...css.matchAll(new RegExp(`${selector}\\s*\\{([^}]*)\\}`, 'g'))];
+
+  const tokens = new Map(
+    blocks.flatMap(([, body]) =>
+      [...body.matchAll(/--([\w-]+):\s*([^;]+);/g)].map(([, name, value]): [string, string] => [
+        name,
+        value.trim(),
+      ]),
+    ),
+  );
+
+  if (tokens.size === 0) throw new Error(`no custom properties under ${selector} in index.css`);
+
+  return tokens;
+}
+
+/**
+ * Relative luminance per WCAG 2.1 for a space-separated `H S% L%` triple, the
+ * shape Tailwind wraps in `hsl(var(--token))`.
+ */
+function luminance(hsl: string): number {
+  const [h, s, l] = hsl.split(/\s+/).map((part) => Number.parseFloat(part));
+  if ([h, s, l].some(Number.isNaN)) throw new Error(`unparseable HSL triple: ${hsl}`);
+
+  const chroma = (1 - Math.abs((2 * l) / 100 - 1)) * (s / 100);
+  const secondary = chroma * (1 - Math.abs(((h / 60) % 2) - 1));
+  const match = l / 100 - chroma / 2;
+
+  const sextant = Math.floor(h / 60) % 6;
+  const [r, g, b] = (
+    [
+      [chroma, secondary, 0],
+      [secondary, chroma, 0],
+      [0, chroma, secondary],
+      [0, secondary, chroma],
+      [secondary, 0, chroma],
+      [chroma, 0, secondary],
+    ] as const
+  )[sextant].map((channel) => channel + match);
+
+  const linear = (channel: number): number =>
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+function contrast(tokens: Map<string, string>, foreground: string, background: string): number {
+  const read = (name: string): string => {
+    const value = tokens.get(name);
+    if (value === undefined) throw new Error(`missing --${name}`);
+    return value;
+  };
+
+  const [lighter, darker] = [luminance(read(foreground)), luminance(read(background))].sort(
+    (a, b) => b - a,
+  );
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Surfaces that `--foreground` and `--muted-foreground` are rendered on top of. */
+const SURFACES = ['background', 'card', 'popover', 'muted', 'secondary', 'accent'];
+
+/** Roles whose colour is also used as text or as a border on a plain surface. */
+const SIGNALS = ['primary', 'destructive', 'success', 'warning'];
+
+describe.each([
+  ['light', ':root'],
+  ['dark', '\\.dark'],
+])('%s theme', (_name, selector) => {
+  const tokens = themeTokens(selector);
+
+  // Every `--x-foreground` exists to sit on `--x`; `--foreground` sits on `--background`.
+  const pairings = [...tokens.keys()]
+    .filter((name) => name.endsWith('foreground'))
+    .map((foreground) => ({
+      foreground,
+      background:
+        foreground === 'foreground' ? 'background' : foreground.replace(/-foreground$/, ''),
+    }));
+
+  it.each(pairings)('$foreground meets AA on $background', ({ foreground, background }) => {
+    expect(contrast(tokens, foreground, background)).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it.each(SURFACES)('foreground and muted-foreground meet AA on %s', (surface) => {
+    expect(contrast(tokens, 'foreground', surface)).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(tokens, 'muted-foreground', surface)).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it.each(SIGNALS)('%s meets AA as text on background and card', (signal) => {
+    expect(contrast(tokens, signal, 'background')).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(contrast(tokens, signal, 'card')).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it('ring meets the non-text minimum against every surface it focuses', () => {
+    for (const surface of ['background', 'card', 'popover']) {
+      expect(contrast(tokens, 'ring', surface)).toBeGreaterThanOrEqual(AA_NON_TEXT);
+    }
+  });
+});

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -46,15 +46,11 @@ export default {
           dark: '#22C55E',
         },
         primary: {
-          light: '#818CF8',
           DEFAULT: 'hsl(var(--primary))',
-          dark: '#4F46E5',
           foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {
-          light: '#C084FC',
           DEFAULT: 'hsl(var(--secondary))',
-          dark: '#9333EA',
           foreground: 'hsl(var(--secondary-foreground))',
         },
         background: 'hsl(var(--background))',
@@ -78,6 +74,14 @@ export default {
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
+        },
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          foreground: 'hsl(var(--success-foreground))',
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
         },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,9 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vitest/config';
+
+// Vitest stubs `.css` imports to an empty string, `?raw` included, so the theme
+// contrast test gets the stylesheet text injected instead.
+const themeCss = readFileSync(fileURLToPath(new URL('./src/index.css', import.meta.url)), 'utf8');
 
 export default defineConfig({
   resolve: {
@@ -15,6 +20,7 @@ export default defineConfig({
     'import.meta.env.VITE_API_BASE_URL': JSON.stringify('http://localhost:8080'),
     __APP_VERSION__: JSON.stringify('0.0.0-test'),
     __BUILD_SHA__: JSON.stringify('testsha'),
+    __THEME_CSS__: JSON.stringify(themeCss),
   },
   test: {
     globals: true,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -6,8 +6,8 @@ import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vitest/config';
 
-// Vitest stubs `.css` imports to an empty string, `?raw` included, so the theme
-// contrast test gets the stylesheet text injected instead.
+// Vitest stubs `.css` imports to an empty string, `?raw` included, so the
+// contrast test takes the stylesheet as injected text.
 const themeCss = readFileSync(fileURLToPath(new URL('./src/index.css', import.meta.url)), 'utf8');
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

The interface now wears the brand's colors instead of the stock shadcn/ui
neutral base: teal-green takes the primary role and tints the neutrals, copper
stays an accent, and `success`/`warning` join the semantic roles the theme
already named. `theme-contrast.test.ts` derives the palette's contrast
obligations from the token names and holds all 70 to WCAG AA.

Closes #586

## Gotchas

- `--destructive` inverts in dark mode — it lightens so it stays readable as
  text on the dark background, which forces a dark `--destructive-foreground`.
  Stock shadcn does the opposite.
- `success` and `warning` ship without a consumer; they were in the issue's
  scope, and #580 is the likely first caller.
- `vitest.config.ts` injects the stylesheet as `__THEME_CSS__` because vitest
  stubs CSS imports to an empty string, `?raw` included.

## Verification

- Broke `--muted-foreground` and confirmed the test caught it — the 70 checks
  aren't decoration.
- Swept the full HSL space against the conversion this replaces: agreement to
  5.6e-16 per channel.