### PR TITLE
test(web): cover CharacterCard and correct the test-stack instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@
 - Workspace packages consumed by other packages must expose `types` and `default` in `exports` and include `main`.
 - Use ISO 8601 strings for timestamps such as `createdAt` and `updatedAt`, not `Date` objects.
 - Maintain game-data accuracy when working with `packages/game-data`.
-- Test alongside code when possible; the API has Vitest coverage, but web and UI testing is planned and not yet implemented.
+- Test alongside code when possible; the API and web app both have Vitest coverage, with React Testing Library for components and Playwright end-to-end specs in `tools/e2e`.
 - Each branded type in `packages/domain/` gets its own file (for example, `uuid.ts`, `isoTimestamp.ts`).
 - Shared API test utilities go in `apps/api/src/test/` with descriptive names (not generic names like "helpers"). This directory is excluded from production builds via `tsconfig.build.json`.
 - Use descriptive, specific file names. Avoid generic names like "helpers."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@
 - Workspace packages consumed by other packages must expose `types` and `default` in `exports` and include `main`.
 - Use ISO 8601 strings for timestamps such as `createdAt` and `updatedAt`, not `Date` objects.
 - Maintain game-data accuracy when working with `packages/game-data`.
-- Test alongside code when possible; the API and web app both have Vitest coverage, with React Testing Library for components and Playwright end-to-end specs in `tools/e2e`.
+- Test alongside code when possible; Vitest covers both apps, and Playwright end-to-end specs live in `tools/e2e`.
 - Each branded type in `packages/domain/` gets its own file (for example, `uuid.ts`, `isoTimestamp.ts`).
 - Shared API test utilities go in `apps/api/src/test/` with descriptive names (not generic names like "helpers"). This directory is excluded from production builds via `tsconfig.build.json`.
 - Use descriptive, specific file names. Avoid generic names like "helpers."

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -3,10 +3,15 @@
 
 # Test generation instructions
 
-## Framework (planned)
+## Framework
 
-The project plans to use **Vitest** as the test runner and **React Testing
-Library** for component tests. Generate tests targeting this stack.
+**Vitest** is the test runner and **React Testing Library** the component
+harness. Both are installed in `apps/api` and `apps/web`; generate tests
+targeting this stack.
+
+End-to-end tests are **Playwright** specs and live in `tools/e2e`, not
+alongside the code they exercise. These instructions cover unit and component
+tests.
 
 ## File placement
 

--- a/.github/copilot/test-generation.instructions.md
+++ b/.github/copilot/test-generation.instructions.md
@@ -5,13 +5,11 @@
 
 ## Framework
 
-**Vitest** is the test runner and **React Testing Library** the component
-harness. Both are installed in `apps/api` and `apps/web`; generate tests
-targeting this stack.
+**Vitest** is the test runner for `apps/api` and `apps/web`, with **React
+Testing Library** for web component tests. Generate tests targeting this stack.
 
-End-to-end tests are **Playwright** specs and live in `tools/e2e`, not
-alongside the code they exercise. These instructions cover unit and component
-tests.
+**Playwright** end-to-end specs live in `tools/e2e` rather than beside the code
+they exercise, and fall outside these instructions.
 
 ## File placement
 

