### PR TITLE
ci: cache Firebase emulators for stack smoke tests

### DIFF
--- a/.github/actions/setup-firebase-emulators/action.yml
+++ b/.github/actions/setup-firebase-emulators/action.yml
@@ -1,0 +1,43 @@
+---
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Setup Firebase emulators
+description: Install the JDK the emulators run on and restore their downloaded artifacts
+
+inputs:
+  java-version:
+    description: JDK version for the emulators. Renovate tracks it in the caller's env block.
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    # The Firestore emulator is a Java process. Pinning it here keeps the jobs
+    # off whatever JDK happens to be baked into the runner image.
+    - name: Set up Java
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+
+    # From the manifest, which syncpack keeps pinned exact: `pnpm exec` writes
+    # warnings to the same stream as the version it reports, and both would land
+    # in GITHUB_OUTPUT.
+    - name: Resolve firebase-tools version
+      id: firebase-tools
+      shell: bash
+      run: |
+        version="$(node -p "require('./package.json').devDependencies['firebase-tools']")"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    # Keyed by firebase-tools, which pins the emulator artifacts it downloads,
+    # so the cache misses only when that dependency moves. Uncached, every run
+    # pulls ~130 MB of Firestore emulator before the stack can start, inside
+    # whatever readiness budget the caller allows.
+    - name: Cache Firebase emulators
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/firebase/emulators
+        key: ${{ runner.os }}-firebase-emulators-${{ steps.firebase-tools.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,31 +148,13 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      # The Firestore emulator is a Java process.
-      - name: Set up Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: ./.github/actions/setup-firebase-emulators
         with:
-          distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
 
-      # Keyed by firebase-tools, which pins the emulator artifacts it downloads,
-      # so the cache misses only when that dependency moves. Uncached, every run
-      # pulls ~130 MB of Firestore emulator before the stack can start.
-      - name: Resolve firebase-tools version
-        id: firebase-tools
-        run: |
-          version="$(node -p "require('./package.json').devDependencies['firebase-tools']")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Firebase emulators
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/firebase/emulators
-          key: ${{ runner.os }}-firebase-emulators-${{ steps.firebase-tools.outputs.version }}
-
       # The stack starts behind `firebase emulators:exec`, so the first
-      # readiness check absorbs emulator startup — and the download above on a
-      # cache miss. Matches the per-server budget in playwright.config.ts.
+      # readiness check absorbs emulator startup — and the emulator download on
+      # a cache miss. Matches the per-server budget in playwright.config.ts.
       - name: Verify dev stack starts
         env:
           TIMEOUT_SECONDS: '120'
@@ -198,26 +180,9 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      # The Firestore emulator is a Java process. Pinning it here keeps the job
-      # off whatever JDK happens to be baked into the runner image.
-      - name: Set up Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: ./.github/actions/setup-firebase-emulators
         with:
-          distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-
-      # Same emulator downloads as the dev-smoke job; see the comment there.
-      - name: Resolve firebase-tools version
-        id: firebase-tools
-        run: |
-          version="$(node -p "require('./package.json').devDependencies['firebase-tools']")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Firebase emulators
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/firebase/emulators
-          key: ${{ runner.os }}-firebase-emulators-${{ steps.firebase-tools.outputs.version }}
 
       # From the manifest, which syncpack keeps pinned exact: `pnpm exec` writes
       # warnings to the same stream as the version it reports, and both would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,27 @@ jobs:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
 
+      # Keyed by firebase-tools, which pins the emulator artifacts it downloads,
+      # so the cache misses only when that dependency moves. Uncached, every run
+      # pulls ~130 MB of Firestore emulator before the stack can start.
+      - name: Resolve firebase-tools version
+        id: firebase-tools
+        run: |
+          version="$(node -p "require('./package.json').devDependencies['firebase-tools']")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Firebase emulators
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/firebase/emulators
+          key: ${{ runner.os }}-firebase-emulators-${{ steps.firebase-tools.outputs.version }}
+
+      # The stack starts behind `firebase emulators:exec`, so the first
+      # readiness check absorbs emulator startup — and the download above on a
+      # cache miss. Matches the per-server budget in playwright.config.ts.
       - name: Verify dev stack starts
+        env:
+          TIMEOUT_SECONDS: '120'
         run: bash scripts/verify-dev.sh
 
   # Drives a real browser through the assembled stack — Firebase emulators, the
@@ -185,6 +205,19 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
+
+      # Same emulator downloads as the dev-smoke job; see the comment there.
+      - name: Resolve firebase-tools version
+        id: firebase-tools
+        run: |
+          version="$(node -p "require('./package.json').devDependencies['firebase-tools']")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Firebase emulators
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/firebase/emulators
+          key: ${{ runner.os }}-firebase-emulators-${{ steps.firebase-tools.outputs.version }}
 
       # From the manifest, which syncpack keeps pinned exact: `pnpm exec` writes
       # warnings to the same stream as the version it reports, and both would


### PR DESCRIPTION
The `Smoke-test dev stack` job failed on develop ([run 30752637429](https://github.com/dungeon-studio/genshin.dungeon.studio/actions/runs/30752637429)) waiting for vite on :5173. `pnpm dev` runs behind `firebase emulators:exec`, so nothing answers until the emulators are up, and no job cached `~/.cache/firebase/emulators` — every run re-downloaded the ~130 MB Firestore emulator jar inside `verify-dev.sh`'s 30s readiness budget. Passing runs finished that step in 15-17s, so the margin was about 2x and one slow download tipped it. Not a code regression; the head commit was a Renovate hook bump.

This caches the emulator artifacts keyed by the firebase-tools version that pins them, and raises the readiness budget to the 120s per-service timeout `playwright.config.ts` already allows, which covers the cache-miss run after a firebase-tools bump. The JDK setup and the cache are the same steps in `dev-smoke` and `e2e`, so they live behind a `setup-firebase-emulators` composite action alongside `setup-node-pnpm`.

Gotchas: `java-version` is an action input rather than a constant inside it, keeping the `# renovate: datasource=java-version` annotation in the job env block where it demonstrably works — I did not verify Renovate reads that annotation inside a composite action, and a silently frozen JDK is a bad failure mode. `dev-smoke` and `e2e` both miss the cache on the same run and both try to save the key; the loser logs a warning and moves on. `verify-dev.sh` keeps its 30s default for local runs, where the cache is already warm.