### PR TITLE
feat(domain): validate optional team fields in assertCollectionTeam

### DIFF
--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -70,7 +70,7 @@ function mockCharacterOwned() {
 
 function mockWeaponOwned() {
   vi.mocked(Weapons.get).mockResolvedValue({
-    weaponInstanceId: 'uuid-1' as UUID,
+    weaponInstanceId: 'uuid-1',
     weaponId: 'staff-of-homa',
     refinementLevel: 1,
     createdAt: '2026-01-01T00:00:00.000Z',

--- a/packages/domain/src/artifact/artifact-plan.test.ts
+++ b/packages/domain/src/artifact/artifact-plan.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { assertArtifactPlan } from './artifact-plan.js';
+
+const VALID_PLAN = {
+  sands: 'ATK Percentage',
+  goblet: 'Hydro DMG Bonus',
+  circlet: 'CRIT Rate',
+  sets: ['aubade-of-morningstar-and-moon'],
+  priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
+  secondaryMinorAffixes: ['ATK Percentage'],
+};
+
+describe('assertArtifactPlan', () => {
+  it('accepts a fully populated plan', () => {
+    expect(() => assertArtifactPlan({ ...VALID_PLAN })).not.toThrow();
+  });
+
+  it('accepts an empty plan', () => {
+    expect(() => assertArtifactPlan({})).not.toThrow();
+  });
+
+  it.each(['sands', 'goblet', 'circlet', 'sets', 'priorityMinorAffixes', 'secondaryMinorAffixes'])(
+    'accepts a plan omitting %s',
+    (field) => {
+      const { [field]: _omitted, ...rest } = VALID_PLAN as Record<string, unknown>;
+      expect(() => assertArtifactPlan(rest)).not.toThrow();
+    },
+  );
+
+  it('throws for a non-object', () => {
+    expect(() => assertArtifactPlan('not-an-object')).toThrow(
+      /artifactPlan must be a non-null object/,
+    );
+  });
+
+  it('throws for null', () => {
+    expect(() => assertArtifactPlan(null)).toThrow(TypeError);
+  });
+
+  it.each(['sands', 'goblet', 'circlet'])('throws for a non-string %s', (field) => {
+    expect(() => assertArtifactPlan({ ...VALID_PLAN, [field]: 42 })).toThrow(
+      new RegExp(`artifactPlan\\.${field} must be a string`),
+    );
+  });
+
+  it('throws for sets that is not an array', () => {
+    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: 'one-set' })).toThrow(
+      /artifactPlan\.sets must be an array/,
+    );
+  });
+
+  it('throws for a non-string set entry', () => {
+    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: [42] })).toThrow(
+      /artifactPlan\.sets\[0\] must be a string/,
+    );
+  });
+
+  it('throws for an empty sets array', () => {
+    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: [] })).toThrow(
+      /artifactPlan\.sets must have between 1 and 2/,
+    );
+  });
+
+  it('throws for more than two sets', () => {
+    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: ['a', 'b', 'c'] })).toThrow(
+      /artifactPlan\.sets must have between 1 and 2/,
+    );
+  });
+
+  it('throws for more than three minor affixes', () => {
+    expect(() =>
+      assertArtifactPlan({ ...VALID_PLAN, secondaryMinorAffixes: ['a', 'b', 'c', 'd'] }),
+    ).toThrow(/artifactPlan\.secondaryMinorAffixes must have between 0 and 3/);
+  });
+
+  it('reports the caller-supplied path', () => {
+    expect(() => assertArtifactPlan({ sands: 42 }, 'members[2].artifactPlan')).toThrow(
+      /members\[2\]\.artifactPlan\.sands must be a string/,
+    );
+  });
+});

