### PR TITLE
feat(web): collapse collection filters on mobile

### DIFF
--- a/apps/web/src/components/filter-bar.test.tsx
+++ b/apps/web/src/components/filter-bar.test.tsx
@@ -188,7 +188,7 @@ describe('FilterBar', () => {
     expect(screen.getByRole('button', { name: 'Filters, 5 active' })).toBeInTheDocument();
   });
 
-  it('leaves the toggle unbadged when sorting alone is not a filter', () => {
+  it('leaves the toggle unbadged when only the sort field is set', () => {
     renderBar({ collapsible: true, filters: baseFilters({ sortField: 'name' }) });
 
     expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();

--- a/apps/web/src/components/filter-bar.test.tsx
+++ b/apps/web/src/components/filter-bar.test.tsx
@@ -25,6 +25,7 @@ function renderBar(
     filters?: BaseFilterState;
     category?: Partial<FilterCategoryConfig<string>>;
     showOwnership?: boolean;
+    collapsible?: boolean;
     filteredCount?: number;
     totalCount?: number;
     ownedCount?: number;
@@ -55,6 +56,7 @@ function renderBar(
       ownedCount={props.ownedCount ?? 2}
       filteredOwnedCount={props.filteredOwnedCount ?? 2}
       showOwnership={props.showOwnership}
+      collapsible={props.collapsible}
     />,
   );
 
@@ -157,5 +159,49 @@ describe('FilterBar', () => {
     renderBar({ filteredCount: 3, totalCount: 5, filteredOwnedCount: 1 });
 
     expect(screen.getByText(/1 \/ 3 owned/)).toBeInTheDocument();
+  });
+
+  it('offers no collapse toggle unless asked for one', () => {
+    renderBar();
+
+    expect(screen.queryByRole('button', { name: /Filters/ })).not.toBeInTheDocument();
+  });
+
+  it('starts collapsed and expands when the toggle is pressed', async () => {
+    const user = userEvent.setup({ delay: null });
+    renderBar({ collapsible: true });
+    const toggle = screen.getByRole('button', { name: /Filters/ });
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('counts every kind of narrowing filter on the toggle', () => {
+    renderBar({
+      collapsible: true,
+      filters: baseFilters({ search: 'amber', rarities: new Set([5, 4]), ownership: 'owned' }),
+      category: { selected: new Set(['A']) },
+    });
+
+    expect(screen.getByRole('button', { name: 'Filters, 5 active' })).toBeInTheDocument();
+  });
+
+  it('leaves the toggle unbadged when sorting alone is not a filter', () => {
+    renderBar({ collapsible: true, filters: baseFilters({ sortField: 'name' }) });
+
+    expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
+  });
+
+  it('ignores filters whose rows are hidden when counting', () => {
+    renderBar({
+      collapsible: true,
+      showOwnership: false,
+      filters: baseFilters({ ownership: 'owned' }),
+      category: { show: false, selected: new Set(['A']) },
+    });
+
+    expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/filter-bar.test.tsx
+++ b/apps/web/src/components/filter-bar.test.tsx
@@ -167,6 +167,19 @@ describe('FilterBar', () => {
     expect(screen.queryByRole('button', { name: /Filters/ })).not.toBeInTheDocument();
   });
 
+  it('collapses only the chips, leaving search and sort reachable', () => {
+    renderBar({ collapsible: true });
+    const region = document.getElementById(
+      screen.getByRole('button', { name: 'Filters' }).getAttribute('aria-controls') ?? '',
+    );
+
+    expect(region).toContainElement(screen.getByRole('button', { name: 'Filter by A' }));
+    expect(region).not.toContainElement(
+      screen.getByRole('searchbox', { name: 'Search items by name' }),
+    );
+    expect(region).not.toContainElement(screen.getByRole('button', { name: 'Sort descending' }));
+  });
+
   it('starts collapsed and expands when the toggle is pressed', async () => {
     const user = userEvent.setup({ delay: null });
     renderBar({ collapsible: true });

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import type { Rarity } from '@genshin/game-data';
-import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search, SlidersHorizontal } from 'lucide-react';
+import {
+  ArrowDownWideNarrow,
+  ArrowUpNarrowWide,
+  ChevronDown,
+  Search,
+  SlidersHorizontal,
+} from 'lucide-react';
 import type { JSX } from 'react';
 import { useId, useState } from 'react';
 
@@ -99,151 +105,142 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
 
   return (
     <div className="space-y-1.5">
+      {/* Wraps rather than squeezing the search box below its placeholder on ~320px screens. */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <div className="relative min-w-28 flex-1 md:max-w-md">
+          <Search
+            className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+            focusable={false}
+          />
+          <Input
+            type="search"
+            placeholder="Search…"
+            value={filters.search}
+            onChange={(e) => onChange({ ...filters, search: e.target.value })}
+            className="h-8 pl-9 text-xs [&::-webkit-search-cancel-button]:grayscale"
+            aria-label={searchLabel}
+          />
+        </div>
+
+        <FilterSummary noun={noun} showOwnership={showOwnership} {...counts} />
+
+        <div className="ml-auto flex shrink-0 items-center">
+          <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
+            {sortLabel}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={toggleSortDirection}
+            aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+            className="-ml-px rounded-l-none px-1.5"
+          >
+            {filters.sortDirection === 'asc' ? (
+              <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+            ) : (
+              <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+            )}
+          </Button>
+        </div>
+      </div>
+
       {collapsible && (
-        <div className="flex items-center gap-1.5 sm:hidden">
+        <div className="sm:hidden">
           <FilterToggle
             expanded={expanded}
             onToggle={() => setExpanded((wasExpanded) => !wasExpanded)}
             activeCount={activeFilterCount}
             controlsId={controlsId}
           />
-
-          <div className="flex-1" />
-
-          <FilterSummary noun={noun} showOwnership={showOwnership} {...counts} />
         </div>
       )}
 
       <div
         id={controlsId}
-        className={cn('space-y-1.5', collapsible && !expanded && 'hidden sm:block')}
+        className={cn(
+          'flex flex-wrap items-center gap-1.5',
+          collapsible && !expanded && 'hidden sm:flex',
+        )}
       >
-        <div className="flex flex-wrap items-center gap-1.5">
-          {showOwnership &&
-            (['all', 'owned', 'unowned'] as const).map((value) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => onChange({ ...filters, ownership: value })}
-                className={cn(
-                  'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
-                  filters.ownership === value
-                    ? 'bg-foreground text-background'
-                    : 'bg-muted text-muted-foreground hover:bg-muted/80',
-                )}
-                aria-pressed={filters.ownership === value}
-              >
-                {value}
-              </button>
-            ))}
-
-          {showOwnership && (
-            <span className="self-center text-border" aria-hidden="true">
-              |
-            </span>
-          )}
-
-          {RARITY_VALUES.map((rarity) => (
+        {showOwnership &&
+          (['all', 'owned', 'unowned'] as const).map((value) => (
             <button
-              key={rarity}
+              key={value}
               type="button"
-              onClick={() => toggleRarity(rarity)}
+              onClick={() => onChange({ ...filters, ownership: value })}
               className={cn(
-                'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
-                filters.rarities.has(rarity)
-                  ? 'bg-geo-dark text-white'
+                'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
+                filters.ownership === value
+                  ? 'bg-foreground text-background'
                   : 'bg-muted text-muted-foreground hover:bg-muted/80',
               )}
-              aria-pressed={filters.rarities.has(rarity)}
-              aria-label={`Filter by ${rarity}-star`}
+              aria-pressed={filters.ownership === value}
             >
-              {rarity}★
+              {value}
             </button>
           ))}
 
-          {showCategory && (
-            <span className="self-center text-border" aria-hidden="true">
-              |
-            </span>
-          )}
+        {showOwnership && (
+          <span className="self-center text-border" aria-hidden="true">
+            |
+          </span>
+        )}
 
-          {showCategory &&
-            category.values.map((value) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => category.onToggle(value)}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
-                  category.selected.has(value)
-                    ? category.activeClassName(value)
-                    : 'bg-muted text-muted-foreground hover:bg-muted/80',
-                )}
-                aria-pressed={category.selected.has(value)}
-                aria-label={`Filter by ${value}`}
-              >
-                <img
-                  src={category.iconPath(value, 'light')}
-                  alt=""
-                  className="h-3.5 w-3.5 dark:hidden"
-                  aria-hidden="true"
-                />
-                <img
-                  src={category.iconPath(value, 'dark')}
-                  alt=""
-                  className="hidden h-3.5 w-3.5 dark:block"
-                  aria-hidden="true"
-                />
-                {value}
-              </button>
-            ))}
-        </div>
+        {RARITY_VALUES.map((rarity) => (
+          <button
+            key={rarity}
+            type="button"
+            onClick={() => toggleRarity(rarity)}
+            className={cn(
+              'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+              filters.rarities.has(rarity)
+                ? 'bg-geo-dark text-white'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            )}
+            aria-pressed={filters.rarities.has(rarity)}
+            aria-label={`Filter by ${rarity}-star`}
+          >
+            {rarity}★
+          </button>
+        ))}
 
-        <div className="flex items-center gap-1.5">
-          <div className="relative w-1/2 lg:w-1/3">
-            <Search
-              className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-              aria-hidden="true"
-              focusable={false}
-            />
-            <Input
-              type="search"
-              placeholder="Search…"
-              value={filters.search}
-              onChange={(e) => onChange({ ...filters, search: e.target.value })}
-              className="h-8 pl-9 text-xs [&::-webkit-search-cancel-button]:grayscale"
-              aria-label={searchLabel}
-            />
-          </div>
+        {showCategory && (
+          <span className="self-center text-border" aria-hidden="true">
+            |
+          </span>
+        )}
 
-          <div className="flex-1" />
-
-          <FilterSummary
-            noun={noun}
-            showOwnership={showOwnership}
-            {...counts}
-            className={collapsible ? 'max-sm:hidden' : undefined}
-          />
-
-          <div className="flex shrink-0 items-center">
-            <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
-              {sortLabel}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={toggleSortDirection}
-              aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
-              className="-ml-px rounded-l-none px-1.5"
-            >
-              {filters.sortDirection === 'asc' ? (
-                <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
-              ) : (
-                <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+        {showCategory &&
+          category.values.map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => category.onToggle(value)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+                category.selected.has(value)
+                  ? category.activeClassName(value)
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
               )}
-            </Button>
-          </div>
-        </div>
+              aria-pressed={category.selected.has(value)}
+              aria-label={`Filter by ${value}`}
+            >
+              <img
+                src={category.iconPath(value, 'light')}
+                alt=""
+                className="h-3.5 w-3.5 dark:hidden"
+                aria-hidden="true"
+              />
+              <img
+                src={category.iconPath(value, 'dark')}
+                alt=""
+                className="hidden h-3.5 w-3.5 dark:block"
+                aria-hidden="true"
+              />
+              {value}
+            </button>
+          ))}
       </div>
     </div>
   );
@@ -272,13 +269,19 @@ function FilterToggle({
       // Without an explicit label the badge joins the text: "Filters3".
       aria-label={activeCount > 0 ? `Filters, ${activeCount} active` : 'Filters'}
     >
-      <SlidersHorizontal className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+      <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
       Filters
       {activeCount > 0 && (
-        <span className="ml-1.5 rounded-full bg-foreground px-1.5 text-xs font-medium text-background">
+        <span className="rounded-full bg-foreground px-1.5 text-xs font-medium text-background">
           {activeCount}
         </span>
       )}
+      {/* Turning marks the state change, so neither direction has to be read as a fixed meaning. */}
+      <ChevronDown
+        className={cn('h-3.5 w-3.5 transition-transform', expanded && 'rotate-180')}
+        aria-hidden="true"
+        focusable={false}
+      />
     </Button>
   );
 }
@@ -286,7 +289,6 @@ function FilterToggle({
 interface FilterSummaryProps extends FilterCounts {
   noun: string;
   showOwnership: boolean;
-  className?: string;
 }
 
 function FilterSummary({
@@ -296,9 +298,8 @@ function FilterSummary({
   totalCount,
   ownedCount,
   filteredOwnedCount,
-  className,
 }: FilterSummaryProps): JSX.Element {
-  const text = cn('text-sm text-muted-foreground', className);
+  const text = 'shrink-0 text-sm text-muted-foreground';
 
   if (!showOwnership) {
     return (

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import type { Rarity } from '@genshin/game-data';
-import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search } from 'lucide-react';
+import { ArrowDownWideNarrow, ArrowUpNarrowWide, Search, SlidersHorizontal } from 'lucide-react';
 import type { JSX } from 'react';
+import { useId, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -47,6 +48,8 @@ interface FilterBarProps<F extends BaseFilterState, T extends string> {
   ownedCount: number;
   filteredOwnedCount: number;
   showOwnership?: boolean;
+  /** Hide the controls behind a toggle below the `sm` breakpoint, leaving the grid the viewport. */
+  collapsible?: boolean;
 }
 
 const RARITY_VALUES: Rarity[] = [5, 4];
@@ -63,9 +66,32 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
   ownedCount,
   filteredOwnedCount,
   showOwnership = true,
+  collapsible = false,
 }: FilterBarProps<F, T>): JSX.Element {
   const showCategory = category.show ?? true;
   const sortLabel = sortFields.find((f) => f.value === filters.sortField)?.label ?? '';
+  const controlsId = useId();
+  const [expanded, setExpanded] = useState(false);
+
+  const activeFilterCount =
+    (filters.search ? 1 : 0) +
+    filters.rarities.size +
+    (showCategory ? category.selected.size : 0) +
+    (showOwnership && filters.ownership !== 'all' ? 1 : 0);
+
+  const status = !showOwnership ? (
+    <>
+      {filteredCount} {noun}
+    </>
+  ) : filteredCount === totalCount ? (
+    <>
+      {ownedCount} / {totalCount} owned
+    </>
+  ) : (
+    <>
+      {filteredOwnedCount} / {filteredCount} owned
+    </>
+  );
 
   function toggleRarity(rarity: Rarity) {
     onChange({ ...filters, rarities: toggleInSet(filters.rarities, rarity) });
@@ -86,139 +112,161 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
 
   return (
     <div className="space-y-1.5">
-      <div className="flex flex-wrap items-center gap-1.5">
-        {showOwnership &&
-          (['all', 'owned', 'unowned'] as const).map((value) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => onChange({ ...filters, ownership: value })}
-              className={cn(
-                'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
-                filters.ownership === value
-                  ? 'bg-foreground text-background'
-                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
-              )}
-              aria-pressed={filters.ownership === value}
-            >
-              {value}
-            </button>
-          ))}
-
-        {showOwnership && (
-          <span className="self-center text-border" aria-hidden="true">
-            |
-          </span>
-        )}
-
-        {RARITY_VALUES.map((rarity) => (
-          <button
-            key={rarity}
-            type="button"
-            onClick={() => toggleRarity(rarity)}
-            className={cn(
-              'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
-              filters.rarities.has(rarity)
-                ? 'bg-geo-dark text-white'
-                : 'bg-muted text-muted-foreground hover:bg-muted/80',
-            )}
-            aria-pressed={filters.rarities.has(rarity)}
-            aria-label={`Filter by ${rarity}-star`}
-          >
-            {rarity}★
-          </button>
-        ))}
-
-        {showCategory && (
-          <span className="self-center text-border" aria-hidden="true">
-            |
-          </span>
-        )}
-
-        {showCategory &&
-          category.values.map((value) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => category.onToggle(value)}
-              className={cn(
-                'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
-                category.selected.has(value)
-                  ? category.activeClassName(value)
-                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
-              )}
-              aria-pressed={category.selected.has(value)}
-              aria-label={`Filter by ${value}`}
-            >
-              <img
-                src={category.iconPath(value, 'light')}
-                alt=""
-                className="h-3.5 w-3.5 dark:hidden"
-                aria-hidden="true"
-              />
-              <img
-                src={category.iconPath(value, 'dark')}
-                alt=""
-                className="hidden h-3.5 w-3.5 dark:block"
-                aria-hidden="true"
-              />
-              {value}
-            </button>
-          ))}
-      </div>
-
-      <div className="flex items-center gap-1.5">
-        <div className="relative w-1/2 lg:w-1/3">
-          <Search
-            className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-            aria-hidden="true"
-            focusable={false}
-          />
-          <Input
-            type="search"
-            placeholder="Search…"
-            value={filters.search}
-            onChange={(e) => onChange({ ...filters, search: e.target.value })}
-            className="h-8 pl-9 text-xs [&::-webkit-search-cancel-button]:grayscale"
-            aria-label={searchLabel}
-          />
-        </div>
-
-        <div className="flex-1" />
-
-        <p className="text-sm text-muted-foreground">
-          {!showOwnership ? (
-            <>
-              {filteredCount} {noun}
-            </>
-          ) : filteredCount === totalCount ? (
-            <>
-              {ownedCount} / {totalCount} owned
-            </>
-          ) : (
-            <>
-              {filteredOwnedCount} / {filteredCount} owned
-            </>
-          )}
-        </p>
-
-        <div className="flex shrink-0 items-center">
-          <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
-            {sortLabel}
-          </Button>
+      {collapsible && (
+        <div className="flex items-center gap-1.5 sm:hidden">
           <Button
             variant="outline"
             size="sm"
-            onClick={toggleSortDirection}
-            aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
-            className="-ml-px rounded-l-none px-1.5"
+            onClick={() => setExpanded(!expanded)}
+            aria-expanded={expanded}
+            aria-controls={controlsId}
+            aria-label={activeFilterCount > 0 ? `Filters, ${activeFilterCount} active` : 'Filters'}
           >
-            {filters.sortDirection === 'asc' ? (
-              <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
-            ) : (
-              <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+            <SlidersHorizontal
+              className="mr-1.5 h-3.5 w-3.5"
+              aria-hidden="true"
+              focusable={false}
+            />
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="ml-1.5 rounded-full bg-foreground px-1.5 text-xs font-medium text-background">
+                {activeFilterCount}
+              </span>
             )}
           </Button>
+
+          <div className="flex-1" />
+
+          <p className="text-sm text-muted-foreground">{status}</p>
+        </div>
+      )}
+
+      <div
+        id={controlsId}
+        className={cn('space-y-1.5', collapsible && !expanded && 'hidden sm:block')}
+      >
+        <div className="flex flex-wrap items-center gap-1.5">
+          {showOwnership &&
+            (['all', 'owned', 'unowned'] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onChange({ ...filters, ownership: value })}
+                className={cn(
+                  'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
+                  filters.ownership === value
+                    ? 'bg-foreground text-background'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80',
+                )}
+                aria-pressed={filters.ownership === value}
+              >
+                {value}
+              </button>
+            ))}
+
+          {showOwnership && (
+            <span className="self-center text-border" aria-hidden="true">
+              |
+            </span>
+          )}
+
+          {RARITY_VALUES.map((rarity) => (
+            <button
+              key={rarity}
+              type="button"
+              onClick={() => toggleRarity(rarity)}
+              className={cn(
+                'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+                filters.rarities.has(rarity)
+                  ? 'bg-geo-dark text-white'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
+              )}
+              aria-pressed={filters.rarities.has(rarity)}
+              aria-label={`Filter by ${rarity}-star`}
+            >
+              {rarity}★
+            </button>
+          ))}
+
+          {showCategory && (
+            <span className="self-center text-border" aria-hidden="true">
+              |
+            </span>
+          )}
+
+          {showCategory &&
+            category.values.map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => category.onToggle(value)}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+                  category.selected.has(value)
+                    ? category.activeClassName(value)
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80',
+                )}
+                aria-pressed={category.selected.has(value)}
+                aria-label={`Filter by ${value}`}
+              >
+                <img
+                  src={category.iconPath(value, 'light')}
+                  alt=""
+                  className="h-3.5 w-3.5 dark:hidden"
+                  aria-hidden="true"
+                />
+                <img
+                  src={category.iconPath(value, 'dark')}
+                  alt=""
+                  className="hidden h-3.5 w-3.5 dark:block"
+                  aria-hidden="true"
+                />
+                {value}
+              </button>
+            ))}
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <div className="relative w-1/2 lg:w-1/3">
+            <Search
+              className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+              focusable={false}
+            />
+            <Input
+              type="search"
+              placeholder="Search…"
+              value={filters.search}
+              onChange={(e) => onChange({ ...filters, search: e.target.value })}
+              className="h-8 pl-9 text-xs [&::-webkit-search-cancel-button]:grayscale"
+              aria-label={searchLabel}
+            />
+          </div>
+
+          <div className="flex-1" />
+
+          <p className={cn('text-sm text-muted-foreground', collapsible && 'max-sm:hidden')}>
+            {status}
+          </p>
+
+          <div className="flex shrink-0 items-center">
+            <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
+              {sortLabel}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={toggleSortDirection}
+              aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+              className="-ml-px rounded-l-none px-1.5"
+            >
+              {filters.sortDirection === 'asc' ? (
+                <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+              ) : (
+                <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+              )}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -35,7 +35,15 @@ export interface FilterCategoryConfig<T extends string> {
   show?: boolean;
 }
 
-interface FilterBarProps<F extends BaseFilterState, T extends string> {
+/** How much of the collection survived the filters, and how much of that the user owns. */
+interface FilterCounts {
+  filteredCount: number;
+  totalCount: number;
+  ownedCount: number;
+  filteredOwnedCount: number;
+}
+
+interface FilterBarProps<F extends BaseFilterState, T extends string> extends FilterCounts {
   filters: F;
   onChange: (filters: F) => void;
   category: FilterCategoryConfig<T>;
@@ -43,10 +51,6 @@ interface FilterBarProps<F extends BaseFilterState, T extends string> {
   /** Plural noun for the status line, e.g. "characters". */
   noun: string;
   searchLabel: string;
-  filteredCount: number;
-  totalCount: number;
-  ownedCount: number;
-  filteredOwnedCount: number;
   showOwnership?: boolean;
   /** Hide the controls behind a toggle below the `sm` breakpoint, leaving the grid the viewport. */
   collapsible?: boolean;
@@ -61,37 +65,21 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
   sortFields,
   noun,
   searchLabel,
-  filteredCount,
-  totalCount,
-  ownedCount,
-  filteredOwnedCount,
   showOwnership = true,
   collapsible = false,
+  ...counts
 }: FilterBarProps<F, T>): JSX.Element {
   const showCategory = category.show ?? true;
   const sortLabel = sortFields.find((f) => f.value === filters.sortField)?.label ?? '';
   const controlsId = useId();
   const [expanded, setExpanded] = useState(false);
 
+  // Sorting reorders rather than narrows, so it never counts as an active filter.
   const activeFilterCount =
     (filters.search ? 1 : 0) +
     filters.rarities.size +
     (showCategory ? category.selected.size : 0) +
     (showOwnership && filters.ownership !== 'all' ? 1 : 0);
-
-  const status = !showOwnership ? (
-    <>
-      {filteredCount} {noun}
-    </>
-  ) : filteredCount === totalCount ? (
-    <>
-      {ownedCount} / {totalCount} owned
-    </>
-  ) : (
-    <>
-      {filteredOwnedCount} / {filteredCount} owned
-    </>
-  );
 
   function toggleRarity(rarity: Rarity) {
     onChange({ ...filters, rarities: toggleInSet(filters.rarities, rarity) });
@@ -114,30 +102,16 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
     <div className="space-y-1.5">
       {collapsible && (
         <div className="flex items-center gap-1.5 sm:hidden">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setExpanded(!expanded)}
-            aria-expanded={expanded}
-            aria-controls={controlsId}
-            aria-label={activeFilterCount > 0 ? `Filters, ${activeFilterCount} active` : 'Filters'}
-          >
-            <SlidersHorizontal
-              className="mr-1.5 h-3.5 w-3.5"
-              aria-hidden="true"
-              focusable={false}
-            />
-            Filters
-            {activeFilterCount > 0 && (
-              <span className="ml-1.5 rounded-full bg-foreground px-1.5 text-xs font-medium text-background">
-                {activeFilterCount}
-              </span>
-            )}
-          </Button>
+          <FilterToggle
+            expanded={expanded}
+            onToggle={() => setExpanded((wasExpanded) => !wasExpanded)}
+            activeCount={activeFilterCount}
+            controlsId={controlsId}
+          />
 
           <div className="flex-1" />
 
-          <p className="text-sm text-muted-foreground">{status}</p>
+          <FilterSummary noun={noun} showOwnership={showOwnership} {...counts} />
         </div>
       )}
 
@@ -245,9 +219,12 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
 
           <div className="flex-1" />
 
-          <p className={cn('text-sm text-muted-foreground', collapsible && 'max-sm:hidden')}>
-            {status}
-          </p>
+          <FilterSummary
+            noun={noun}
+            showOwnership={showOwnership}
+            {...counts}
+            className={collapsible ? 'max-sm:hidden' : undefined}
+          />
 
           <div className="flex shrink-0 items-center">
             <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
@@ -270,5 +247,80 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
         </div>
       </div>
     </div>
+  );
+}
+
+interface FilterToggleProps {
+  expanded: boolean;
+  onToggle: () => void;
+  activeCount: number;
+  /** Element the button discloses, for `aria-controls`. */
+  controlsId: string;
+}
+
+function FilterToggle({
+  expanded,
+  onToggle,
+  activeCount,
+  controlsId,
+}: FilterToggleProps): JSX.Element {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-controls={controlsId}
+      // The badge reads as part of the word without one, e.g. "Filters3".
+      aria-label={activeCount > 0 ? `Filters, ${activeCount} active` : 'Filters'}
+    >
+      <SlidersHorizontal className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+      Filters
+      {activeCount > 0 && (
+        <span className="ml-1.5 rounded-full bg-foreground px-1.5 text-xs font-medium text-background">
+          {activeCount}
+        </span>
+      )}
+    </Button>
+  );
+}
+
+interface FilterSummaryProps extends FilterCounts {
+  noun: string;
+  showOwnership: boolean;
+  className?: string;
+}
+
+function FilterSummary({
+  noun,
+  showOwnership,
+  filteredCount,
+  totalCount,
+  ownedCount,
+  filteredOwnedCount,
+  className,
+}: FilterSummaryProps): JSX.Element {
+  const text = cn('text-sm text-muted-foreground', className);
+
+  if (!showOwnership) {
+    return (
+      <p className={text}>
+        {filteredCount} {noun}
+      </p>
+    );
+  }
+
+  if (filteredCount === totalCount) {
+    return (
+      <p className={text}>
+        {ownedCount} / {totalCount} owned
+      </p>
+    );
+  }
+
+  return (
+    <p className={text}>
+      {filteredOwnedCount} / {filteredCount} owned
+    </p>
   );
 }

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -57,7 +57,7 @@ interface FilterBarProps<F extends BaseFilterState, T extends string> extends Fi
   noun: string;
   searchLabel: string;
   showOwnership?: boolean;
-  /** Hide the controls behind a toggle below the `sm` breakpoint. */
+  /** Hide the filter chips behind a toggle below the `sm` breakpoint. */
   collapsible?: boolean;
 }
 
@@ -325,7 +325,6 @@ function FilterToggle({
           {activeCount}
         </span>
       )}
-      {/* Turning marks the state change, so neither direction has to be read as a fixed meaning. */}
       <ChevronDown
         className={cn('h-3.5 w-3.5 transition-transform', expanded && 'rotate-180')}
         aria-hidden="true"

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -123,25 +123,28 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
           />
         </div>
 
-        <FilterSummary noun={noun} showOwnership={showOwnership} {...counts} />
+        {/* Held together so the slack falls before the pair, not between them. */}
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          <FilterSummary noun={noun} showOwnership={showOwnership} {...counts} />
 
-        <div className="ml-auto flex shrink-0 items-center">
-          <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
-            {sortLabel}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={toggleSortDirection}
-            aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
-            className="-ml-px rounded-l-none px-1.5"
-          >
-            {filters.sortDirection === 'asc' ? (
-              <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
-            ) : (
-              <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
-            )}
-          </Button>
+          <div className="flex items-center">
+            <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
+              {sortLabel}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={toggleSortDirection}
+              aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+              className="-ml-px rounded-l-none px-1.5"
+            >
+              {filters.sortDirection === 'asc' ? (
+                <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+              ) : (
+                <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+              )}
+            </Button>
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -75,7 +75,6 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
   ...counts
 }: FilterBarProps<F, T>): JSX.Element {
   const showCategory = category.show ?? true;
-  const sortLabel = sortFields.find((f) => f.value === filters.sortField)?.label ?? '';
   const controlsId = useId();
   const [expanded, setExpanded] = useState(false);
 
@@ -86,65 +85,20 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
     (showCategory ? category.selected.size : 0) +
     (showOwnership && filters.ownership !== 'all' ? 1 : 0);
 
-  function toggleRarity(rarity: Rarity) {
-    onChange({ ...filters, rarities: toggleInSet(filters.rarities, rarity) });
-  }
-
-  function cycleSortField() {
-    const currentIndex = sortFields.findIndex((f) => f.value === filters.sortField);
-    const nextField = sortFields[(currentIndex + 1) % sortFields.length].value;
-    onChange({ ...filters, sortField: nextField });
-  }
-
-  function toggleSortDirection() {
-    onChange({
-      ...filters,
-      sortDirection: filters.sortDirection === 'asc' ? 'desc' : 'asc',
-    });
-  }
-
   return (
     <div className="space-y-1.5">
       {/* Wraps rather than squeezing the search box below its placeholder on ~320px screens. */}
       <div className="flex flex-wrap items-center gap-1.5">
-        <div className="relative min-w-28 flex-1 md:max-w-md">
-          <Search
-            className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-            aria-hidden="true"
-            focusable={false}
-          />
-          <Input
-            type="search"
-            placeholder="Search…"
-            value={filters.search}
-            onChange={(e) => onChange({ ...filters, search: e.target.value })}
-            className="h-8 pl-9 text-xs [&::-webkit-search-cancel-button]:grayscale"
-            aria-label={searchLabel}
-          />
-        </div>
+        <SearchField
+          value={filters.search}
+          onChange={(search) => onChange({ ...filters, search })}
+          label={searchLabel}
+        />
 
         {/* Held together so the slack falls before the pair, not between them. */}
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
           <FilterSummary noun={noun} showOwnership={showOwnership} {...counts} />
-
-          <div className="flex items-center">
-            <Button variant="outline" size="sm" onClick={cycleSortField} className="rounded-r-none">
-              {sortLabel}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={toggleSortDirection}
-              aria-label={`Sort ${filters.sortDirection === 'asc' ? 'ascending' : 'descending'}`}
-              className="-ml-px rounded-l-none px-1.5"
-            >
-              {filters.sortDirection === 'asc' ? (
-                <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
-              ) : (
-                <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
-              )}
-            </Button>
-          </div>
+          <SortControl filters={filters} onChange={onChange} sortFields={sortFields} />
         </div>
       </div>
 
@@ -159,93 +113,185 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
         </div>
       )}
 
