### PR TITLE
fix(api): use numeric uid for the container user

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -56,8 +56,7 @@ COPY --from=builder /app/packages/validation ./packages/validation
 
 EXPOSE 8080
 
-# The base image's node user, numeric so a host checking for non-root does not
-# have to resolve the name.
+# The base image's node user; hosts verifying non-root cannot resolve the name
 USER 1000:1000
 
 CMD ["node", "apps/api/dist/main.js"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -56,6 +56,8 @@ COPY --from=builder /app/packages/validation ./packages/validation
 
 EXPOSE 8080
 
-USER node
+# The base image's node user, numeric so a host checking for non-root does not
+# have to resolve the name.
+USER 1000:1000
 
 CMD ["node", "apps/api/dist/main.js"]


### PR DESCRIPTION
## Summary

The API image declares its runtime user as uid/gid 1000 rather than the name
`node`, so a host verifying the container runs as non-root can check it without
resolving names. This has to land before #1077 (hadolint `v2.14.0` -> `v2.15.0`)
can go green — that bump's new DL3066 rule fails pre-commit on this one line,
and it is the only failing check there.

## Gotchas

- `1000:1000` is the same account, not a guess: the base image creates `node`
  with `--uid 1000 --gid 1000`. Nothing else in the repo references the user by
  name, but the coupling is now positional — a base image that renumbers would
  drift silently.

## Verification

- CI on this PR still runs hadolint 2.14.0, which predates DL3066, so it cannot
  confirm the fix. Ran 2.15.0 directly against `apps/api/Dockerfile` with the
  repo config: DL3066 before the change, exit 0 after.