### PR TITLE
fix(ci): pass E2E_BASE_URL through turbo to deployed e2e task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -33,7 +33,8 @@
     },
     "test:deployed": {
       "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "env": ["E2E_BASE_URL"]
     },
     "typecheck": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Turborepo's strict environment mode (default in v2) strips env vars not
declared in a task's `env` key, so the deploy workflow's job-level
E2E_BASE_URL never reached the `test:deployed` shell. The task aborted
with "must name the origin of the deployment under test". Declare
E2E_BASE_URL so turbo forwards it.