### PR TITLE
ci: prune stale pull requests on the daily schedule

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,6 +16,9 @@ permissions:
   issues: read
 
 concurrency:
+  # A truncated stale sweep loses the operations-per-run resume cache and
+  # restarts from the first pull request, so in-progress runs are never
+  # cancelled.
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
@@ -70,3 +73,35 @@ jobs:
             }
 
             core.info(`${summary} Within the ${STALE_DAYS}-day window.`);
+
+  stale-pull-requests:
+    name: Prune stale pull requests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # `actions: write` is omitted: it covers only the resume cache, so a
+      # truncated run warns and restarts rather than failing.
+      issues: write
+      pull-requests: write
+
+    steps:
+      # Both issue legs are disabled, not just marking: an issue already
+      # carrying the label would otherwise stay eligible for closing.
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          # Closing a Renovate pull request tells Renovate the version is
+          # unwanted and it will not re-offer it. Renovate labels nothing by
+          # default, so this depends on renovate.json applying the label.
+          exempt-pr-labels: dependencies
+          stale-pr-message: >-
+            This has been quiet for 30 days, so it's picked up a stale label. A
+            comment or a push clears the label and restarts the clock. Otherwise
+            this closes in another 14 days.
+          close-pr-message: >-
+            Closing this after 44 quiet days. That isn't a call on the change
+            itself, and nothing is lost: the branch stays where it is, so
+            comment here if you want to pick it back up and I'll reopen it.


### PR DESCRIPTION
## Summary

Abandoned pull request branches now age out on their own — the daily schedule labels anything untouched for 30 days and closes it 14 days after that. Ported from the `stale-pull-requests` job in `alunduil-chezmoi`, into the existing Daily workflow rather than a new file, since it shares the concurrency group.

Issues are deliberately untouched: both issue legs are disabled, because the 200+ open backlog is the roadmap and not a triage queue. That is why #132 (Set up stale issues and pull requests workflow) was closed not-planned; its close-out left the door open to a narrow pull-request-only variant, which this is.

## Gotchas

- Drafts are in scope — `exempt-draft-pr` defaults to `false` — so the first run closes #865 (feat(web): add mobile hamburger nav and responsive header, 48 quiet days) outright, and labels #879, #916, and #935, which then close within two weeks absent activity. Chosen knowingly over a label-only variant.
- The Renovate exemption rides on `renovate.json` applying the `dependencies` label, not on authorship. Drop that label and Renovate pull requests become closable — and closing one tells Renovate the version is unwanted, so it never re-offers it.
- Job-level `permissions:` replaces the workflow-level block rather than merging, so this job runs without `contents: read`. `actions: write` is omitted too: it covers only the operations-per-run resume cache, so a truncated sweep warns and restarts instead of failing.

## Verification

- Confirmed `exempt-draft-pr` defaults to `false` in `actions/stale` `action.yml`, then measured every open pull request against the 30- and 44-day thresholds to produce the first-run fallout above.