-      <div
-        id={controlsId}
-        className={cn(
-          'flex flex-wrap items-center gap-1.5',
-          collapsible && !expanded && 'hidden sm:flex',
-        )}
+      <div id={controlsId} className={cn(collapsible && !expanded && 'hidden sm:block')}>
+        <FilterChips
+          filters={filters}
+          onChange={onChange}
+          category={category}
+          showOwnership={showOwnership}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface SearchFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+}
+
+function SearchField({ value, onChange, label }: SearchFieldProps): JSX.Element {
+  return (
+    <div className="relative min-w-28 flex-1 md:max-w-md">
+      <Search
+        className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        aria-hidden="true"
+        focusable={false}
+      />
+      <Input
+        type="search"
+        placeholder="Search…"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 pl-9 text-xs [&::-webkit-search-cancel-button]:grayscale"
+        aria-label={label}
+      />
+    </div>
+  );
+}
+
+interface SortControlProps<F extends BaseFilterState> {
+  filters: F;
+  onChange: (filters: F) => void;
+  sortFields: readonly { value: F['sortField']; label: string }[];
+}
+
+function SortControl<F extends BaseFilterState>({
+  filters,
+  onChange,
+  sortFields,
+}: SortControlProps<F>): JSX.Element {
+  const label = sortFields.find((f) => f.value === filters.sortField)?.label ?? '';
+  const ascending = filters.sortDirection === 'asc';
+
+  function cycleField() {
+    const currentIndex = sortFields.findIndex((f) => f.value === filters.sortField);
+    onChange({ ...filters, sortField: sortFields[(currentIndex + 1) % sortFields.length].value });
+  }
+
+  function toggleDirection() {
+    onChange({ ...filters, sortDirection: ascending ? 'desc' : 'asc' });
+  }
+
+  return (
+    <div className="flex items-center">
+      <Button variant="outline" size="sm" onClick={cycleField} className="rounded-r-none">
+        {label}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={toggleDirection}
+        aria-label={`Sort ${ascending ? 'ascending' : 'descending'}`}
+        className="-ml-px rounded-l-none px-1.5"
       >
-        {showOwnership &&
-          (['all', 'owned', 'unowned'] as const).map((value) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => onChange({ ...filters, ownership: value })}
-              className={cn(
-                'rounded-full px-2.5 py-1 text-xs font-medium capitalize transition-colors',
-                filters.ownership === value
-                  ? 'bg-foreground text-background'
-                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
-              )}
-              aria-pressed={filters.ownership === value}
-            >
-              {value}
-            </button>
-          ))}
-
-        {showOwnership && (
-          <span className="self-center text-border" aria-hidden="true">
-            |
-          </span>
+        {ascending ? (
+          <ArrowUpNarrowWide className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
+        ) : (
+          <ArrowDownWideNarrow className="h-3.5 w-3.5" aria-hidden="true" focusable={false} />
         )}
+      </Button>
+    </div>
+  );
+}
 
