### PR TITLE
chore: aggregate vitest projects in a root config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,8 +92,7 @@
   // ]
 
   // Testing
-  // Anchor the extension to the root config so the sidebar shows its declared
-  // projects instead of every discovered `*vite*.config.*` — the default search
-  // pattern also matches apps/web/vite.config.ts, which has no `test` block.
+  // Without this, the extension's default search pattern also picks up
+  // apps/web/vite.config.ts, which has no `test` block.
   "vitest.rootConfig": "./vitest.config.ts"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,15 +84,16 @@
   ],
 
   // CSS/Tailwind - DISABLED until Issue #20 is implemented
-  "css.validate": true
+  "css.validate": true,
   // Uncomment when Tailwind is installed:
   // "tailwindCSS.experimental.classRegex": [
   //   ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
   //   ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
   // ]
 
-  // Testing - DISABLED until Vitest is installed (Phase 4)
-  // Uncomment these settings when Vitest is added to package.json
-  // "vitest.enable": true,
-  // "vitest.commandLine": "pnpm test"
+  // Testing
+  // Anchor the extension to the root config so the sidebar shows its declared
+  // projects instead of every discovered `*vite*.config.*` — the default search
+  // pattern also matches apps/web/vite.config.ts, which has no `test` block.
+  "vitest.rootConfig": "./vitest.config.ts"
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "genshin-dungeon-studio",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "description": "Team building companion for Genshin Impact",
   "keywords": [
     "genshin-impact",
@@ -47,7 +48,8 @@
     "syncpack": "15.3.2",
     "tsx": "4.23.7",
     "turbo": "2.10.8",
-    "typescript": "npm:@typescript/typescript6@6.0.2"
+    "typescript": "npm:@typescript/typescript6@6.0.2",
+    "vitest": "4.1.10"
   },
   "packageManager": "pnpm@11.20.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       typescript:
         specifier: npm:@typescript/typescript6@6.0.2
         version: '@typescript/typescript6@6.0.2'
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.7)(yaml@2.9.0))
 
   apps/api:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from 'vitest/config';
+
+// Aggregates every workspace package that opts into Vitest by owning a
+// `vitest.config.ts`. Globbing the config file rather than the directory keeps
+// `apps/web/vite.config.ts` (no `test` block) and `tools/e2e` (Playwright) out
+// of the project list without an exclusion to maintain.
+//
+// `pnpm turbo run test` remains the build-ordered entry point; this config
+// serves the editor and a single-process `pnpm vitest` at the root.
+export default defineConfig({
+  test: {
+    projects: [
+      'apps/*/vitest.config.ts',
+      'packages/*/vitest.config.ts',
+      'tools/*/vitest.config.ts',
+    ],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,10 @@ import { defineConfig } from 'vitest/config';
 // `apps/web/vite.config.ts` (no `test` block) and `tools/e2e` (Playwright) out
 // of the project list without an exclusion to maintain.
 //
-// `pnpm turbo run test` remains the build-ordered entry point; this config
-// serves the editor and a single-process `pnpm vitest` at the root.
+// `pnpm turbo run test` remains the build-ordered entry point and the only one
+// that produces reports. `coverage` and `reporters` are root-only options, so
+// each project's copies apply when turbo runs it as its own root and are
+// ignored here; a root `pnpm vitest` prints results and writes no artifacts.
 export default defineConfig({
   test: {
     projects: [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,15 +3,13 @@
 
 import { defineConfig } from 'vitest/config';
 
-// Aggregates every workspace package that opts into Vitest by owning a
-// `vitest.config.ts`. Globbing the config file rather than the directory keeps
-// `apps/web/vite.config.ts` (no `test` block) and `tools/e2e` (Playwright) out
-// of the project list without an exclusion to maintain.
+// Globbing the config filename, not the directory, leaves out
+// `apps/web/vite.config.ts` (no `test` block) and `tools/e2e` (Playwright)
+// with no exclusion list to maintain.
 //
-// `pnpm turbo run test` remains the build-ordered entry point and the only one
-// that produces reports. `coverage` and `reporters` are root-only options, so
-// each project's copies apply when turbo runs it as its own root and are
-// ignored here; a root `pnpm vitest` prints results and writes no artifacts.
+// `coverage` and `reporters` are root-only in Vitest: each project config's
+// copies apply only when turbo runs that package as its own root, so a root
+// `pnpm vitest` writes no junit or coverage artifacts.
 export default defineConfig({
   test: {
     projects: [


### PR DESCRIPTION
## Summary

Adds a root `vitest.config.ts` whose `test.projects` globs `*/vitest.config.ts` across `apps`, `packages`, and `tools`, and points the VS Code Vitest extension at it. Replaces the `// "vitest.enable"` / `// "vitest.commandLine"` block in `.vscode/settings.json`, commented "DISABLED until Vitest is installed (Phase 4)" — Vitest is installed in all seven packages, and neither setting exists in the current extension.

## Gotchas

**#465 asks for `vitest.workspace.ts`, which cannot exist here.** That file and the `test.workspace` option were removed in Vitest 4 (this repo is on 4.1.10); the resolver throws and points at `test.projects`. The issue's project list is stale too — it names `apps/api` and `packages/collection-json`, but seven packages have suites.

**The glob targets config filenames, not directories.** That is what keeps `apps/web/vite.config.ts` (a build config, no `test` block) and `tools/e2e` (Playwright) out of the project list. Packages opt in by owning a `vitest.config.ts`, so nothing needs updating as packages land — the acceptance criterion about keeping the file current.

**The root run produces no reports.** `coverage` and `reporters` are root-only options, so the identical blocks in all seven package configs apply when turbo runs each package as its own root and are ignored when those files load as projects. `pnpm turbo run test` stays the report-producing entry point, and it never reads the root config. The root path also does not get turbo's `^build` ordering.

**Root `"type": "module"`** matches every workspace package; without it Vite loads the config through its CommonJS fallback and warns.

## Verification

I could not check the testing sidebar — no VS Code in this environment. That `vitest.rootConfig` suppresses the stray `vite.config.ts` entry rests on the extension's documented discovery behaviour, not an observed sidebar. It is the one acceptance criterion left unconfirmed.

`apps/web`'s `artifact-planner` test times out at 5s under the full parallel run. It passes in isolation and fails identically under `turbo run test`, which never reads the new config — a load-dependent flake on this host (Node 24 against the pinned 26.7.0), not a regression here.

Closes #465