### PR TITLE
chore(renovate): unbatch updates, track hidden pins

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -54,6 +54,7 @@ step "Installing reuse-tool"
 # ---------------------------------------------------------------------------
 step "Installing hadolint"
 
+# renovate: datasource=github-releases depName=hadolint/hadolint
 HADOLINT_VERSION="v2.12.0"
 sudo curl -fsSL \
   "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
@@ -65,10 +66,12 @@ sudo chmod +x /usr/local/bin/hadolint
 # ---------------------------------------------------------------------------
 step "Installing lychee"
 
-LYCHEE_VERSION="lychee-v0.24.2"
+# renovate: datasource=github-releases depName=lycheeverse/lychee extractVersion=^lychee-v(?<version>.+)$
+LYCHEE_VERSION="0.24.2"
+LYCHEE_DIR=lychee-x86_64-unknown-linux-gnu
 curl -fsSL \
-  "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
-  | sudo tar -xz -C /usr/local/bin --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
+  "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/${LYCHEE_DIR}.tar.gz" \
+  | sudo tar -xz -C /usr/local/bin --strip-components=1 "${LYCHEE_DIR}/lychee"
 sudo chmod +x /usr/local/bin/lychee
 
 # ---------------------------------------------------------------------------

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
+# renovate: datasource=npm depName=corepack
 ARG COREPACK_VERSION=0.34.6
 
 # Build stage

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:best-practices",
     "security:openssf-scorecard",
-    "customManagers:githubActionsVersions"
+    "customManagers:githubActionsVersions",
+    "customManagers:dockerfileVersions"
   ],
   "timezone": "Europe/London",
   "labels": ["dependencies", "automated"],
@@ -30,78 +31,39 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Group all npm dependencies in a single PR",
-      "matchManagers": ["npm"],
-      "groupName": "npm dependencies",
-      "groupSlug": "npm",
-      "addLabels": ["npm"]
-    },
-    {
-      "description": "Group all Terraform dependencies in a single PR",
-      "matchManagers": ["terraform"],
-      "groupName": "terraform dependencies",
-      "groupSlug": "terraform",
-      "addLabels": ["terraform", "infrastructure"]
-    },
-    {
-      "description": "Bump the Terraform CLI version in lockstep across the infrastructure required_version constraint and the CI workflow TERRAFORM_VERSION pins",
+      "description": "Move the Terraform CLI in one pull request across the bootstrap and dev required_version constraints and the TERRAFORM_VERSION pins in four workflows",
       "matchDepNames": ["hashicorp/terraform"],
-      "groupName": "terraform dependencies",
-      "groupSlug": "terraform",
-      "addLabels": ["terraform", "infrastructure"]
+      "groupName": "terraform cli"
     },
     {
-      "description": "Group all GitHub Actions updates in a single PR",
-      "matchManagers": ["github-actions"],
-      "groupName": "github actions",
-      "groupSlug": "github-actions",
-      "addLabels": ["actions"]
-    },
-    {
-      "description": "Group all Docker updates in a single PR",
-      "matchManagers": ["dockerfile"],
-      "groupName": "docker dependencies",
-      "groupSlug": "docker",
-      "addLabels": ["docker"]
-    },
-    {
-      "description": "Group all DevContainer updates in a single PR",
-      "matchManagers": ["devcontainer"],
-      "groupName": "devcontainer dependencies",
-      "groupSlug": "devcontainer",
-      "addLabels": ["devcontainer"]
-    },
-    {
-      "description": "Group all pre-commit hook updates in a single PR",
-      "matchManagers": ["pre-commit"],
-      "groupName": "pre-commit hooks",
-      "groupSlug": "pre-commit",
-      "addLabels": ["pre-commit"]
-    },
-    {
-      "description": "Bump fsfe/reuse-tool in lockstep across pre-commit and install-reuse.sh",
+      "description": "Move reuse in one pull request across the pre-commit rev and the REUSE_VERSION pin in scripts/install-reuse.sh",
       "matchDepNames": ["fsfe/reuse-tool"],
-      "groupName": "pre-commit hooks",
-      "groupSlug": "pre-commit",
-      "addLabels": ["pre-commit"]
+      "groupName": "reuse"
     },
     {
-      "description": "Group every Node.js pin into a single PR, whichever manager reports it: .nvmrc, the devcontainer feature, the API runtime Dockerfile, and the package.json engines field.",
+      "description": "Move hadolint in one pull request across the ci.yml pin and the devcontainer bootstrap script",
+      "matchDepNames": ["hadolint/hadolint"],
+      "groupName": "hadolint"
+    },
+    {
+      "description": "Move the lychee binary in one pull request across the ci.yml pin and the devcontainer bootstrap script; lycheeverse/lychee-action versions separately and stays out of the group",
+      "matchDepNames": ["lycheeverse/lychee"],
+      "groupName": "lychee"
+    },
+    {
+      "description": "Move Node in one pull request across .nvmrc, the API runtime image, the devcontainer feature, and the package.json engines field",
       "matchDepNames": ["node"],
-      "groupName": "node",
-      "groupSlug": "node",
-      "addLabels": ["node"]
+      "groupName": "node"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track REUSE_VERSION in scripts/install-reuse.sh against fsfe/reuse-tool releases",
-      "managerFilePatterns": ["/^scripts/install-reuse\\.sh$/"],
-      "matchStrings": ["REUSE_VERSION=\"\\$\\{REUSE_VERSION:-(?<currentValue>[^}]+)\\}\""],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "fsfe/reuse-tool",
-      "extractVersionTemplate": "^v(?<version>.+)$"
+      "description": "Track annotated *_VERSION pins in shell scripts, including the ${VAR:-default} override form",
+      "managerFilePatterns": ["scripts/*.sh", ".devcontainer/*.sh"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION=[\"']?(?:\\$\\{[A-Za-z0-9_]+:-)?(?<currentValue>[^\"'}\\s]+)\\}?[\"']?\\s"
+      ]
     }
   ]
 }