-        {RARITY_VALUES.map((rarity) => (
+const CHIP = 'rounded-full px-2.5 py-1 text-xs font-medium transition-colors';
+const CHIP_IDLE = 'bg-muted text-muted-foreground hover:bg-muted/80';
+
+interface FilterChipsProps<F extends BaseFilterState, T extends string> {
+  filters: F;
+  onChange: (filters: F) => void;
+  category: FilterCategoryConfig<T>;
+  showOwnership: boolean;
+}
+
+function FilterChips<F extends BaseFilterState, T extends string>({
+  filters,
+  onChange,
+  category,
+  showOwnership,
+}: FilterChipsProps<F, T>): JSX.Element {
+  const showCategory = category.show ?? true;
+
+  function toggleRarity(rarity: Rarity) {
+    onChange({ ...filters, rarities: toggleInSet(filters.rarities, rarity) });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {showOwnership &&
+        (['all', 'owned', 'unowned'] as const).map((value) => (
           <button
-            key={rarity}
+            key={value}
             type="button"
-            onClick={() => toggleRarity(rarity)}
+            onClick={() => onChange({ ...filters, ownership: value })}
             className={cn(
-              'rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
-              filters.rarities.has(rarity)
-                ? 'bg-geo-dark text-white'
-                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+              CHIP,
+              'capitalize',
+              filters.ownership === value ? 'bg-foreground text-background' : CHIP_IDLE,
             )}
-            aria-pressed={filters.rarities.has(rarity)}
-            aria-label={`Filter by ${rarity}-star`}
+            aria-pressed={filters.ownership === value}
           >
-            {rarity}★
+            {value}
           </button>
         ))}
 
-        {showCategory && (
-          <span className="self-center text-border" aria-hidden="true">
-            |
-          </span>
-        )}
+      {showOwnership && <ChipDivider />}
 
-        {showCategory &&
-          category.values.map((value) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => category.onToggle(value)}
-              className={cn(
-                'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
-                category.selected.has(value)
-                  ? category.activeClassName(value)
-                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
-              )}
-              aria-pressed={category.selected.has(value)}
-              aria-label={`Filter by ${value}`}
-            >
-              <img
-                src={category.iconPath(value, 'light')}
-                alt=""
-                className="h-3.5 w-3.5 dark:hidden"
-                aria-hidden="true"
-              />
-              <img
-                src={category.iconPath(value, 'dark')}
-                alt=""
-                className="hidden h-3.5 w-3.5 dark:block"
-                aria-hidden="true"
-              />
-              {value}
-            </button>
-          ))}
-      </div>
+      {RARITY_VALUES.map((rarity) => (
+        <button
+          key={rarity}
+          type="button"
+          onClick={() => toggleRarity(rarity)}
+          className={cn(CHIP, filters.rarities.has(rarity) ? 'bg-geo-dark text-white' : CHIP_IDLE)}
+          aria-pressed={filters.rarities.has(rarity)}
+          aria-label={`Filter by ${rarity}-star`}
+        >
+          {rarity}★
+        </button>
+      ))}
+
+      {showCategory && <ChipDivider />}
+
+      {showCategory &&
+        category.values.map((value) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => category.onToggle(value)}
+            className={cn(
+              CHIP,
+              'inline-flex items-center gap-1.5',
+              category.selected.has(value) ? category.activeClassName(value) : CHIP_IDLE,
+            )}
+            aria-pressed={category.selected.has(value)}
+            aria-label={`Filter by ${value}`}
+          >
+            <img
+              src={category.iconPath(value, 'light')}
+              alt=""
+              className="h-3.5 w-3.5 dark:hidden"
+              aria-hidden="true"
+            />
+            <img
+              src={category.iconPath(value, 'dark')}
+              alt=""
+              className="hidden h-3.5 w-3.5 dark:block"
+              aria-hidden="true"
+            />
+            {value}
+          </button>
+        ))}
     </div>
+  );
+}
+
+function ChipDivider(): JSX.Element {
+  return (
+    <span className="self-center text-border" aria-hidden="true">
+      |
+    </span>
   );
 }
 