--- a/apps/web/src/features/collection/characters/character-card.test.tsx
+++ b/apps/web/src/features/collection/characters/character-card.test.tsx
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { Character } from '@genshin/game-data';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CharacterCard } from './character-card';
+
+const AMBER = {
+  id: 'amber',
+  name: 'Amber',
+  element: 'Pyro',
+  weaponType: 'Bow',
+  rarity: 4,
+  region: 'Mondstadt',
+  version: '1.0',
+  releaseDate: '2020-09-28',
+} satisfies Character;
+
+describe('CharacterCard', () => {
+  it('adds an unowned character when its card is clicked', async () => {
+    const onAdd = vi.fn();
+    render(<CharacterCard character={AMBER} onAdd={onAdd} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Amber to collection' }));
+
+    expect(onAdd).toHaveBeenCalledWith('amber');
+  });
+
+  it('removes an owned character without offering to add it again', async () => {
+    const onRemove = vi.fn();
+    render(<CharacterCard character={AMBER} owned onRemove={onRemove} />);
+
+    expect(screen.queryByRole('button', { name: /Add Amber/ })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Amber from collection' }));
+
+    expect(onRemove).toHaveBeenCalledWith('amber');
+  });
+
+  it('sets a new constellation level from the popover', async () => {
+    const onConstellationChange = vi.fn();
+    render(
+      <CharacterCard
+        character={AMBER}
+        owned
+        constellationLevel={2}
+        onRemove={vi.fn()}
+        onConstellationChange={onConstellationChange}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Constellation level 2 for Amber, click to edit' }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Set constellation level 5' }));
+
+    expect(onConstellationChange).toHaveBeenCalledWith('amber', 5);
+  });
+
+  it('offers every constellation level, marking the current one', async () => {
+    render(
+      <CharacterCard
+        character={AMBER}
+        owned
+        constellationLevel={2}
+        onRemove={vi.fn()}
+        onConstellationChange={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Constellation level 2 for Amber, click to edit' }),
+    );
+
+    expect(screen.getAllByRole('button', { name: /^Set constellation level/ })).toHaveLength(7);
+    expect(screen.getByRole('button', { name: 'Set constellation level 2' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('renders no controls when given no callbacks', () => {
+    render(<CharacterCard character={AMBER} owned constellationLevel={4} />);
+
+    expect(screen.getByText('Amber')).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/features/collection/characters/character-card.test.tsx
+++ b/apps/web/src/features/collection/characters/character-card.test.tsx
@@ -4,6 +4,7 @@
 import type { Character } from '@genshin/game-data';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { CharacterCard } from './character-card';
@@ -19,6 +20,27 @@ const AMBER = {
   releaseDate: '2020-09-28',
 } satisfies Character;
 
+/** C0 through C6. */
+const CONSTELLATION_LEVEL_COUNT = 7;
+
+/**
+ * Renders the owned, interactive card.
+ *
+ * `onRemove` is what selects that branch — an owned card with no callbacks at
+ * all renders the read-only variant instead, controls and all omitted.
+ */
+function renderOwnedCard(props: Partial<ComponentProps<typeof CharacterCard>> = {}) {
+  return render(<CharacterCard character={AMBER} owned onRemove={vi.fn()} {...props} />);
+}
+
+async function openConstellationPopover(currentLevel: number) {
+  await userEvent.click(
+    screen.getByRole('button', {
+      name: `Constellation level ${currentLevel} for Amber, click to edit`,
+    }),
+  );
+}
+
 describe('CharacterCard', () => {
   it('adds an unowned character when its card is clicked', async () => {
     const onAdd = vi.fn();
@@ -31,7 +53,7 @@ describe('CharacterCard', () => {
 
   it('removes an owned character without offering to add it again', async () => {
     const onRemove = vi.fn();
-    render(<CharacterCard character={AMBER} owned onRemove={onRemove} />);
+    renderOwnedCard({ onRemove });
 
     expect(screen.queryByRole('button', { name: /Add Amber/ })).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Remove Amber from collection' }));
@@ -41,40 +63,22 @@ describe('CharacterCard', () => {
 
   it('sets a new constellation level from the popover', async () => {
     const onConstellationChange = vi.fn();
-    render(
-      <CharacterCard
-        character={AMBER}
-        owned
-        constellationLevel={2}
-        onRemove={vi.fn()}
-        onConstellationChange={onConstellationChange}
-      />,
-    );
+    renderOwnedCard({ constellationLevel: 2, onConstellationChange });
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Constellation level 2 for Amber, click to edit' }),
-    );
+    await openConstellationPopover(2);
     await userEvent.click(screen.getByRole('button', { name: 'Set constellation level 5' }));
 
     expect(onConstellationChange).toHaveBeenCalledWith('amber', 5);
   });
 
   it('offers every constellation level, marking the current one', async () => {
-    render(
-      <CharacterCard
-        character={AMBER}
-        owned
-        constellationLevel={2}
-        onRemove={vi.fn()}
-        onConstellationChange={vi.fn()}
-      />,
-    );
+    renderOwnedCard({ constellationLevel: 2, onConstellationChange: vi.fn() });
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Constellation level 2 for Amber, click to edit' }),
-    );
+    await openConstellationPopover(2);
 
-    expect(screen.getAllByRole('button', { name: /^Set constellation level/ })).toHaveLength(7);
+    expect(screen.getAllByRole('button', { name: /^Set constellation level/ })).toHaveLength(
+      CONSTELLATION_LEVEL_COUNT,
+    );
     expect(screen.getByRole('button', { name: 'Set constellation level 2' })).toHaveAttribute(
       'aria-pressed',
       'true',

--- a/apps/web/src/features/collection/characters/character-card.test.tsx
+++ b/apps/web/src/features/collection/characters/character-card.test.tsx
@@ -24,10 +24,8 @@ const AMBER = {
 const CONSTELLATION_LEVEL_COUNT = 7;
 
 /**
- * Renders the owned, interactive card.
- *
- * `onRemove` is what selects that branch — an owned card with no callbacks at
- * all renders the read-only variant instead, controls and all omitted.
+ * `onRemove` is what selects the owned, interactive branch. An owned card with
+ * no callbacks renders the read-only variant instead.
  */
 function renderOwnedCard(props: Partial<ComponentProps<typeof CharacterCard>> = {}) {
   return render(<CharacterCard character={AMBER} owned onRemove={vi.fn()} {...props} />);

--- a/apps/web/src/features/collection/characters/character-card.tsx
+++ b/apps/web/src/features/collection/characters/character-card.tsx
@@ -23,6 +23,88 @@ const CONSTELLATION_LEVELS = Array.from(
   (_, i) => MIN_CONSTELLATION_LEVEL + i,
 );
 
+interface ConstellationPopoverProps {
+  character: Character;
+  constellationLevel: number;
+  onConstellationChange: (characterId: Character['id'], level: number) => void;
+}
+
+function ConstellationPopover({
+  character,
+  constellationLevel,
+  onConstellationChange,
+}: ConstellationPopoverProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          onClick={(e) => e.stopPropagation()}
+          className="relative z-10 shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground hover:bg-muted/80"
+          aria-label={`Constellation level ${constellationLevel} for ${character.name}, click to edit`}
+        >
+          C{constellationLevel}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-auto p-2"
+        side="top"
+        align="end"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="mb-1.5 text-center text-xs font-medium text-muted-foreground">
+          Constellation
+        </p>
+        <div className="flex gap-1">
+          {CONSTELLATION_LEVELS.map((level) => (
+            <button
+              key={level}
+              type="button"
+              onClick={() => {
+                onConstellationChange(character.id, level);
+                setOpen(false);
+              }}
+              className={cn(
+                'h-7 w-7 rounded text-xs font-bold tabular-nums transition-colors',
+                level === constellationLevel
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80',
+              )}
+              aria-label={`Set constellation level ${level}`}
+              aria-pressed={level === constellationLevel}
+            >
+              {level}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface RemoveButtonProps {
+  character: Character;
+  onRemove: (characterId: Character['id']) => void;
+}
+
+function RemoveButton({ character, onRemove }: RemoveButtonProps): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onRemove(character.id);
+      }}
+      className="relative z-10 shrink-0 rounded-md p-1 text-destructive opacity-0 transition-opacity group-hover:opacity-100 hover:bg-destructive hover:text-destructive-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
+      aria-label={`Remove ${character.name} from collection`}
+    >
+      <Trash2 className="h-4 w-4" />
+    </button>
+  );
+}
+
 interface CharacterCardProps {
   character: Character;
   owned?: boolean;
@@ -42,8 +124,6 @@ export function CharacterCard({
   onRemove,
   onConstellationChange,
 }: CharacterCardProps): JSX.Element {
-  const [popoverOpen, setPopoverOpen] = useState(false);
-
   const borderColors = owned ? ELEMENT_BORDER_COLORS : ELEMENT_BORDER_COLORS_DIM;
 
   const sharedClassName = cn(
@@ -51,90 +131,36 @@ export function CharacterCard({
     borderColors[character.element],
   );
 
+  const selectedRingClassName = cn(
+    'ring-2 ring-offset-2 ring-offset-background',
+    ELEMENT_SELECTED_RINGS[character.element],
+  );
+
+  const readOnly = !onAdd && !onRemove;
+
   const content = (
     <>
       <CharacterSummary character={character} dimmed={!owned} />
 
       {owned && onConstellationChange && (
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              onClick={(e) => e.stopPropagation()}
-              className="relative z-10 shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-bold tabular-nums text-muted-foreground hover:bg-muted/80"
-              aria-label={`Constellation level ${constellationLevel} for ${character.name}, click to edit`}
-            >
-              C{constellationLevel}
-            </button>
-          </PopoverTrigger>
-          <PopoverContent
-            className="w-auto p-2"
-            side="top"
-            align="end"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <p className="mb-1.5 text-center text-xs font-medium text-muted-foreground">
-              Constellation
-            </p>
-            <div className="flex gap-1">
-              {CONSTELLATION_LEVELS.map((level) => (
-                <button
-                  key={level}
-                  type="button"
-                  onClick={() => {
-                    onConstellationChange(character.id, level);
-                    setPopoverOpen(false);
-                  }}
-                  className={cn(
-                    'h-7 w-7 rounded text-xs font-bold tabular-nums transition-colors',
-                    level === constellationLevel
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-muted text-muted-foreground hover:bg-muted/80',
-                  )}
-                  aria-label={`Set constellation level ${level}`}
-                  aria-pressed={level === constellationLevel}
-                >
-                  {level}
-                </button>
-              ))}
-            </div>
-          </PopoverContent>
-        </Popover>
+        <ConstellationPopover
+          character={character}
+          constellationLevel={constellationLevel}
+          onConstellationChange={onConstellationChange}
+        />
       )}
 
-      {owned && onRemove && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove(character.id);
-          }}
-          className="relative z-10 shrink-0 rounded-md p-1 text-destructive opacity-0 transition-opacity group-hover:opacity-100 hover:bg-destructive hover:text-destructive-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
-          aria-label={`Remove ${character.name} from collection`}
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
-      )}
+      {owned && onRemove && <RemoveButton character={character} onRemove={onRemove} />}
     </>
   );
 
-  if (!onAdd && !onRemove) {
+  if (readOnly) {
     return <div className={sharedClassName}>{content}</div>;
   }
 
   if (owned) {
     return (
-      <div
-        className={cn(
-          sharedClassName,
-          'group',
-          selected &&
-            cn(
-              'ring-2 ring-offset-2 ring-offset-background',
-              ELEMENT_SELECTED_RINGS[character.element],
-            ),
-        )}
-      >
+      <div className={cn(sharedClassName, 'group', selected && selectedRingClassName)}>
         {content}
       </div>
     );
@@ -150,11 +176,7 @@ export function CharacterCard({
         sharedClassName,
         'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
         selected
-          ? cn(
-              'ring-2 ring-offset-2 ring-offset-background',
-              ELEMENT_SELECTED_RINGS[character.element],
-              ELEMENT_FOCUS_RINGS[character.element],
-            )
+          ? cn(selectedRingClassName, ELEMENT_FOCUS_RINGS[character.element])
           : 'focus-visible:ring-ring',
       )}
       aria-label={`Add ${character.name} to collection`}


### PR DESCRIPTION
## Summary

`CharacterCard` is now covered by component tests, and the agent instruction
files describe the test stack that exists rather than one that was planned. The
new coverage is then spent refactoring the component's inline control markup
into named pieces.

Closes #526

## Gotchas

- **#526 was mostly already delivered** — the web Vitest suite covers Phases 1
  and 2, and Playwright landed via #1009 as `tools/e2e` rather than in
  `apps/web` as the issue scoped it. `CharacterCard` was the one named
  component with no coverage, so this is the issue's residue.
- **Production code changes on a testing issue.** `6d1517b` adds the tests;
  `98713fd` and `92f99f7` refactor under them, reviewable separately.
- **The selected-ring extraction has no test behind it** — the suite asserts no
  class names by design. It rests on `cn` being `twMerge(clsx(...))` with the
  extracted classes in different merge groups from the `focus-visible:ring-*`
  they nest inside.

## Verification

- Mutated the constellation callback to a constant and confirmed the suite goes
  red, checking the tests didn't go vacuous when both they and the component
  were refactored together.