--- a/scripts/install-reuse.sh
+++ b/scripts/install-reuse.sh
@@ -10,6 +10,7 @@
 
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=fsfe/reuse-tool extractVersion=^v(?<version>.+)$
 REUSE_VERSION="${REUSE_VERSION:-6.2.0}"
 
 if command -v reuse > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Renovate opens each dependency update as its own mergeable pull request instead of five manager-wide batches, and four version pins it previously couldn't see are now tracked. Batching made every PR only as mergeable as its worst member, and members baked independently under `minimumReleaseAge`, so a group branch kept getting rebased and re-baked as each new member cleared three days.

Closes #1085

## Gotchas

- Six package rules remain. The no-timestamp carve-out is unchanged and load-bearing — without it those eight update types stall forever on a pending `renovate/stability-days` check with no PR ever opening. The other five are lockstep rules: one logical dependency written in more than one file, where merging half leaves the repo broken between commits.
- `HADOLINT_VERSION` is left at `v2.12.0` in the devcontainer, three minors behind `ci.yml`. The new lockstep group will bump both to the same version on its next run, which is a better proof the rule works than a manual edit.
- `groupName` batches into one PR but does not force a common version. #1081 added the `node` group and Node is still divergent on develop — `engines.node` at `26.5.1`, everything else at `24.18.1`. That needs collapsing duplicate pins, not a rule, and is out of scope here.
- Per-manager `addLabels` are gone. `release-drafter`'s autolabeler already derives `infrastructure` and `actions` from changed paths, and nothing reads `npm`, `docker`, `devcontainer`, `pre-commit`, or `node`. Top-level `labels` keeps `automated`, which feeds release-drafter's patch version-resolver.
- The devcontainer lychee pin stored its `lychee-v` tag prefix in the value, which would never compare equal to an `extractVersion`-normalised upstream tag. The script now holds the bare version and builds the tag in the URL, as `ci.yml` already does.

## Verification

- Ran the config's own `matchStrings` and the upstream `customManagers:dockerfileVersions` regex (fetched from `renovatebot/renovate`) against the real files: all four pins extract the right `depName` and `currentValue`, including the `${VAR:-default}` form in `install-reuse.sh`.
- `bash -n` on both edited scripts; full `pre-commit` gate passed, including `renovate-config-validator --strict --no-global` and `hadolint`.