### PR TITLE
fix(ci): run the deployed e2e suite through turbo with its env

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -33,7 +33,8 @@
     },
     "test:deployed": {
       "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["E2E_BASE_URL", "CI"]
     },
     "typecheck": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

The Deploy workflow's `verify` job (new in #1058) failed on its first real run on `develop`: [run #202](https://github.com/dungeon-studio/genshin.dungeon.studio/actions/runs/30889864343) errored before a single test executed with

```
Cannot find module '.../tools/e2e/node_modules/@genshin/game-data/dist/index.js'
  imported from .../tools/e2e/specs/fixtures.ts
```

The job ran the deployed suite outside turbo, on the premise that these specs reach for no workspace package. They do: `specs/fixtures.ts` imports `@genshin/game-data`, and Playwright loads every spec while collecting tests regardless of the `@deployed` grep. With nothing to build its `dist/` ahead of the run, the import failed. Its PR-time sibling in `ci.yml` never hits this because it runs through turbo, where `test:e2e` declares `dependsOn: ["^build", ...]`.

Routing `test:deployed` through turbo surfaced a second, masked failure ([run #30893928614](https://github.com/dungeon-studio/genshin.dungeon.studio/actions/runs/30893928614)): turbo runs tasks in a strict environment and strips any variable the task does not declare, so the deployed run failed its own `E2E_BASE_URL` guard before starting.

## Changes

- **`turbo.json`** — register `test:deployed` with `dependsOn: ["^build"]` (compiles `@genshin/game-data` first; no `@genshin/api#build`, since the suite targets a live deployment rather than a local API) and `cache: false`.
- **`turbo.json`** — declare `passThroughEnv: ["E2E_BASE_URL", "CI"]` on the task. `E2E_BASE_URL` is the deployment target the script guards on and `playwright.config.ts` reads as `baseURL` (unset, the config also brings up a local API + Vite in the deployment's place); `CI` selects the HTML reporter the report-upload step collects. `passThroughEnv` rather than `env` because the task is uncached and these are runtime inputs, not cache keys.
- **`.github/workflows/deploy.yml`** — call `pnpm turbo run test:deployed --filter=@genshin/e2e` instead of raw `pnpm --filter`, and correct the comment that claimed the specs use no workspace package.

## Verification

- `turbo --dry` confirms `@genshin/e2e#test:deployed` now depends on `@genshin/game-data#build`, and the resolved task definition carries `passThroughEnv: ["CI", "E2E_BASE_URL"]`.
- The two failures were module resolution and an env guard — both occur before any network call, so the dry-run graph is conclusive for them. The suite itself drives the live deployment; the next deploy on `develop` exercises it end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka9WM8ppjGHT1REYzudiJ7)_