### PR TITLE
refactor(domain): type constellation level as a 0-6 union

### DIFF
--- a/apps/api/src/repositories/characters/document.test.ts
+++ b/apps/api/src/repositories/characters/document.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import { CONSTELLATION_LEVELS } from '@genshin/domain';
 import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 
@@ -19,10 +19,7 @@ const TIMESTAMP = '2024-01-15T12:00:00.000Z';
 
 const arbCharacter = fc.record({
   characterId: arbCharacterId,
-  constellationLevel: fc.integer({
-    min: MIN_CONSTELLATION_LEVEL,
-    max: MAX_CONSTELLATION_LEVEL,
-  }),
+  constellationLevel: fc.constantFrom(...CONSTELLATION_LEVELS),
   createdAt: arbTimestamp,
   updatedAt: arbTimestamp,
 });

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
+import type { CollectionCharacter, ConstellationLevel, ISOTimestamp } from '@genshin/domain';
 
 import { db } from '@/lib/firebase/firestore.js';
 
@@ -43,7 +43,7 @@ export interface SaveResult {
 export async function save(
   userId: string,
   characterId: string,
-  constellationLevel: number,
+  constellationLevel: ConstellationLevel,
 ): Promise<SaveResult> {
   const docRef = collectionRef(userId).doc(characterId);
   const existing = await docRef.get();

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
+import type { ConstellationLevel } from '@genshin/domain';
 import { characterItemHref, characterRepresentation, serialiseCharacter } from '@genshin/domain';
 import { getCharacterById } from '@genshin/game-data';
 import { Hono } from 'hono';
@@ -31,7 +32,12 @@ characters.use('*', auth);
 
 characters.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: characterItemV1 }]));
 
-type SaveCharacterBody = FromSchema<typeof characterPutRequestV1.schema>;
+// FromSchema widens `integer` with `minimum`/`maximum` to `number`, so the
+// intersection restores the range the validated body is already guaranteed to
+// satisfy.
+type SaveCharacterBody = FromSchema<typeof characterPutRequestV1.schema> & {
+  constellationLevel: ConstellationLevel;
+};
 
 // GET /api/characters — List user's character collection
 characters.get('/', async (c) => {

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -32,9 +32,8 @@ characters.use('*', auth);
 
 characters.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: characterItemV1 }]));
 
-// FromSchema widens `integer` with `minimum`/`maximum` to `number`, so the
-// intersection restores the range the validated body is already guaranteed to
-// satisfy.
+// FromSchema widens the schema's integer bounds to `number`; request validation
+// has already enforced them, so the intersection puts the range back.
 type SaveCharacterBody = FromSchema<typeof characterPutRequestV1.schema> & {
   constellationLevel: ConstellationLevel;
 };