@@ -294,35 +340,19 @@ interface FilterSummaryProps extends FilterCounts {
   showOwnership: boolean;
 }
 
-function FilterSummary({
+function FilterSummary(props: FilterSummaryProps): JSX.Element {
+  return <p className="shrink-0 text-sm text-muted-foreground">{summaryText(props)}</p>;
+}
+
+function summaryText({
   noun,
   showOwnership,
   filteredCount,
   totalCount,
   ownedCount,
   filteredOwnedCount,
-}: FilterSummaryProps): JSX.Element {
-  const text = 'shrink-0 text-sm text-muted-foreground';
-
-  if (!showOwnership) {
-    return (
-      <p className={text}>
-        {filteredCount} {noun}
-      </p>
-    );
-  }
-
-  if (filteredCount === totalCount) {
-    return (
-      <p className={text}>
-        {ownedCount} / {totalCount} owned
-      </p>
-    );
-  }
-
-  return (
-    <p className={text}>
-      {filteredOwnedCount} / {filteredCount} owned
-    </p>
-  );
+}: FilterSummaryProps): string {
+  if (!showOwnership) return `${filteredCount} ${noun}`;
+  if (filteredCount === totalCount) return `${ownedCount} / ${totalCount} owned`;
+  return `${filteredOwnedCount} / ${filteredCount} owned`;
 }

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -35,7 +35,6 @@ export interface FilterCategoryConfig<T extends string> {
   show?: boolean;
 }
 
-/** How much of the collection survived the filters, and how much of that the user owns. */
 interface FilterCounts {
   filteredCount: number;
   totalCount: number;
@@ -48,11 +47,11 @@ interface FilterBarProps<F extends BaseFilterState, T extends string> extends Fi
   onChange: (filters: F) => void;
   category: FilterCategoryConfig<T>;
   sortFields: readonly { value: F['sortField']; label: string }[];
-  /** Plural noun for the status line, e.g. "characters". */
+  /** Plural noun for the summary, e.g. "characters". */
   noun: string;
   searchLabel: string;
   showOwnership?: boolean;
-  /** Hide the controls behind a toggle below the `sm` breakpoint, leaving the grid the viewport. */
+  /** Hide the controls behind a toggle below the `sm` breakpoint. */
   collapsible?: boolean;
 }
 
@@ -74,7 +73,7 @@ export function FilterBar<F extends BaseFilterState, T extends string>({
   const controlsId = useId();
   const [expanded, setExpanded] = useState(false);
 
-  // Sorting reorders rather than narrows, so it never counts as an active filter.
+  // Sorting reorders rather than narrows, so it never counts.
   const activeFilterCount =
     (filters.search ? 1 : 0) +
     filters.rarities.size +
@@ -254,7 +253,6 @@ interface FilterToggleProps {
   expanded: boolean;
   onToggle: () => void;
   activeCount: number;
-  /** Element the button discloses, for `aria-controls`. */
   controlsId: string;
 }
 
@@ -271,7 +269,7 @@ function FilterToggle({
       onClick={onToggle}
       aria-expanded={expanded}
       aria-controls={controlsId}
-      // The badge reads as part of the word without one, e.g. "Filters3".
+      // Without an explicit label the badge joins the text: "Filters3".
       aria-label={activeCount > 0 ? `Filters, ${activeCount} active` : 'Filters'}
     >
       <SlidersHorizontal className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" focusable={false} />

--- a/apps/web/src/features/collection/characters/character-filters.tsx
+++ b/apps/web/src/features/collection/characters/character-filters.tsx
@@ -21,6 +21,7 @@ interface CharacterFiltersProps {
   ownedCount: number;
   filteredOwnedCount: number;
   showOwnership?: boolean;
+  collapsible?: boolean;
 }
 
 const ELEMENT_VALUES = Object.values(ELEMENTS);
@@ -29,6 +30,7 @@ export function CharacterFilters({
   filters,
   onChange,
   showOwnership = true,
+  collapsible = false,
   ...counts
 }: CharacterFiltersProps): JSX.Element {
   function toggleElement(element: Element) {
@@ -43,6 +45,7 @@ export function CharacterFilters({
       noun="characters"
       searchLabel="Search characters by name"
       showOwnership={showOwnership}
+      collapsible={collapsible}
       category={{
         values: ELEMENT_VALUES,
         selected: filters.elements,

--- a/apps/web/src/features/collection/weapons/weapon-filters.tsx
+++ b/apps/web/src/features/collection/weapons/weapon-filters.tsx
@@ -21,6 +21,7 @@ interface WeaponFiltersProps {
   filteredOwnedCount: number;
   showOwnership?: boolean;
   showWeaponTypes?: boolean;
+  collapsible?: boolean;
 }
 
 const WEAPON_TYPE_VALUES = Object.values(WEAPON_TYPES);
@@ -30,6 +31,7 @@ export function WeaponFilters({
   onChange,
   showOwnership = true,
   showWeaponTypes = true,
+  collapsible = false,
   ...counts
 }: WeaponFiltersProps): JSX.Element {
   function toggleWeaponType(type: WeaponType) {
@@ -44,6 +46,7 @@ export function WeaponFilters({
       noun="weapons"
       searchLabel="Search weapons by name"
       showOwnership={showOwnership}
+      collapsible={collapsible}
       category={{
         values: WEAPON_TYPE_VALUES,
         selected: filters.weaponTypes,

--- a/apps/web/src/pages/characters-page.tsx
+++ b/apps/web/src/pages/characters-page.tsx
@@ -76,6 +76,7 @@ export function CharactersPage(): JSX.Element {
             totalCount={CHARACTERS.length}
             ownedCount={ownedCount}
             filteredOwnedCount={filteredOwnedCount}
+            collapsible
           />
         </Container>
       </div>

--- a/apps/web/src/pages/weapons-page.tsx
+++ b/apps/web/src/pages/weapons-page.tsx
@@ -146,6 +146,7 @@ export function WeaponsPage(): JSX.Element {
             totalCount={WEAPONS.length}
             ownedCount={ownedWeaponIds.size}
             filteredOwnedCount={filteredOwnedCount}
+            collapsible
           />
         </Container>
       </div>


### PR DESCRIPTION
## Summary

On phones the collection pages give the card grid the viewport back without putting anything out of reach: search, the collection count, and sort share one row that stays visible at every width, and only the filter chips fold behind a `Filters` toggle. Desktop hides nothing — the chips just moved below the search row. The weapons bar goes from 192px to 108px on a 390px screen.

Closes #684

## Gotchas

- The search box's `min-w-28` and `md:max-w-md` are both load-bearing. Without the floor, ~320px squeezed it until the placeholder clipped to "Sear"; without the cap, `flex-1` stretched it across the desktop bar and stranded the count mid-row.
- Breakpoint visibility is pure CSS — only the expanded flag is React state, so there is no `matchMedia` to drift from Tailwind.
- The teams pools share this component and stay opted out of collapsing: they scroll inside their own panel, not against the viewport.

## Verification

- Measured in Chromium at 320/360/390/640/768/1280: nothing wraps outside the intended 320px case, and the toggle is gone from 640px up. The refactor commits left that geometry identical, including the bar height at 640 where the chips wrap.