### PR TITLE
feat(api): classify validation errors with problem type URIs

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { ProblemDetail } from '@genshin/domain';
 import { GoogleError, Status } from 'google-gax';
 import { HTTPException } from 'hono/http-exception';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ProblemException } from '@/http/problem.js';
 
 import { app } from './app.js';
 
@@ -26,6 +29,9 @@ beforeAll(() => {
   });
   app.get('/__test/http-exception', () => {
     throw new HTTPException(503, { message: 'service unavailable' });
+  });
+  app.get('/__test/problem-exception', () => {
+    throw new ProblemException(422, { type: '/problems/test', message: 'classified failure' });
   });
 });
 
@@ -51,6 +57,24 @@ describe('CORS', () => {
   it('allows credentials, so the browser sends the ID token', async () => {
     const res = await app.request('/health', { headers: { Origin: origin } });
     expect(res.headers.get('access-control-allow-credentials')).toBe('true');
+  });
+});
+
+describe('onError problem type', () => {
+  it('carries the type of a classified error into the problem document', async () => {
+    const res = await app.request('/__test/problem-exception');
+    const problem = (await res.json()) as ProblemDetail;
+
+    expect(res.status).toBe(422);
+    expect(problem.type).toBe('/problems/test');
+    expect(problem.detail).toBe('classified failure');
+  });
+
+  it('falls back to about:blank for an unclassified error', async () => {
+    const res = await app.request('/__test/http-exception');
+    const problem = (await res.json()) as ProblemDetail;
+
+    expect(problem.type).toBe('about:blank');
   });
 });
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,7 +11,7 @@ import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 
-import { ProblemException } from '@/http/problem.js';
+import { ABOUT_BLANK, problemTypeOf } from '@/http/problem.js';
 import { retryAfterSeconds } from '@/http/retry-after.js';
 import type { AuthVariables } from '@/middleware/auth.js';
 import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