--- a/packages/domain/src/artifact/artifact-plan.ts
+++ b/packages/domain/src/artifact/artifact-plan.ts
@@ -41,14 +41,9 @@ const MIN_MINOR_AFFIXES = 0;
 const MAX_MINOR_AFFIXES = 3;
 
 /**
- * Assert that `value` has the shape of an {@link ArtifactPlan}.
- *
- * Checks structure only — affix names and set IDs are checked against
- * game-data by {@link validateArtifactPlan}, which reports every problem at
- * once instead of throwing on the first.
- *
- * @param path - Prefix for error messages, so a nested plan reports its
- *   position (e.g. `CollectionTeam.members[0].artifactPlan`).
+ * Structural check only. Affix names and set IDs are validated against
+ * game-data by `validateArtifactPlan`, which collects every problem instead of
+ * throwing on the first.
  */
 export function assertArtifactPlan(
   value: unknown,

--- a/packages/domain/src/artifact/artifact-plan.ts
+++ b/packages/domain/src/artifact/artifact-plan.ts
@@ -32,3 +32,61 @@ export interface ArtifactPlan {
   /** 0–3 secondary minor affixes (must be disjoint from priorityMinorAffixes) */
   secondaryMinorAffixes?: ArtifactMinorAffix[];
 }
+
+function assertOptionalString(plan: Record<string, unknown>, path: string, field: string): void {
+  if (plan[field] !== undefined && typeof plan[field] !== 'string') {
+    throw new TypeError(`${path}.${field} must be a string, got: ${JSON.stringify(plan[field])}`);
+  }
+}
+
+function assertOptionalStringArray(
+  plan: Record<string, unknown>,
+  path: string,
+  field: string,
+  min: number,
+  max: number,
+): void {
+  const arr = plan[field];
+  if (arr === undefined) return;
+  if (!Array.isArray(arr)) {
+    throw new TypeError(`${path}.${field} must be an array, got: ${JSON.stringify(arr)}`);
+  }
+  if (arr.length < min || arr.length > max) {
+    throw new TypeError(
+      `${path}.${field} must have between ${min} and ${max} elements, got: ${arr.length}`,
+    );
+  }
+  arr.forEach((element, index) => {
+    if (typeof element !== 'string') {
+      throw new TypeError(
+        `${path}.${field}[${index}] must be a string, got: ${JSON.stringify(element)}`,
+      );
+    }
+  });
+}
+
+/**
+ * Assert that `value` has the shape of an {@link ArtifactPlan}.
+ *
+ * Checks structure only — affix names and set IDs are checked against
+ * game-data by {@link validateArtifactPlan}, which reports every problem at
+ * once instead of throwing on the first.
+ *
+ * @param path - Prefix for error messages, so a nested plan reports its
+ *   position (e.g. `CollectionTeam.members[0].artifactPlan`).
+ */
+export function assertArtifactPlan(
+  value: unknown,
+  path = 'artifactPlan',
+): asserts value is ArtifactPlan {
+  if (typeof value !== 'object' || value === null) {
+    throw new TypeError(`${path} must be a non-null object, got: ${JSON.stringify(value)}`);
+  }
+  const plan = value as Record<string, unknown>;
+  assertOptionalString(plan, path, 'sands');
+  assertOptionalString(plan, path, 'goblet');
+  assertOptionalString(plan, path, 'circlet');
+  assertOptionalStringArray(plan, path, 'sets', 1, 2);
+  assertOptionalStringArray(plan, path, 'priorityMinorAffixes', 0, 3);
+  assertOptionalStringArray(plan, path, 'secondaryMinorAffixes', 0, 3);
+}

--- a/packages/domain/src/artifact/artifact-plan.ts
+++ b/packages/domain/src/artifact/artifact-plan.ts
@@ -9,6 +9,8 @@ import type {
   SandsMainAffix,
 } from '@genshin/game-data';
 
+import { assertOptionalString, assertOptionalStringArray } from '../assertions.js';
+
 /**
  * Artifact plan configuration for a team member.
  *
@@ -33,37 +35,10 @@ export interface ArtifactPlan {
   secondaryMinorAffixes?: ArtifactMinorAffix[];
 }
 
-function assertOptionalString(plan: Record<string, unknown>, path: string, field: string): void {
-  if (plan[field] !== undefined && typeof plan[field] !== 'string') {
-    throw new TypeError(`${path}.${field} must be a string, got: ${JSON.stringify(plan[field])}`);
-  }
-}
-
-function assertOptionalStringArray(
-  plan: Record<string, unknown>,
-  path: string,
-  field: string,
-  min: number,
-  max: number,
-): void {
-  const arr = plan[field];
-  if (arr === undefined) return;
-  if (!Array.isArray(arr)) {
-    throw new TypeError(`${path}.${field} must be an array, got: ${JSON.stringify(arr)}`);
-  }
-  if (arr.length < min || arr.length > max) {
-    throw new TypeError(
-      `${path}.${field} must have between ${min} and ${max} elements, got: ${arr.length}`,
-    );
-  }
-  arr.forEach((element, index) => {
-    if (typeof element !== 'string') {
-      throw new TypeError(
-        `${path}.${field}[${index}] must be a string, got: ${JSON.stringify(element)}`,
-      );
-    }
-  });
-}
+const MIN_SETS = 1;
+const MAX_SETS = 2;
+const MIN_MINOR_AFFIXES = 0;
+const MAX_MINOR_AFFIXES = 3;
 
 /**
  * Assert that `value` has the shape of an {@link ArtifactPlan}.
@@ -83,10 +58,20 @@ export function assertArtifactPlan(
     throw new TypeError(`${path} must be a non-null object, got: ${JSON.stringify(value)}`);
   }
   const plan = value as Record<string, unknown>;
-  assertOptionalString(plan, path, 'sands');
-  assertOptionalString(plan, path, 'goblet');
-  assertOptionalString(plan, path, 'circlet');
-  assertOptionalStringArray(plan, path, 'sets', 1, 2);
-  assertOptionalStringArray(plan, path, 'priorityMinorAffixes', 0, 3);
-  assertOptionalStringArray(plan, path, 'secondaryMinorAffixes', 0, 3);
+  assertOptionalString(plan.sands, `${path}.sands`);
+  assertOptionalString(plan.goblet, `${path}.goblet`);
+  assertOptionalString(plan.circlet, `${path}.circlet`);
+  assertOptionalStringArray(plan.sets, `${path}.sets`, MIN_SETS, MAX_SETS);
+  assertOptionalStringArray(
+    plan.priorityMinorAffixes,
+    `${path}.priorityMinorAffixes`,
+    MIN_MINOR_AFFIXES,
+    MAX_MINOR_AFFIXES,
+  );
+  assertOptionalStringArray(
+    plan.secondaryMinorAffixes,
+    `${path}.secondaryMinorAffixes`,
+    MIN_MINOR_AFFIXES,
+    MAX_MINOR_AFFIXES,
+  );
 }

--- a/packages/domain/src/assertions.ts
+++ b/packages/domain/src/assertions.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/**
+ * Field-level assertion primitives shared by the `assertCollection*` guards.
+ *
+ * Each takes the value and the dotted path it sits at, so a guard on a nested
+ * structure reports the position that failed rather than the outermost type.
+ */
+
+export function assertString(value: unknown, path: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`${path} must be a string, got: ${JSON.stringify(value)}`);
+  }
+}
+
+export function assertOptionalString(value: unknown, path: string): void {
+  if (value !== undefined) assertString(value, path);
+}
+
+export function assertOptionalStringArray(
+  value: unknown,
+  path: string,
+  min: number,
+  max: number,
+): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${path} must be an array, got: ${JSON.stringify(value)}`);
+  }
+  if (value.length < min || value.length > max) {
+    throw new TypeError(
+      `${path} must have between ${min} and ${max} elements, got: ${value.length}`,
+    );
+  }
+  value.forEach((element, index) => {
+    assertString(element, `${path}[${index}]`);
+  });
+}

--- a/packages/domain/src/assertions.ts
+++ b/packages/domain/src/assertions.ts
@@ -4,8 +4,9 @@
 /**
  * Field-level assertion primitives shared by the `assertCollection*` guards.
  *
- * Each takes the value and the dotted path it sits at, so a guard on a nested
- * structure reports the position that failed rather than the outermost type.
+ * Passing the path in is what lets a guard over a nested structure report the
+ * position that failed, such as `CollectionTeam.members[0].artifactPlan.sets`,
+ * rather than the outermost type.
  */
 
 export function assertString(value: unknown, path: string): asserts value is string {

--- a/packages/domain/src/team/collection-team-member.ts
+++ b/packages/domain/src/team/collection-team-member.ts
@@ -21,12 +21,6 @@ export interface CollectionTeamMember {
   artifactPlan?: ArtifactPlan;
 }
 
-/**
- * Assert that `value` has the shape of a {@link CollectionTeamMember}.
- *
- * @param path - Prefix for error messages, so a member reports its position
- *   within the team (e.g. `CollectionTeam.members[0]`).
- */
 export function assertCollectionTeamMember(
   value: unknown,
   path = 'CollectionTeamMember',

--- a/packages/domain/src/team/collection-team-member.ts
+++ b/packages/domain/src/team/collection-team-member.ts
@@ -4,6 +4,8 @@
 import type { Character } from '@genshin/game-data';
 
 import type { ArtifactPlan } from '../artifact/artifact-plan.js';
+import { assertArtifactPlan } from '../artifact/artifact-plan.js';
+import { assertOptionalString, assertString } from '../assertions.js';
 import type { UUID } from '../uuid.js';
 
 /**
@@ -17,4 +19,25 @@ export interface CollectionTeamMember {
   characterId: Character['id'];
   weaponInstanceId?: UUID;
   artifactPlan?: ArtifactPlan;
+}
+
+/**
+ * Assert that `value` has the shape of a {@link CollectionTeamMember}.
+ *
+ * @param path - Prefix for error messages, so a member reports its position
+ *   within the team (e.g. `CollectionTeam.members[0]`).
+ */
+export function assertCollectionTeamMember(
+  value: unknown,
+  path = 'CollectionTeamMember',
+): asserts value is CollectionTeamMember {
+  if (typeof value !== 'object' || value === null) {
+    throw new TypeError(`${path} must be a non-null object, got: ${JSON.stringify(value)}`);
+  }
+  const member = value as Record<string, unknown>;
+  assertString(member.characterId, `${path}.characterId`);
+  assertOptionalString(member.weaponInstanceId, `${path}.weaponInstanceId`);
+  if (member.artifactPlan !== undefined) {
+    assertArtifactPlan(member.artifactPlan, `${path}.artifactPlan`);
+  }
 }

--- a/packages/domain/src/team/collection-team-member.ts
+++ b/packages/domain/src/team/collection-team-member.ts
@@ -6,7 +6,7 @@ import type { Character } from '@genshin/game-data';
 import type { ArtifactPlan } from '../artifact/artifact-plan.js';
 import { assertArtifactPlan } from '../artifact/artifact-plan.js';
 import { assertOptionalString, assertString } from '../assertions.js';
-import type { UUID } from '../uuid.js';
+import type { CollectionWeaponId } from '../weapon/collection-weapon.js';
 
 /**
  * CollectionTeamMember represents a single character position in a team with
@@ -17,7 +17,7 @@ import type { UUID } from '../uuid.js';
  */
 export interface CollectionTeamMember {
   characterId: Character['id'];
-  weaponInstanceId?: UUID;
+  weaponInstanceId?: CollectionWeaponId;
   artifactPlan?: ArtifactPlan;
 }
 

--- a/packages/domain/src/team/collection-team.test.ts
+++ b/packages/domain/src/team/collection-team.test.ts
@@ -41,7 +41,6 @@ const VALID_PLAN = {
   secondaryMinorAffixes: ['ATK Percentage'],
 };
 
-/** A valid team carrying `member` at `index`, the rest of the slots empty. */
 function teamWithMember(member: unknown, index = 0): Record<string, unknown> {
   const members = [null, null, null, null];
   members[index] = member as null;

--- a/packages/domain/src/team/collection-team.test.ts
+++ b/packages/domain/src/team/collection-team.test.ts
@@ -24,9 +24,6 @@ const VALID_MEMBERS: CollectionTeamMembers = [
   null,
 ];
 
-/** Padding for a single-member `members` tuple. */
-const NULLS = [null, null, null] as const;
-
 const VALID_TEAM = {
   slot: 1 as TeamSlot,
   name: 'Team 1',
@@ -34,6 +31,22 @@ const VALID_TEAM = {
   createdAt: VALID_TIMESTAMP,
   updatedAt: VALID_TIMESTAMP,
 };
+
+const VALID_PLAN = {
+  sands: 'ATK Percentage',
+  goblet: 'Hydro DMG Bonus',
+  circlet: 'CRIT Rate',
+  sets: ['aubade-of-morningstar-and-moon'],
+  priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
+  secondaryMinorAffixes: ['ATK Percentage'],
+};
+
+/** A valid team carrying `member` at `index`, the rest of the slots empty. */
+function teamWithMember(member: unknown, index = 0): Record<string, unknown> {
+  const members = [null, null, null, null];
+  members[index] = member as null;
+  return { ...VALID_TEAM, members };
+}
 
 describe('TEAM_SLOTS', () => {
   it('contains all slots from MIN to MAX', () => {
@@ -151,49 +164,29 @@ describe('assertCollectionTeam', () => {
   });
 
   it('throws for member without characterId', () => {
-    expect(() =>
-      assertCollectionTeam({
-        ...VALID_TEAM,
-        members: [{ notCharacterId: 'x' }, null, null, null],
-      }),
-    ).toThrow(/characterId/);
+    expect(() => assertCollectionTeam(teamWithMember({ notCharacterId: 'x' }))).toThrow(
+      /members\[0\]\.characterId must be a string/,
+    );
   });
 
   it('accepts a member with a weapon instance and a full artifact plan', () => {
     expect(() =>
       assertCollectionTeam({
-        ...VALID_TEAM,
+        ...teamWithMember({
+          characterId: 'columbina',
+          weaponInstanceId: '3f2a1c6e-9d4b-4a7f-8e21-0b5c6d7e8f90',
+          artifactPlan: VALID_PLAN,
+        }),
         description: 'Hydro core',
-        members: [
-          {
-            characterId: 'columbina',
-            weaponInstanceId: '3f2a1c6e-9d4b-4a7f-8e21-0b5c6d7e8f90',
-            artifactPlan: {
-              sands: 'ATK Percentage',
-              goblet: 'Hydro DMG Bonus',
-              circlet: 'CRIT Rate',
-              sets: ['aubade-of-morningstar-and-moon'],
-              priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
-              secondaryMinorAffixes: ['ATK Percentage'],
-            },
-          },
-          null,
-          null,
-          null,
-        ],
       }),
     ).not.toThrow();
   });
 
   it('accepts a member with a partially filled artifact plan', () => {
     expect(() =>
-      assertCollectionTeam({
-        ...VALID_TEAM,
-        members: [
-          { characterId: 'columbina', artifactPlan: { sands: 'ATK Percentage' } },
-          ...NULLS,
-        ],
-      }),
+      assertCollectionTeam(
+        teamWithMember({ characterId: 'columbina', artifactPlan: { sands: 'ATK Percentage' } }),
+      ),
     ).not.toThrow();
   });
 
@@ -201,44 +194,39 @@ describe('assertCollectionTeam', () => {
     expect(() => assertCollectionTeam({ ...VALID_TEAM, description: 123 })).toThrow(/description/);
   });
 
+  it('throws for a non-object member', () => {
+    expect(() => assertCollectionTeam(teamWithMember('not-an-object'))).toThrow(
+      /members\[0\] must be a non-null object/,
+    );
+  });
+
   it('throws for non-string weaponInstanceId', () => {
     expect(() =>
-      assertCollectionTeam({
-        ...VALID_TEAM,
-        members: [{ characterId: 'columbina', weaponInstanceId: 42 }, ...NULLS],
-      }),
+      assertCollectionTeam(teamWithMember({ characterId: 'columbina', weaponInstanceId: 42 })),
     ).toThrow(/members\[0\]\.weaponInstanceId/);
   });
 
   it('throws for a non-object artifact plan', () => {
     expect(() =>
-      assertCollectionTeam({
-        ...VALID_TEAM,
-        members: [{ characterId: 'columbina', artifactPlan: 'not-an-object' }, ...NULLS],
-      }),
+      assertCollectionTeam(
+        teamWithMember({ characterId: 'columbina', artifactPlan: 'not-an-object' }),
+      ),
     ).toThrow(/members\[0\]\.artifactPlan must be a non-null object/);
   });
 
   it('throws for a non-string main affix in an artifact plan', () => {
     expect(() =>
-      assertCollectionTeam({
-        ...VALID_TEAM,
-        members: [{ characterId: 'columbina', artifactPlan: { sands: 42 } }, ...NULLS],
-      }),
+      assertCollectionTeam(
+        teamWithMember({ characterId: 'columbina', artifactPlan: { sands: 42 } }),
+      ),
     ).toThrow(/members\[0\]\.artifactPlan\.sands must be a string/);
   });
 
   it('throws for a malformed artifact plan on a later member', () => {
     expect(() =>
-      assertCollectionTeam({
-        ...VALID_TEAM,
-        members: [
-          null,
-          null,
-          { characterId: 'durin', artifactPlan: { sets: 'not-an-array' } },
-          null,
-        ],
-      }),
+      assertCollectionTeam(
+        teamWithMember({ characterId: 'durin', artifactPlan: { sets: 'not-an-array' } }, 2),
+      ),
     ).toThrow(/members\[2\]\.artifactPlan\.sets must be an array/);
   });
 

--- a/packages/domain/src/team/collection-team.test.ts
+++ b/packages/domain/src/team/collection-team.test.ts
@@ -24,6 +24,9 @@ const VALID_MEMBERS: CollectionTeamMembers = [
   null,
 ];
 
+/** Padding for a single-member `members` tuple. */
+const NULLS = [null, null, null] as const;
+
 const VALID_TEAM = {
   slot: 1 as TeamSlot,
   name: 'Team 1',
@@ -154,6 +157,89 @@ describe('assertCollectionTeam', () => {
         members: [{ notCharacterId: 'x' }, null, null, null],
       }),
     ).toThrow(/characterId/);
+  });
+
+  it('accepts a member with a weapon instance and a full artifact plan', () => {
+    expect(() =>
+      assertCollectionTeam({
+        ...VALID_TEAM,
+        description: 'Hydro core',
+        members: [
+          {
+            characterId: 'columbina',
+            weaponInstanceId: '3f2a1c6e-9d4b-4a7f-8e21-0b5c6d7e8f90',
+            artifactPlan: {
+              sands: 'ATK Percentage',
+              goblet: 'Hydro DMG Bonus',
+              circlet: 'CRIT Rate',
+              sets: ['aubade-of-morningstar-and-moon'],
+              priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
+              secondaryMinorAffixes: ['ATK Percentage'],
+            },
+          },
+          null,
+          null,
+          null,
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts a member with a partially filled artifact plan', () => {
+    expect(() =>
+      assertCollectionTeam({
+        ...VALID_TEAM,
+        members: [
+          { characterId: 'columbina', artifactPlan: { sands: 'ATK Percentage' } },
+          ...NULLS,
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws for non-string description', () => {
+    expect(() => assertCollectionTeam({ ...VALID_TEAM, description: 123 })).toThrow(/description/);
+  });
+
+  it('throws for non-string weaponInstanceId', () => {
+    expect(() =>
+      assertCollectionTeam({
+        ...VALID_TEAM,
+        members: [{ characterId: 'columbina', weaponInstanceId: 42 }, ...NULLS],
+      }),
+    ).toThrow(/members\[0\]\.weaponInstanceId/);
+  });
+
+  it('throws for a non-object artifact plan', () => {
+    expect(() =>
+      assertCollectionTeam({
+        ...VALID_TEAM,
+        members: [{ characterId: 'columbina', artifactPlan: 'not-an-object' }, ...NULLS],
+      }),
+    ).toThrow(/members\[0\]\.artifactPlan must be a non-null object/);
+  });
+
+  it('throws for a non-string main affix in an artifact plan', () => {
+    expect(() =>
+      assertCollectionTeam({
+        ...VALID_TEAM,
+        members: [{ characterId: 'columbina', artifactPlan: { sands: 42 } }, ...NULLS],
+      }),
+    ).toThrow(/members\[0\]\.artifactPlan\.sands must be a string/);
+  });
+
+  it('throws for a malformed artifact plan on a later member', () => {
+    expect(() =>
+      assertCollectionTeam({
+        ...VALID_TEAM,
+        members: [
+          null,
+          null,
+          { characterId: 'durin', artifactPlan: { sets: 'not-an-array' } },
+          null,
+        ],
+      }),
+    ).toThrow(/members\[2\]\.artifactPlan\.sets must be an array/);
   });
 
   it('throws for invalid createdAt', () => {

--- a/packages/domain/src/team/collection-team.ts
+++ b/packages/domain/src/team/collection-team.ts
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
+import { assertArtifactPlan } from '../artifact/artifact-plan.js';
 import type { ISOTimestamp } from '../iso-timestamp.js';
 import { isISOTimestamp, nowTimestamp } from '../iso-timestamp.js';
 import type { CollectionTeamMember } from './collection-team-member.js';
@@ -85,13 +86,27 @@ export function assertCollectionTeam(value: unknown): asserts value is Collectio
       `CollectionTeam.members must have exactly ${MAX_TEAM_MEMBERS} entries, got: ${data.members.length}`,
     );
   }
-  for (const member of data.members) {
+  for (const [i, member] of (data.members as unknown[]).entries()) {
     if (member === null) continue;
-    if (typeof member !== 'object' || typeof member.characterId !== 'string') {
+    const entry = member as Record<string, unknown>;
+    if (typeof member !== 'object' || typeof entry.characterId !== 'string') {
       throw new TypeError(
         `CollectionTeam.members entries must have a string characterId, got: ${JSON.stringify(member)}`,
       );
     }
+    if (entry.weaponInstanceId !== undefined && typeof entry.weaponInstanceId !== 'string') {
+      throw new TypeError(
+        `CollectionTeam.members[${i}].weaponInstanceId must be a string, got: ${JSON.stringify(entry.weaponInstanceId)}`,
+      );
+    }
+    if (entry.artifactPlan !== undefined) {
+      assertArtifactPlan(entry.artifactPlan, `CollectionTeam.members[${i}].artifactPlan`);
+    }
+  }
+  if (data.description !== undefined && typeof data.description !== 'string') {
+    throw new TypeError(
+      `CollectionTeam.description must be a string, got: ${JSON.stringify(data.description)}`,
+    );
   }
   if (!isISOTimestamp(data.createdAt)) {
     throw new TypeError(

--- a/packages/domain/src/team/collection-team.ts
+++ b/packages/domain/src/team/collection-team.ts
@@ -1,10 +1,11 @@
 /* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
 /* SPDX-License-Identifier: MIT */
 
-import { assertArtifactPlan } from '../artifact/artifact-plan.js';
+import { assertOptionalString, assertString } from '../assertions.js';
 import type { ISOTimestamp } from '../iso-timestamp.js';
 import { isISOTimestamp, nowTimestamp } from '../iso-timestamp.js';
 import type { CollectionTeamMember } from './collection-team-member.js';
+import { assertCollectionTeamMember } from './collection-team-member.js';
 
 export const MIN_TEAM_SLOT = 1;
 export const MAX_TEAM_SLOT = 4;
@@ -73,9 +74,7 @@ export function assertCollectionTeam(value: unknown): asserts value is Collectio
       `CollectionTeam.slot must be an integer between ${MIN_TEAM_SLOT} and ${MAX_TEAM_SLOT}, got: ${JSON.stringify(data.slot)}`,
     );
   }
-  if (typeof data.name !== 'string') {
-    throw new TypeError(`CollectionTeam.name must be a string, got: ${JSON.stringify(data.name)}`);
-  }
+  assertString(data.name, 'CollectionTeam.name');
   if (!Array.isArray(data.members)) {
     throw new TypeError(
       `CollectionTeam.members must be an array, got: ${JSON.stringify(data.members)}`,
@@ -88,26 +87,9 @@ export function assertCollectionTeam(value: unknown): asserts value is Collectio
   }
   for (const [i, member] of (data.members as unknown[]).entries()) {
     if (member === null) continue;
-    const entry = member as Record<string, unknown>;
-    if (typeof member !== 'object' || typeof entry.characterId !== 'string') {
-      throw new TypeError(
-        `CollectionTeam.members entries must have a string characterId, got: ${JSON.stringify(member)}`,
-      );
-    }
-    if (entry.weaponInstanceId !== undefined && typeof entry.weaponInstanceId !== 'string') {
-      throw new TypeError(
-        `CollectionTeam.members[${i}].weaponInstanceId must be a string, got: ${JSON.stringify(entry.weaponInstanceId)}`,
-      );
-    }
-    if (entry.artifactPlan !== undefined) {
-      assertArtifactPlan(entry.artifactPlan, `CollectionTeam.members[${i}].artifactPlan`);
-    }
+    assertCollectionTeamMember(member, `CollectionTeam.members[${i}]`);
   }
-  if (data.description !== undefined && typeof data.description !== 'string') {
-    throw new TypeError(
-      `CollectionTeam.description must be a string, got: ${JSON.stringify(data.description)}`,
-    );
-  }
+  assertOptionalString(data.description, 'CollectionTeam.description');
   if (!isISOTimestamp(data.createdAt)) {
     throw new TypeError(
       `CollectionTeam.createdAt must be an ISO 8601 timestamp, got: ${JSON.stringify(data.createdAt)}`,

--- a/packages/domain/src/weapon/collection-weapon.ts
+++ b/packages/domain/src/weapon/collection-weapon.ts
@@ -6,20 +6,26 @@ import { getWeaponById } from '@genshin/game-data';
 
 import type { ISOTimestamp } from '../iso-timestamp.js';
 import { isISOTimestamp } from '../iso-timestamp.js';
-import type { UUID } from '../uuid.js';
 
 export const MIN_REFINEMENT_LEVEL = 1;
 export const MAX_REFINEMENT_LEVEL = 5;
 
+/**
+ * Identifier for one weapon instance in a user's collection.
+ *
+ * The API mints these with `randomUUID`, but the served profiles constrain the
+ * field to a non-empty string rather than a UUID format, so nothing may rely on
+ * the shape. Equality is the only operation performed on it.
+ */
+export type CollectionWeaponId = string;
+
 export interface CollectionWeapon {
-  weaponInstanceId: UUID;
+  weaponInstanceId: CollectionWeaponId;
   weaponId: Weapon['id'];
   refinementLevel: number;
   createdAt: ISOTimestamp;
   updatedAt: ISOTimestamp;
 }
-
-export type CollectionWeaponId = CollectionWeapon['weaponInstanceId'];
 
 export function isValidRefinementLevel(value: unknown): value is number {
   return (


### PR DESCRIPTION
## Summary

`assertCollectionTeam` now rejects a non-string `description`, a non-string `weaponInstanceId`, and a malformed `artifactPlan`, closing the gap where optional fields reached callers unchecked on the Firestore read path and in the collection+json deserialiser.

Closes #504.

## Gotchas

- `weaponInstanceId` loses the branded `UUID` type. A `typeof` check would grant a brand it doesn't establish, and tightening the check instead would reject inputs Ajv accepts — the served profile allows any non-empty string, and nothing does more with the value than compare it. Only the two declarations move: #916 is mid-rename over the same fixtures, so its `as UUID` casts and the now-vestigial type stay for that sweep.
- A malformed member now reports `CollectionTeam.members[2].characterId must be a string` rather than `CollectionTeam.members entries must have a string characterId`. The old text is asserted only by these tests.
- Plan fields are optional here, matching the interface and the Zod schema. `deserialiseArtifactPlan` requires all six present, which is a bug — #1144.
- On the Firestore path this guard now largely duplicates `V1TeamSchema`; #1147 tracks thinning it, including that tightening a shipped Zod version is a narrowing change the compat gate rejects.