### PR TITLE
fix(ci): group every Node.js pin regardless of manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,8 +86,7 @@
       "addLabels": ["pre-commit"]
     },
     {
-      "description": "Group the Node.js version across .nvmrc, the devcontainer feature, and the API runtime Dockerfile into a single PR, keeping dev, CI, and production on one version.",
-      "matchManagers": ["nvm", "devcontainer", "dockerfile"],
+      "description": "Group every Node.js pin into a single PR, whichever manager reports it: .nvmrc, the devcontainer feature, the API runtime Dockerfile, and the package.json engines field.",
       "matchDepNames": ["node"],
       "groupName": "node",
       "groupSlug": "node",


### PR DESCRIPTION
## Summary

Renovate no longer files the `engines.node` bump in a different PR from the `.nvmrc` bump. The node rule enumerated `matchManagers: ["nvm", "devcontainer", "dockerfile"]`, so the npm manager's view of `node` fell outside the group and rode the npm branch instead — #1010 took `.nvmrc` and the devcontainer feature to 24.18.1 while #1011 took `engines` to 26.5.1 on the same day. The sibling lockstep rules for `hashicorp/terraform` and `fsfe/reuse-tool` match on depName alone; this makes the node rule read the same way. Addresses one acceptance criterion of #1037.

## Gotchas

- Grouping bundles, it does not reconcile. Each pin still resolves its own target from its own datasource, so the current 24 / 25 / 26 spread across `.nvmrc`, `@types/node`, and `engines` survives this change — #1037 still owns the deliberate fix.
- `apps/api/Dockerfile` lags at `node:24.18.0-slim` for an unrelated reason: it is digest-pinned, so it bakes on the docker datasource's own clock and can miss the group's window even though `dockerfile` was already in scope.
- Dropping `matchManagers` widens the rule to any manager reporting depName `node`. `@types/node` carries a different depName and is unaffected.
- Effect is unverifiable until Renovate's next run; the validator only proves the config parses.
- Only the node rule changes here. Whether the five manager-scoped grouping rules should exist at all is #1085, deliberately kept separate as a behaviour change.