--- a/apps/web/src/features/collection/characters/character-card.tsx
+++ b/apps/web/src/features/collection/characters/character-card.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import type { ConstellationLevel } from '@genshin/domain';
+import { CONSTELLATION_LEVELS, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 import type { Character } from '@genshin/game-data';
 import { Trash2 } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -18,15 +19,10 @@ import {
 } from '@/lib/element-styles';
 import { cn } from '@/lib/utils';
 
-const CONSTELLATION_LEVELS = Array.from(
-  { length: MAX_CONSTELLATION_LEVEL - MIN_CONSTELLATION_LEVEL + 1 },
-  (_, i) => MIN_CONSTELLATION_LEVEL + i,
-);
-
 interface ConstellationPopoverProps {
   character: Character;
-  constellationLevel: number;
-  onConstellationChange: (characterId: Character['id'], level: number) => void;
+  constellationLevel: ConstellationLevel;
+  onConstellationChange: (characterId: Character['id'], level: ConstellationLevel) => void;
 }
 
 function ConstellationPopover({
@@ -108,11 +104,11 @@ function RemoveButton({ character, onRemove }: RemoveButtonProps): JSX.Element {
 interface CharacterCardProps {
   character: Character;
   owned?: boolean;
-  constellationLevel?: number;
+  constellationLevel?: ConstellationLevel;
   selected?: boolean;
   onAdd?: (characterId: Character['id']) => void;
   onRemove?: (characterId: Character['id']) => void;
-  onConstellationChange?: (characterId: Character['id'], level: number) => void;
+  onConstellationChange?: (characterId: Character['id'], level: ConstellationLevel) => void;
 }
 
 export function CharacterCard({

--- a/apps/web/src/features/collection/characters/use-character-collection-api.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-api.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { assertCollectionDocument } from '@genshin/collection-json';
-import type { CharacterId, CollectionCharacter } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter, ConstellationLevel } from '@genshin/domain';
 import { deserialiseCharacter, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -94,7 +94,11 @@ export function useRemoveCharacterMutation(
 
 export function useSetConstellationLevelMutation(
   userId: string | undefined,
-): UseMutationResult<MutationResult, Error, { characterId: CharacterId; level: number }> {
+): UseMutationResult<
+  MutationResult,
+  Error,
+  { characterId: CharacterId; level: ConstellationLevel }
+> {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -103,7 +107,7 @@ export function useSetConstellationLevelMutation(
       level,
     }: {
       characterId: CharacterId;
-      level: number;
+      level: ConstellationLevel;
     }): Promise<MutationResult> => {
       const response = await apiPut(`/api/characters/${encodeURIComponent(characterId)}`, {
         constellationLevel: level,

--- a/apps/web/src/features/collection/characters/use-character-collection-api.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-api.ts
@@ -92,23 +92,21 @@ export function useRemoveCharacterMutation(
   });
 }
 
+export interface SetConstellationLevelVariables {
+  characterId: CharacterId;
+  level: ConstellationLevel;
+}
+
 export function useSetConstellationLevelMutation(
   userId: string | undefined,
-): UseMutationResult<
-  MutationResult,
-  Error,
-  { characterId: CharacterId; level: ConstellationLevel }
-> {
+): UseMutationResult<MutationResult, Error, SetConstellationLevelVariables> {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async ({
       characterId,
       level,
-    }: {
-      characterId: CharacterId;
-      level: ConstellationLevel;
-    }): Promise<MutationResult> => {
+    }: SetConstellationLevelVariables): Promise<MutationResult> => {
       const response = await apiPut(`/api/characters/${encodeURIComponent(characterId)}`, {
         constellationLevel: level,
       });

--- a/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
@@ -1,27 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type {
-  CharacterId,
-  CollectionCharacter,
-  ConstellationLevel,
-  ISOTimestamp,
-} from '@genshin/domain';
+import type { CharacterId, CollectionCharacter } from '@genshin/domain';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { mergeCollections, useCollectionStore } from './use-character-collection-store';
+import { makeCharacter } from '@/test/fixtures';
 
-function makeCharacter(
-  id: string,
-  constellationLevel: ConstellationLevel = 0,
-): CollectionCharacter {
-  return {
-    characterId: id as CharacterId,
-    constellationLevel,
-    createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-    updatedAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-  };
-}
+import { mergeCollections, useCollectionStore } from './use-character-collection-store';
 
 describe('useCollectionStore', () => {
   beforeEach(() => {
@@ -69,16 +54,6 @@ describe('useCollectionStore', () => {
       useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, 3);
 
       expect(useCollectionStore.getState().characters['amber'].constellationLevel).toBe(3);
-    });
-
-    // ConstellationLevel keeps these out of reach for typed callers; the casts
-    // exercise the runtime guard that still backs untyped and persisted input.
-    it('ignores invalid constellation levels', () => {
-      useCollectionStore.getState().addCharacter('amber' as CharacterId);
-      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, -1 as never);
-      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, 7 as never);
-
-      expect(useCollectionStore.getState().characters['amber'].constellationLevel).toBe(0);
     });
 
     it('ignores updates for characters not in the collection', () => {

--- a/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
@@ -1,12 +1,20 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CharacterId, CollectionCharacter, ISOTimestamp } from '@genshin/domain';
+import type {
+  CharacterId,
+  CollectionCharacter,
+  ConstellationLevel,
+  ISOTimestamp,
+} from '@genshin/domain';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { mergeCollections, useCollectionStore } from './use-character-collection-store';
 
-function makeCharacter(id: string, constellationLevel = 0): CollectionCharacter {
+function makeCharacter(
+  id: string,
+  constellationLevel: ConstellationLevel = 0,
+): CollectionCharacter {
   return {
     characterId: id as CharacterId,
     constellationLevel,
@@ -63,10 +71,12 @@ describe('useCollectionStore', () => {
       expect(useCollectionStore.getState().characters['amber'].constellationLevel).toBe(3);
     });
 
+    // ConstellationLevel keeps these out of reach for typed callers; the casts
+    // exercise the runtime guard that still backs untyped and persisted input.
     it('ignores invalid constellation levels', () => {
       useCollectionStore.getState().addCharacter('amber' as CharacterId);
-      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, -1);
-      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, 7);
+      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, -1 as never);
+      useCollectionStore.getState().setConstellationLevel('amber' as CharacterId, 7 as never);
 
       expect(useCollectionStore.getState().characters['amber'].constellationLevel).toBe(0);
     });

--- a/apps/web/src/features/collection/characters/use-character-collection-store.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-store.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { CharacterId, CollectionCharacter, ConstellationLevel } from '@genshin/domain';
-import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL, nowTimestamp } from '@genshin/domain';
+import { MIN_CONSTELLATION_LEVEL, nowTimestamp } from '@genshin/domain';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
@@ -73,8 +73,6 @@ export const useCollectionStore = create<CollectionState>()(
       },
 
       setConstellationLevel: (characterId, level) => {
-        if (!isValidConstellationLevel(level)) return;
-
         const entry = get().characters[characterId];
         if (!entry) return;
 

--- a/apps/web/src/features/collection/characters/use-character-collection-store.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-store.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CharacterId, CollectionCharacter } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter, ConstellationLevel } from '@genshin/domain';
 import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL, nowTimestamp } from '@genshin/domain';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
@@ -35,7 +35,7 @@ interface CollectionState {
   characters: Record<CharacterId, CollectionCharacter>;
   addCharacter: (characterId: CharacterId) => void;
   removeCharacter: (characterId: CharacterId) => void;
-  setConstellationLevel: (characterId: CharacterId, level: number) => void;
+  setConstellationLevel: (characterId: CharacterId, level: ConstellationLevel) => void;
   isOwned: (characterId: CharacterId) => boolean;
   getCharacter: (characterId: CharacterId) => CollectionCharacter | undefined;
   replaceCharacters: (characters: Record<CharacterId, CollectionCharacter>) => void;

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -8,7 +8,10 @@ import { toast } from 'sonner';
 
 import { useAuth } from '@/features/auth/use-auth';
 
-import type { MutationResult } from './use-character-collection-api';
+import type {
+  MutationResult,
+  SetConstellationLevelVariables,
+} from './use-character-collection-api';
 import {
   useAddCharacterMutation,
   useCharacterCollectionQuery,
@@ -16,6 +19,19 @@ import {
   useSetConstellationLevelMutation,
 } from './use-character-collection-api';
 import { mergeCollections, useCollectionStore } from './use-character-collection-store';
+
+// Entries the merge left ahead of the server, in the shape the mutation takes.
+function entriesAheadOfServer(
+  merged: Record<CharacterId, CollectionCharacter>,
+  server: Record<CharacterId, CollectionCharacter>,
+): SetConstellationLevelVariables[] {
+  return Object.entries(merged)
+    .filter(([id, entry]) => {
+      const serverEntry = server[id];
+      return !serverEntry || entry.constellationLevel > serverEntry.constellationLevel;
+    })
+    .map(([id, entry]) => ({ characterId: id, level: entry.constellationLevel }));
+}
 
 export interface UseCollectionResult {
   characters: Record<CharacterId, CollectionCharacter>;
@@ -82,15 +98,7 @@ export function useCollection(): UseCollectionResult {
       const merged = mergeCollections(localData, apiCharacters);
       replaceCharacters(merged);
 
-      // Push entries that differ from the server
-      const diffs: Array<{ characterId: CharacterId; level: ConstellationLevel }> = [];
-      for (const id of Object.keys(merged)) {
-        const entry = merged[id];
-        const serverEntry = apiCharacters[id];
-        if (!serverEntry || entry.constellationLevel > serverEntry.constellationLevel) {
-          diffs.push({ characterId: id, level: entry.constellationLevel });
-        }
-      }
+      const diffs = entriesAheadOfServer(merged, apiCharacters);
 
       for (const diff of diffs) {
         setConstellationLevelApi(diff, {

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -20,7 +20,6 @@ import {
 } from './use-character-collection-api';
 import { mergeCollections, useCollectionStore } from './use-character-collection-store';
 
-// Entries the merge left ahead of the server, in the shape the mutation takes.
 function entriesAheadOfServer(
   merged: Record<CharacterId, CollectionCharacter>,
   server: Record<CharacterId, CollectionCharacter>,

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CharacterId, CollectionCharacter } from '@genshin/domain';
-import { isValidConstellationLevel, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import type { CharacterId, CollectionCharacter, ConstellationLevel } from '@genshin/domain';
+import { MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
@@ -21,7 +21,7 @@ export interface UseCollectionResult {
   characters: Record<CharacterId, CollectionCharacter>;
   addCharacter: (characterId: CharacterId) => void;
   removeCharacter: (characterId: CharacterId) => void;
-  setConstellationLevel: (characterId: CharacterId, level: number) => void;
+  setConstellationLevel: (characterId: CharacterId, level: ConstellationLevel) => void;
   isOwned: (characterId: CharacterId) => boolean;
   getCharacter: (characterId: CharacterId) => CollectionCharacter | undefined;
   isLoading: boolean;
@@ -83,14 +83,11 @@ export function useCollection(): UseCollectionResult {
       replaceCharacters(merged);
 
       // Push entries that differ from the server
-      const diffs: Array<{ characterId: CharacterId; level: number }> = [];
+      const diffs: Array<{ characterId: CharacterId; level: ConstellationLevel }> = [];
       for (const id of Object.keys(merged)) {
         const entry = merged[id];
         const serverEntry = apiCharacters[id];
-        if (
-          isValidConstellationLevel(entry.constellationLevel) &&
-          (!serverEntry || entry.constellationLevel > serverEntry.constellationLevel)
-        ) {
+        if (!serverEntry || entry.constellationLevel > serverEntry.constellationLevel) {
           diffs.push({ characterId: id, level: entry.constellationLevel });
         }
       }
@@ -185,7 +182,7 @@ export function useCollection(): UseCollectionResult {
   );
 
   const setConstellationLevel = useCallback(
-    (id: CharacterId, level: number) => {
+    (id: CharacterId, level: ConstellationLevel) => {
       const previousLevel = useCollectionStore.getState().characters[id]?.constellationLevel;
       if (previousLevel === undefined || previousLevel === level) return;
 

--- a/apps/web/src/features/teams/character-pool.tsx
+++ b/apps/web/src/features/teams/character-pool.tsx
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CharacterId, CollectionCharacter, TeamSlot } from '@genshin/domain';
+import type {
+  CharacterId,
+  CollectionCharacter,
+  ConstellationLevel,
+  TeamSlot,
+} from '@genshin/domain';
+import { MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
 import type { Character, WeaponType } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { Lock, Users } from 'lucide-react';
@@ -120,7 +126,7 @@ export function CharacterPool({
               <PoolCharacterCard
                 key={character.id}
                 character={character}
-                constellationLevel={entry?.constellationLevel ?? 0}
+                constellationLevel={entry?.constellationLevel ?? MIN_CONSTELLATION_LEVEL}
                 assignedToCurrentMember={assignedToCurrentMember}
                 assignedToOtherMember={assignedToOtherMember}
                 disabled={!clickable}
@@ -144,7 +150,7 @@ export function CharacterPool({
 
 interface PoolCharacterCardProps {
   character: Character;
-  constellationLevel: number;
+  constellationLevel: ConstellationLevel;
   assignedToCurrentMember: boolean;
   assignedToOtherMember: boolean;
   disabled: boolean;

--- a/apps/web/src/pages/characters-page.tsx
+++ b/apps/web/src/pages/characters-page.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { ConstellationLevel } from '@genshin/domain';
 import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { Loader2 } from 'lucide-react';
@@ -38,7 +39,7 @@ export function CharactersPage(): JSX.Element {
     };
   }, [filters, ownedIds]);
 
-  function handleConstellationChange(characterId: Character['id'], level: number) {
+  function handleConstellationChange(characterId: Character['id'], level: ConstellationLevel) {
     setConstellationLevel(characterId, level);
   }
 

--- a/apps/web/src/test/fixtures.ts
+++ b/apps/web/src/test/fixtures.ts
@@ -7,6 +7,7 @@ import type {
   CollectionCharacter,
   CollectionTeam,
   CollectionWeapon,
+  ConstellationLevel,
   ISOTimestamp,
   TeamSlot,
   UUID,
@@ -25,7 +26,10 @@ const FIXED_TIMESTAMP = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
 
 // Domain-object builders. IDs must exist in @genshin/game-data because the
 // deserialisers validate them against the static catalogue.
-export function makeCharacter(id: string, constellationLevel = 0): CollectionCharacter {
+export function makeCharacter(
+  id: string,
+  constellationLevel: ConstellationLevel = 0,
+): CollectionCharacter {
   return {
     characterId: id as CharacterId,
     constellationLevel,

--- a/packages/domain/src/character/collection-character.ts
+++ b/packages/domain/src/character/collection-character.ts
@@ -10,16 +10,32 @@ import { isISOTimestamp } from '../iso-timestamp.js';
 export const MIN_CONSTELLATION_LEVEL = 0;
 export const MAX_CONSTELLATION_LEVEL = 6;
 
+/**
+ * Constellation activation level for a character (0–6).
+ *
+ * A character starts at 0 and gains one level per duplicate copy obtained,
+ * capping at 6.
+ */
+export type ConstellationLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/**
+ * All valid constellation level values.
+ */
+export const CONSTELLATION_LEVELS: readonly ConstellationLevel[] = Array.from(
+  { length: MAX_CONSTELLATION_LEVEL - MIN_CONSTELLATION_LEVEL + 1 },
+  (_, i) => (MIN_CONSTELLATION_LEVEL + i) as ConstellationLevel,
+);
+
 export interface CollectionCharacter {
   characterId: Character['id'];
-  constellationLevel: number;
+  constellationLevel: ConstellationLevel;
   createdAt: ISOTimestamp;
   updatedAt: ISOTimestamp;
 }
 
 export type CharacterId = CollectionCharacter['characterId'];
 
-export function isValidConstellationLevel(value: unknown): value is number {
+export function isValidConstellationLevel(value: unknown): value is ConstellationLevel {
   return (
     typeof value === 'number' &&
     Number.isInteger(value) &&

--- a/packages/domain/src/character/collection-character.ts
+++ b/packages/domain/src/character/collection-character.ts
@@ -10,17 +10,9 @@ import { isISOTimestamp } from '../iso-timestamp.js';
 export const MIN_CONSTELLATION_LEVEL = 0;
 export const MAX_CONSTELLATION_LEVEL = 6;
 
-/**
- * Constellation activation level for a character (0–6).
- *
- * A character starts at 0 and gains one level per duplicate copy obtained,
- * capping at 6.
- */
+/** Activation level of a character's constellation, one level per duplicate copy obtained. */
 export type ConstellationLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-/**
- * All valid constellation level values.
- */
 export const CONSTELLATION_LEVELS: readonly ConstellationLevel[] = Array.from(
   { length: MAX_CONSTELLATION_LEVEL - MIN_CONSTELLATION_LEVEL + 1 },
   (_, i) => (MIN_CONSTELLATION_LEVEL + i) as ConstellationLevel,

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -7,11 +7,13 @@ export { validateArtifactPlan } from './artifact/artifact-plan-validation.js';
 export type { AuthIdentity } from './profile/auth-identity.js';
 export {
   assertCollectionCharacter,
+  CONSTELLATION_LEVELS,
   isValidConstellationLevel,
   MAX_CONSTELLATION_LEVEL,
   MIN_CONSTELLATION_LEVEL,
   type CharacterId,
   type CollectionCharacter,
+  type ConstellationLevel,
 } from './character/collection-character.js';
 export {
   assertCollectionTeam,


### PR DESCRIPTION
## Summary

`constellationLevel` was `number` from the domain type out to the React props, so the 0–6 range lived only in a runtime predicate. It is now a `ConstellationLevel` literal union, following the `TeamSlot`/`TEAM_SLOTS` pattern next to it in `packages/domain`. Later commits clean up the seams the union exposed. No behaviour change.

Closes #498

## Gotchas

- **The store's input guard is gone.** `setConstellationLevel` used to return early on an out-of-range level. The union makes that unreachable, and the only test covering it needed `as never` to defeat the type. The domain suite covers the predicate over `unknown`, and `assertCollectionCharacter` still guards where untrusted data arrives. Push back here if you want the defence in depth kept.
- The versioned Zod storage schemas stay `z.number()`. They gate structure only, and narrowing them would fail the monotonic-widening compatibility check.
- Two type-only gains I declined: switching the published `put-request-v1` profile to an `enum` (edits a shipped wire artifact) and rebuilding `CONSTELLATION_LEVELS` from a `const` tuple to drop its cast (widens `MAX_CONSTELLATION_LEVEL` off `6`, and diverges from `TEAM_SLOTS`).