### PR TITLE
fix(ci): build workspace packages before the deployed e2e suite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -249,10 +249,11 @@ jobs:
 
       - uses: ./.github/actions/setup-playwright
 
-      # Not through turbo: these specs reach for no workspace package, so there
-      # is no build to order ahead of them.
+      # Through turbo so `^build` compiles the workspace packages the specs
+      # import: fixtures.ts pulls @genshin/game-data, which Playwright loads
+      # while collecting tests regardless of the @deployed grep.
       - name: Run end-to-end tests
-        run: pnpm --filter @genshin/e2e test:deployed
+        run: pnpm turbo run test:deployed --filter=@genshin/e2e
 
       - name: Upload Playwright report
         if: failure()

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,10 @@
       "dependsOn": ["^build", "@genshin/api#build"],
       "cache": false
     },
+    "test:deployed": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "typecheck": {
       "dependsOn": ["^build"],
       "inputs": [


### PR DESCRIPTION
The Deploy workflow's verify job ran `pnpm --filter @genshin/e2e
test:deployed` outside turbo, on the premise that the deployed specs
reach for no workspace package. They do: specs/fixtures.ts imports
@genshin/game-data, and Playwright loads every spec while collecting
tests regardless of the @deployed grep. With nothing to build its
dist/ ahead of the run, the import failed with Cannot find module
'@genshin/game-data/dist/index.js' and the job errored before a single
test ran.

Route test:deployed through turbo, like its PR-time sibling test:e2e,
so `^build` compiles @genshin/game-data first. Register the task in
turbo.json with `^build` (no local API build — the suite targets a
live deployment) and cache disabled.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ka9WM8ppjGHT1REYzudiJ7