@@ -60,7 +60,7 @@ app.onError((err, c) => {
     if (retryAfter !== undefined) headers['Retry-After'] = String(retryAfter);
     return c.json(
       {
-        type: resolved instanceof ProblemException ? resolved.type : 'about:blank',
+        type: problemTypeOf(resolved),
         title: STATUS_CODES[resolved.status] ?? 'Unknown Error',
         status: resolved.status,
         detail: resolved.message,
@@ -72,7 +72,7 @@ app.onError((err, c) => {
   console.error('Unexpected error:', resolved);
   return c.json(
     {
-      type: 'about:blank',
+      type: ABOUT_BLANK,
       title: 'Internal Server Error',
       status: 500,
       detail: 'An unexpected error occurred',
@@ -85,7 +85,7 @@ app.onError((err, c) => {
 app.notFound((c) =>
   c.json(
     {
-      type: 'about:blank',
+      type: ABOUT_BLANK,
       title: 'Not Found',
       status: 404,
       detail: 'The requested resource does not exist',

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,6 +11,7 @@ import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 
+import { ProblemException } from '@/http/problem.js';
 import { retryAfterSeconds } from '@/http/retry-after.js';
 import type { AuthVariables } from '@/middleware/auth.js';
 import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
@@ -59,7 +60,7 @@ app.onError((err, c) => {
     if (retryAfter !== undefined) headers['Retry-After'] = String(retryAfter);
     return c.json(
       {
-        type: 'about:blank',
+        type: resolved instanceof ProblemException ? resolved.type : 'about:blank',
         title: STATUS_CODES[resolved.status] ?? 'Unknown Error',
         status: resolved.status,
         detail: resolved.message,

--- a/apps/api/src/http/problem.ts
+++ b/apps/api/src/http/problem.ts
@@ -4,29 +4,25 @@
 import { HTTPException } from 'hono/http-exception';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
-/** The RFC 9457 type for a problem carrying no classification beyond its status. */
+/** RFC 9457's type for a problem with no classification beyond its status. */
 export const ABOUT_BLANK = 'about:blank';
 
-/** The classification and human-readable message of a problem. */
 export type ProblemOptions = {
-  /** URI reference identifying the problem type. */
   type: string;
-  /** Human-readable explanation, serialised as the problem document's `detail`. */
+  /** Serialised as the problem document's `detail`. */
   message: string;
 };
 
 /**
  * An HTTP error carrying an RFC 9457 problem type URI.
  *
- * RFC 9457 makes `type` the primary classifier and `detail` supplementary, so
- * a thrower that knows which failure mode it hit reports it here rather than
- * only in the human-readable message. The error handler serialises `type` into
- * the problem document; a plain `HTTPException` classifies as `about:blank`.
+ * RFC 9457 makes `type` the classifier clients branch on and `detail` merely
+ * supplementary, so a thrower that knows its failure mode records it here. The
+ * error handler serialises it; a plain `HTTPException` gets `about:blank`.
  *
  * @see https://www.rfc-editor.org/rfc/rfc9457#name-type
  */
 export class ProblemException extends HTTPException {
-  /** URI reference identifying the problem type. */
   readonly type: string;
 
   constructor(status: ContentfulStatusCode, options: ProblemOptions) {

--- a/apps/api/src/http/problem.ts
+++ b/apps/api/src/http/problem.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { HTTPException } from 'hono/http-exception';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+
+/**
+ * An HTTP error carrying an RFC 9457 problem type URI.
+ *
+ * RFC 9457 makes `type` the primary classifier and `detail` supplementary, so
+ * a thrower that knows which failure mode it hit reports it here rather than
+ * only in the human-readable message. The error handler serialises `type` into
+ * the problem document; a plain `HTTPException` classifies as `about:blank`.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9457#name-type
+ */
+export class ProblemException extends HTTPException {
+  /** URI reference identifying the problem type. */
+  readonly type: string;
+
+  constructor(status: ContentfulStatusCode, options: { type: string; message: string }) {
+    super(status, { message: options.message });
+    this.type = options.type;
+  }
+}

--- a/apps/api/src/http/problem.ts
+++ b/apps/api/src/http/problem.ts
@@ -4,6 +4,17 @@
 import { HTTPException } from 'hono/http-exception';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
+/** The RFC 9457 type for a problem carrying no classification beyond its status. */
+export const ABOUT_BLANK = 'about:blank';
+
+/** The classification and human-readable message of a problem. */
+export type ProblemOptions = {
+  /** URI reference identifying the problem type. */
+  type: string;
+  /** Human-readable explanation, serialised as the problem document's `detail`. */
+  message: string;
+};
+
 /**
  * An HTTP error carrying an RFC 9457 problem type URI.
  *
@@ -18,8 +29,13 @@ export class ProblemException extends HTTPException {
   /** URI reference identifying the problem type. */
   readonly type: string;
 
-  constructor(status: ContentfulStatusCode, options: { type: string; message: string }) {
+  constructor(status: ContentfulStatusCode, options: ProblemOptions) {
     super(status, { message: options.message });
     this.type = options.type;
   }
+}
+
+/** How an error classifies, which is `about:blank` unless it says otherwise. */
+export function problemTypeOf(err: unknown): string {
+  return err instanceof ProblemException ? err.type : ABOUT_BLANK;
 }

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -61,18 +61,18 @@ describe('validateRequestBody middleware', () => {
     return app;
   }
 
-  async function problemType(app: ReturnType<typeof createApp>, body: unknown) {
-    const res = await app.request(putRequest(body));
-    const json = (await res.json()) as { type: string };
-    return json.type;
-  }
-
   function putRequest(body: unknown) {
     return new Request('http://localhost/test', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
+  }
+
+  async function problemType(schema: JsonSchemaProfile, body: unknown) {
+    const res = await createApp([schema], schema.path).request(putRequest(body));
+    const json = (await res.json()) as { type: string };
+    return json.type;
   }
 
   it('sets validatedBody when body conforms to negotiated schema', async () => {
@@ -101,42 +101,39 @@ describe('validateRequestBody middleware', () => {
   });
 
   describe('problem type classification', () => {
-    it('classifies a missing required property', async () => {
-      const app = createApp([schemaV2], schemaV2.path);
+    const categories = [
+      {
+        failure: 'a missing required property',
+        schema: schemaV2,
+        body: { level: 5 },
+        type: '/problems/validation/missing-property',
+      },
+      {
+        failure: 'a property of the wrong type',
+        schema: schemaV2,
+        body: { name: 42, level: 5 },
+        type: '/problems/validation/invalid-type',
+      },
+      {
+        failure: 'a property outside its permitted range',
+        schema: schemaV2,
+        body: { name: 'test', level: 99 },
+        type: '/problems/validation/out-of-range',
+      },
+      {
+        failure: 'an unexpected property',
+        schema: schemaV1,
+        body: { name: 'test', extra: true },
+        type: '/problems/validation/additional-properties',
+      },
+    ];
 
-      await expect(problemType(app, { level: 5 })).resolves.toBe(
-        '/problems/validation/missing-property',
-      );
-    });
-
-    it('classifies a property of the wrong type', async () => {
-      const app = createApp([schemaV2], schemaV2.path);
-
-      await expect(problemType(app, { name: 42, level: 5 })).resolves.toBe(
-        '/problems/validation/invalid-type',
-      );
-    });
-
-    it('classifies a property outside its permitted range', async () => {
-      const app = createApp([schemaV2], schemaV2.path);
-
-      await expect(problemType(app, { name: 'test', level: 99 })).resolves.toBe(
-        '/problems/validation/out-of-range',
-      );
-    });
-
-    it('classifies an unexpected property', async () => {
-      const app = createApp([schemaV1], schemaV1.path);
-
-      await expect(problemType(app, { name: 'test', extra: true })).resolves.toBe(
-        '/problems/validation/additional-properties',
-      );
+    it.each(categories)('classifies $failure', async ({ schema, body, type }) => {
+      await expect(problemType(schema, body)).resolves.toBe(type);
     });
 
     it('widens to the parent type when failures span categories', async () => {
-      const app = createApp([schemaV2], schemaV2.path);
-
-      await expect(problemType(app, { level: 99, extra: true })).resolves.toBe(
+      await expect(problemType(schemaV2, { level: 99, extra: true })).resolves.toBe(
         '/problems/validation',
       );
     });

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -12,43 +12,38 @@ import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profi
 import type { ValidatedRequestBodyVariables } from './validate-request-body.js';
 import { validateRequestBody } from './validate-request-body.js';
 
-const schemaV1: JsonSchemaProfile = {
-  path: '/profiles/json-schema/test/put-request-v1.json',
-  schema: {
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-    additionalProperties: false,
-  },
-};
-
-const schemaV2: JsonSchemaProfile = {
-  path: '/profiles/json-schema/test/put-request-v2.json',
-  schema: {
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    type: 'object',
-    properties: {
-      name: { type: 'string' },
-      level: { type: 'integer', minimum: 1, maximum: 10 },
+function putRequestSchema(
+  version: string,
+  properties: Record<string, unknown>,
+  required: string[],
+): JsonSchemaProfile {
+  return {
+    path: `/profiles/json-schema/test/put-request-${version}.json`,
+    schema: {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties,
+      required,
+      additionalProperties: false,
     },
-    required: ['name', 'level'],
-    additionalProperties: false,
-  },
-};
+  };
+}
 
-// `pattern` is absent from the middleware's keyword mapping, which is the point
-// of this fixture: it reaches the classification fallback.
-const schemaUnmapped: JsonSchemaProfile = {
-  path: '/profiles/json-schema/test/put-request-unmapped-v1.json',
-  schema: {
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    type: 'object',
-    properties: { name: { type: 'string', pattern: '^[a-z]+$' } },
-    required: ['name'],
-    additionalProperties: false,
-  },
-};
+const schemaV1 = putRequestSchema('v1', { name: { type: 'string' } }, ['name']);
+
+const schemaV2 = putRequestSchema(
+  'v2',
+  { name: { type: 'string' }, level: { type: 'integer', minimum: 1, maximum: 10 } },
+  ['name', 'level'],
+);
+
+// `pattern` has no entry in the keyword mapping, so this fixture reaches the
+// classification fallback.
+const schemaUnmapped = putRequestSchema(
+  'unmapped-v1',
+  { name: { type: 'string', pattern: '^[a-z]+$' } },
+  ['name'],
+);
 
 describe('validateRequestBody middleware', () => {
   function createApp(schemas: JsonSchemaProfile[], negotiatedPath: string) {

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -54,7 +54,7 @@ describe('validateRequestBody middleware', () => {
       },
     );
     // Stands in for the application error handler, which is what actually puts
-    // `type` on the wire; here it only has to expose what the middleware threw.
+    // `type` on the wire; this one only exposes what the middleware threw.
     app.onError((err, c) =>
       c.json(
         { type: err instanceof ProblemException ? err.type : 'about:blank' },
@@ -103,8 +103,6 @@ describe('validateRequestBody middleware', () => {
     expect(res.status).toBe(422);
   });
 
-  // RFC 9457 makes `type` the classifier clients branch on, so each failure
-  // mode has to be distinguishable without parsing the human-readable detail.
   describe('problem type classification', () => {
     it('classifies a missing required property', async () => {
       const app = createApp([schemaV2], schemaV2.path);

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -37,6 +37,19 @@ const schemaV2: JsonSchemaProfile = {
   },
 };
 
+// `pattern` is absent from the middleware's keyword mapping, which is the point
+// of this fixture: it reaches the classification fallback.
+const schemaUnmapped: JsonSchemaProfile = {
+  path: '/profiles/json-schema/test/put-request-unmapped-v1.json',
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: { name: { type: 'string', pattern: '^[a-z]+$' } },
+    required: ['name'],
+    additionalProperties: false,
+  },
+};
+
 describe('validateRequestBody middleware', () => {
   function createApp(schemas: JsonSchemaProfile[], negotiatedPath: string) {
     const app = new Hono<{
@@ -134,6 +147,12 @@ describe('validateRequestBody middleware', () => {
 
     it('widens to the parent type when failures span categories', async () => {
       await expect(problemType(schemaV2, { level: 99, extra: true })).resolves.toBe(
+        '/problems/validation',
+      );
+    });
+
+    it('falls back to the parent type for a constraint outside the vocabulary', async () => {
+      await expect(problemType(schemaUnmapped, { name: 'UPPERCASE' })).resolves.toBe(
         '/problems/validation',
       );
     });

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import { describe, expect, it } from 'vitest';
 
+import { ProblemException } from '@/http/problem.js';
 import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
 import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 
@@ -26,7 +28,10 @@ const schemaV2: JsonSchemaProfile = {
   schema: {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     type: 'object',
-    properties: { name: { type: 'string' }, level: { type: 'integer' } },
+    properties: {
+      name: { type: 'string' },
+      level: { type: 'integer', minimum: 1, maximum: 10 },
+    },
     required: ['name', 'level'],
     additionalProperties: false,
   },
@@ -48,7 +53,21 @@ describe('validateRequestBody middleware', () => {
         return c.json({ body: c.get('validatedBody') }, 200);
       },
     );
+    // Stands in for the application error handler, which is what actually puts
+    // `type` on the wire; here it only has to expose what the middleware threw.
+    app.onError((err, c) =>
+      c.json(
+        { type: err instanceof ProblemException ? err.type : 'about:blank' },
+        err instanceof HTTPException ? err.status : 500,
+      ),
+    );
     return app;
+  }
+
+  async function problemType(app: ReturnType<typeof createApp>, body: unknown) {
+    const res = await app.request(putRequest(body));
+    const json = (await res.json()) as { type: string };
+    return json.type;
   }
 
   function putRequest(body: unknown) {
@@ -84,11 +103,48 @@ describe('validateRequestBody middleware', () => {
     expect(res.status).toBe(422);
   });
 
-  it('returns 422 when body has extra properties', async () => {
-    const app = createApp([schemaV1], schemaV1.path);
-    const res = await app.request(putRequest({ name: 'test', extra: true }));
+  // RFC 9457 makes `type` the classifier clients branch on, so each failure
+  // mode has to be distinguishable without parsing the human-readable detail.
+  describe('problem type classification', () => {
+    it('classifies a missing required property', async () => {
+      const app = createApp([schemaV2], schemaV2.path);
 
-    expect(res.status).toBe(422);
+      await expect(problemType(app, { level: 5 })).resolves.toBe(
+        '/problems/validation/missing-property',
+      );
+    });
+
+    it('classifies a property of the wrong type', async () => {
+      const app = createApp([schemaV2], schemaV2.path);
+
+      await expect(problemType(app, { name: 42, level: 5 })).resolves.toBe(
+        '/problems/validation/invalid-type',
+      );
+    });
+
+    it('classifies a property outside its permitted range', async () => {
+      const app = createApp([schemaV2], schemaV2.path);
+
+      await expect(problemType(app, { name: 'test', level: 99 })).resolves.toBe(
+        '/problems/validation/out-of-range',
+      );
+    });
+
+    it('classifies an unexpected property', async () => {
+      const app = createApp([schemaV1], schemaV1.path);
+
+      await expect(problemType(app, { name: 'test', extra: true })).resolves.toBe(
+        '/problems/validation/additional-properties',
+      );
+    });
+
+    it('widens to the parent type when failures span categories', async () => {
+      const app = createApp([schemaV2], schemaV2.path);
+
+      await expect(problemType(app, { level: 99, extra: true })).resolves.toBe(
+        '/problems/validation',
+      );
+    });
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/apps/api/src/middleware/validate-request-body.test.ts
+++ b/apps/api/src/middleware/validate-request-body.test.ts
@@ -5,7 +5,7 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { describe, expect, it } from 'vitest';
 
-import { ProblemException } from '@/http/problem.js';
+import { problemTypeOf } from '@/http/problem.js';
 import type { NegotiatedRequestSchemaVariables } from '@/middleware/negotiate-request-schema.js';
 import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 
@@ -56,10 +56,7 @@ describe('validateRequestBody middleware', () => {
     // Stands in for the application error handler, which is what actually puts
     // `type` on the wire; this one only exposes what the middleware threw.
     app.onError((err, c) =>
-      c.json(
-        { type: err instanceof ProblemException ? err.type : 'about:blank' },
-        err instanceof HTTPException ? err.status : 500,
-      ),
+      c.json({ type: problemTypeOf(err) }, err instanceof HTTPException ? err.status : 500),
     );
     return app;
   }

--- a/apps/api/src/middleware/validate-request-body.ts
+++ b/apps/api/src/middleware/validate-request-body.ts
@@ -6,9 +6,45 @@ import { Ajv2020 } from 'ajv/dist/2020.js';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
+import { ProblemException } from '@/http/problem.js';
 import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 
 const ajv = new Ajv2020({ allErrors: true });
+
+/**
+ * Problem type for a validation failure that resists a narrower label, either
+ * because the keyword has no category or because the body broke several
+ * categories at once and no single one describes the response.
+ */
+const VALIDATION = '/problems/validation';
+
+// The failure mode a client branches on, keyed by the ajv keyword that
+// rejected the body. Keywords absent here fall back to VALIDATION.
+const PROBLEM_TYPE_BY_KEYWORD: Record<string, string> = {
+  additionalProperties: `${VALIDATION}/additional-properties`,
+  exclusiveMaximum: `${VALIDATION}/out-of-range`,
+  exclusiveMinimum: `${VALIDATION}/out-of-range`,
+  maxItems: `${VALIDATION}/out-of-range`,
+  maxLength: `${VALIDATION}/out-of-range`,
+  maxProperties: `${VALIDATION}/out-of-range`,
+  maximum: `${VALIDATION}/out-of-range`,
+  minItems: `${VALIDATION}/out-of-range`,
+  minLength: `${VALIDATION}/out-of-range`,
+  minProperties: `${VALIDATION}/out-of-range`,
+  minimum: `${VALIDATION}/out-of-range`,
+  multipleOf: `${VALIDATION}/out-of-range`,
+  required: `${VALIDATION}/missing-property`,
+  type: `${VALIDATION}/invalid-type`,
+  unevaluatedProperties: `${VALIDATION}/additional-properties`,
+};
+
+// A response carries one type, so a body failing several categories widens to
+// the parent rather than claiming a category that only covers part of it.
+function validationProblemType(errors: ErrorObject[]): string {
+  const types = new Set(errors.map((e) => PROBLEM_TYPE_BY_KEYWORD[e.keyword] ?? VALIDATION));
+  const [only] = types;
+  return types.size === 1 && only ? only : VALIDATION;
+}
 
 export type ValidatedRequestBodyVariables = {
   /** The parsed and validated request body. */
@@ -50,15 +86,17 @@ export function validateRequestBody(schemas: JsonSchemaProfile[]): MiddlewareHan
     }
 
     if (!entry.validate(body)) {
-      const detail = entry.validate.errors
-        ?.map((e: ErrorObject) => {
+      const errors = entry.validate.errors ?? [];
+      const detail = errors
+        .map((e: ErrorObject) => {
           const path = e.instancePath || '/';
           return `${path}: ${e.message}`;
         })
         .join('; ');
 
-      throw new HTTPException(422, {
-        message: detail ?? 'Request body validation failed',
+      throw new ProblemException(422, {
+        type: validationProblemType(errors),
+        message: detail || 'Request body validation failed',
       });
     }
 

--- a/apps/api/src/middleware/validate-request-body.ts
+++ b/apps/api/src/middleware/validate-request-body.ts
@@ -12,12 +12,7 @@ import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profi
 
 const ajv = new Ajv2020({ allErrors: true });
 
-/**
- * Problem type for a validation failure that resists a narrower label, either
- * because the keyword has no category or because the body broke several
- * categories at once and no single one describes the response. Doubles as the
- * prefix its narrower categories extend.
- */
+/** Parent type for a validation failure carrying no narrower classification. */
 const VALIDATION = '/problems/validation';
 const MISSING_PROPERTY = `${VALIDATION}/missing-property`;
 const INVALID_TYPE = `${VALIDATION}/invalid-type`;
@@ -25,7 +20,7 @@ const OUT_OF_RANGE = `${VALIDATION}/out-of-range`;
 const ADDITIONAL_PROPERTIES = `${VALIDATION}/additional-properties`;
 
 // The failure mode a client branches on, keyed by the ajv keyword that
-// rejected the body. Keywords absent here fall back to VALIDATION.
+// rejected the body.
 const PROBLEM_TYPE_BY_KEYWORD: Record<string, string> = {
   additionalProperties: ADDITIONAL_PROPERTIES,
   exclusiveMaximum: OUT_OF_RANGE,
@@ -44,7 +39,6 @@ const PROBLEM_TYPE_BY_KEYWORD: Record<string, string> = {
   unevaluatedProperties: ADDITIONAL_PROPERTIES,
 };
 
-/** The RFC 9457 classification and message describing why a body was rejected. */
 function validationProblem(errors: ErrorObject[]): ProblemOptions {
   const types = new Set(errors.map((e) => PROBLEM_TYPE_BY_KEYWORD[e.keyword] ?? VALIDATION));
   const [only] = types;

--- a/apps/api/src/middleware/validate-request-body.ts
+++ b/apps/api/src/middleware/validate-request-body.ts
@@ -42,14 +42,13 @@ const PROBLEM_TYPE_BY_KEYWORD: Record<string, string> = {
 function validationProblem(errors: ErrorObject[]): ProblemOptions {
   const types = new Set(errors.map((e) => PROBLEM_TYPE_BY_KEYWORD[e.keyword] ?? VALIDATION));
   const [only] = types;
+  // A response carries one type, so a body failing several categories widens to
+  // the parent rather than claiming one that covers only part of it.
+  const type = types.size === 1 && only ? only : VALIDATION;
+
   const detail = errors.map((e) => `${e.instancePath || '/'}: ${e.message}`).join('; ');
 
-  return {
-    // A response carries one type, so a body failing several categories widens
-    // to the parent rather than claiming one that covers only part of it.
-    type: types.size === 1 && only ? only : VALIDATION,
-    message: detail || 'Request body validation failed',
-  };
+  return { type, message: detail || 'Request body validation failed' };
 }
 
 export type ValidatedRequestBodyVariables = {

--- a/apps/api/src/middleware/validate-request-body.ts
+++ b/apps/api/src/middleware/validate-request-body.ts
@@ -6,6 +6,7 @@ import { Ajv2020 } from 'ajv/dist/2020.js';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
+import type { ProblemOptions } from '@/http/problem.js';
 import { ProblemException } from '@/http/problem.js';
 import type { JsonSchemaProfile } from '@/profiles/json-schema/json-schema-profile.js';
 
@@ -14,36 +15,47 @@ const ajv = new Ajv2020({ allErrors: true });
 /**
  * Problem type for a validation failure that resists a narrower label, either
  * because the keyword has no category or because the body broke several
- * categories at once and no single one describes the response.
+ * categories at once and no single one describes the response. Doubles as the
+ * prefix its narrower categories extend.
  */
 const VALIDATION = '/problems/validation';
+const MISSING_PROPERTY = `${VALIDATION}/missing-property`;
+const INVALID_TYPE = `${VALIDATION}/invalid-type`;
+const OUT_OF_RANGE = `${VALIDATION}/out-of-range`;
+const ADDITIONAL_PROPERTIES = `${VALIDATION}/additional-properties`;
 
 // The failure mode a client branches on, keyed by the ajv keyword that
 // rejected the body. Keywords absent here fall back to VALIDATION.
 const PROBLEM_TYPE_BY_KEYWORD: Record<string, string> = {
-  additionalProperties: `${VALIDATION}/additional-properties`,
-  exclusiveMaximum: `${VALIDATION}/out-of-range`,
-  exclusiveMinimum: `${VALIDATION}/out-of-range`,
-  maxItems: `${VALIDATION}/out-of-range`,
-  maxLength: `${VALIDATION}/out-of-range`,
-  maxProperties: `${VALIDATION}/out-of-range`,
-  maximum: `${VALIDATION}/out-of-range`,
-  minItems: `${VALIDATION}/out-of-range`,
-  minLength: `${VALIDATION}/out-of-range`,
-  minProperties: `${VALIDATION}/out-of-range`,
-  minimum: `${VALIDATION}/out-of-range`,
-  multipleOf: `${VALIDATION}/out-of-range`,
-  required: `${VALIDATION}/missing-property`,
-  type: `${VALIDATION}/invalid-type`,
-  unevaluatedProperties: `${VALIDATION}/additional-properties`,
+  additionalProperties: ADDITIONAL_PROPERTIES,
+  exclusiveMaximum: OUT_OF_RANGE,
+  exclusiveMinimum: OUT_OF_RANGE,
+  maxItems: OUT_OF_RANGE,
+  maxLength: OUT_OF_RANGE,
+  maxProperties: OUT_OF_RANGE,
+  maximum: OUT_OF_RANGE,
+  minItems: OUT_OF_RANGE,
+  minLength: OUT_OF_RANGE,
+  minProperties: OUT_OF_RANGE,
+  minimum: OUT_OF_RANGE,
+  multipleOf: OUT_OF_RANGE,
+  required: MISSING_PROPERTY,
+  type: INVALID_TYPE,
+  unevaluatedProperties: ADDITIONAL_PROPERTIES,
 };
 
-// A response carries one type, so a body failing several categories widens to
-// the parent rather than claiming a category that only covers part of it.
-function validationProblemType(errors: ErrorObject[]): string {
+/** The RFC 9457 classification and message describing why a body was rejected. */
+function validationProblem(errors: ErrorObject[]): ProblemOptions {
   const types = new Set(errors.map((e) => PROBLEM_TYPE_BY_KEYWORD[e.keyword] ?? VALIDATION));
   const [only] = types;
-  return types.size === 1 && only ? only : VALIDATION;
+  const detail = errors.map((e) => `${e.instancePath || '/'}: ${e.message}`).join('; ');
+
+  return {
+    // A response carries one type, so a body failing several categories widens
+    // to the parent rather than claiming one that covers only part of it.
+    type: types.size === 1 && only ? only : VALIDATION,
+    message: detail || 'Request body validation failed',
+  };
 }
 
 export type ValidatedRequestBodyVariables = {
@@ -86,18 +98,7 @@ export function validateRequestBody(schemas: JsonSchemaProfile[]): MiddlewareHan
     }
 
     if (!entry.validate(body)) {
-      const errors = entry.validate.errors ?? [];
-      const detail = errors
-        .map((e: ErrorObject) => {
-          const path = e.instancePath || '/';
-          return `${path}: ${e.message}`;
-        })
-        .join('; ');
-
-      throw new ProblemException(422, {
-        type: validationProblemType(errors),
-        message: detail || 'Request body validation failed',
-      });
+      throw new ProblemException(422, validationProblem(entry.validate.errors ?? []));
     }
 
     c.set('validatedBody', body);

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -56,6 +56,20 @@ Negotiation rules:
 
 Return errors as `application/problem+json` with stable fields and consistent extension members where needed. Every response includes a `detail` field, even generic ones such as `500 Internal Server Error` or `404 Not Found`, so clients parse error bodies uniformly without branching on status code.
 
+The `type` field classifies the failure and is the field clients branch on; `detail` carries a human-readable message whose wording isn't part of the contract. Errors with no narrower classification use `about:blank`.
+
+Request body validation classifies against this vocabulary:
+
+| `type`                                       | Meaning                                                       |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| `/problems/validation/missing-property`      | A required property is absent.                                |
+| `/problems/validation/invalid-type`          | A property holds a value of the wrong type.                   |
+| `/problems/validation/out-of-range`          | A numeric, length, or size constraint is violated.            |
+| `/problems/validation/additional-properties` | The body carries a property the schema doesn't define.        |
+| `/problems/validation`                       | The failure spans several of the above, or fits none of them. |
+
+These URIs identify failure modes and don't resolve to a document.
+
 See [RFC9457]: <https://www.rfc-editor.org/rfc/rfc9457>
 
 ### 6. Consistent list behavior

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -56,17 +56,17 @@ Negotiation rules:
 
 Return errors as `application/problem+json` with stable fields and consistent extension members where needed. Every response includes a `detail` field, even generic ones such as `500 Internal Server Error` or `404 Not Found`, so clients parse error bodies uniformly without branching on status code.
 
-The `type` field classifies the failure and is the field clients branch on; `detail` carries a human-readable message whose wording isn't part of the contract. Errors with no narrower classification use `about:blank`.
+Clients branch on `type`, which classifies the failure; `detail` carries a human-readable message whose wording isn't part of the contract. Errors with no narrower classification use `about:blank`.
 
 Request body validation classifies against this vocabulary:
 
-| `type`                                       | Meaning                                                       |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| `/problems/validation/missing-property`      | A required property is absent.                                |
-| `/problems/validation/invalid-type`          | A property holds a value of the wrong type.                   |
-| `/problems/validation/out-of-range`          | A numeric, length, or size constraint is violated.            |
-| `/problems/validation/additional-properties` | The body carries a property the schema doesn't define.        |
-| `/problems/validation`                       | The failure spans several of the above, or fits none of them. |
+| `type`                                       | Meaning                                                 |
+| -------------------------------------------- | ------------------------------------------------------- |
+| `/problems/validation/missing-property`      | A required property is absent.                          |
+| `/problems/validation/invalid-type`          | A property holds a value of the wrong type.             |
+| `/problems/validation/out-of-range`          | A value falls outside a numeric, length, or size bound. |
+| `/problems/validation/additional-properties` | The body carries a property the schema doesn't define.  |
+| `/problems/validation`                       | The failure spans several categories, or fits none.     |
 
 These URIs identify failure modes and don't resolve to a document.
 


### PR DESCRIPTION
## Summary

Request body validation failures now carry an RFC 9457 `type` URI naming the failure mode, so a client can tell a missing required field from an out-of-range value without parsing the ajv prose in `detail`. Previously every failure came back as `about:blank`. The vocabulary is documented in the REST conventions reference.

`ProblemException` subclasses `HTTPException` and carries the URI to the error handler, so every existing thrower keeps emitting `about:blank` unchanged.

Closes #466

## Gotchas

- ajv runs with `allErrors`, but a response carries one `type`. A body breaking several categories at once widens to the parent `/problems/validation` rather than picking one error and mislabelling the rest.
- These URIs are identifiers only; nothing serves them. That departs from the `/profiles/...` precedent, where every URI the API emits dereferences. Serving problem documentation is a bigger change than the issue asks for, so it's left out.
- The malformed-JSON 400 in the same middleware deliberately stays `about:blank`. Nothing was validated, so no validation category applies.
- Only the first commit changes behaviour. The rest are refactors, a comment trim, a coverage test, and a merge; reviewing them separately is cheaper than reading the combined diff.
- One refactor rewrites the two pre-existing `about:blank` literals in the error handler to a shared constant. That is the only place the diff reaches past the issue's scope.
- Two branches in `validationProblem` stay permanently partial in coverage. Both guard against an empty ajv error list, which ajv does not produce after a failed validate, so the only ways to cover them are to contort the code or assert a state that cannot occur.
- The merge from develop resolved two additive conflicts in `app.test.ts`, where #1152 had claimed the same two regions for its catch-all route and Allow header suite. Both sides kept; suites reordered so the two `onError` suites sit together.
- `apps/api/src/http/problem.ts` was already sitting untracked in the worktree from an earlier session; the first commit adopts it as-is.

## Verification

- All CI checks green on the merged tree, including `codecov/patch` after a test was added for the vocabulary's unclassified row.
- Ran `pnpm turbo run typecheck lint test` locally: 218 API tests and 254 web tests pass.
- Mutation-checked the parameterized classification table by pointing `required` at the wrong category; exactly the one case failed, so the table still exercises the keyword mapping rather than asserting itself.