### PR TITLE
feat(api)!: drop the /api prefix from routes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -71,7 +71,7 @@ body:
         - OS: macOS 15
 
         For API or backend issues:
-        - Endpoint: POST /api/teams
+        - Endpoint: POST /teams
         - Node: 22.x
         - OS: Debian 13
 

--- a/.github/copilot/new-api-route.prompt.md
+++ b/.github/copilot/new-api-route.prompt.md
@@ -28,7 +28,7 @@ Problem Details, update these routes to match.
 1. Create `apps/api/src/${input:resource}/routes.ts` with the route handlers.
 2. Start the file with the SPDX header.
 3. Follow the REST conventions:
-   - Resource-oriented paths: `/api/${input:resource}`.
+   - Resource-oriented paths: `/${input:resource}`.
    - Correct HTTP method semantics.
    - Use `HTTPException` for errors; the global error handler formats the
      response.

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -75,14 +75,14 @@ describe('Allow header', () => {
   }
 
   it.each([
-    ['a read-only collection', '/api/characters', ['GET', 'HEAD', 'OPTIONS']],
-    ['a writable collection', '/api/weapons', ['GET', 'HEAD', 'OPTIONS', 'POST']],
+    ['a read-only collection', '/characters', ['GET', 'HEAD', 'OPTIONS']],
+    ['a writable collection', '/weapons', ['GET', 'HEAD', 'OPTIONS', 'POST']],
     [
       'a parameterized item resource',
-      '/api/weapons/8c1a9c4e-1c2e-4a3f-9d5b-6f7a8b9c0d1e',
+      '/weapons/8c1a9c4e-1c2e-4a3f-9d5b-6f7a8b9c0d1e',
       ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH'],
     ],
-    ['the user profile', '/api/profile', ['GET', 'HEAD', 'OPTIONS', 'PATCH']],
+    ['the user profile', '/profile', ['GET', 'HEAD', 'OPTIONS', 'PATCH']],
   ])('advertises the methods of %s', async (_resource, path, methods) => {
     const res = await app.request(path, { method: 'OPTIONS' });
     expect(allowed(res)).toEqual(methods);
@@ -107,7 +107,7 @@ describe('Allow header', () => {
   });
 
   it('accompanies the CORS preflight response', async () => {
-    const res = await app.request('/api/weapons', {
+    const res = await app.request('/weapons', {
       method: 'OPTIONS',
       headers: {
         Origin: 'http://localhost:5173',

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -99,10 +99,10 @@ app.notFound((c) =>
 app.route('/health', health);
 app.route('/profiles/json-schema', jsonSchemaProfiles);
 app.route('/profiles/alps', alpsProfiles);
-app.route('/api/characters', characters);
-app.route('/api/profile', userProfile);
-app.route('/api/teams', teams);
-app.route('/api/weapons', weapons);
+app.route('/characters', characters);
+app.route('/profile', userProfile);
+app.route('/teams', teams);
+app.route('/weapons', weapons);
 
 // Root must be registered after all other routes so it can discover them
 app.route('/', root(app));

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -52,13 +52,13 @@ describe('Character routes', () => {
 
   describe('authentication', () => {
     it('returns 401 without Authorization header', async () => {
-      const res = await app.request('/api/characters');
+      const res = await app.request('/characters');
 
       expect(res.status).toBe(401);
     });
 
     it('returns 401 with malformed Authorization header', async () => {
-      const res = await app.request('/api/characters', {
+      const res = await app.request('/characters', {
         headers: { Authorization: 'NotBearer token' },
       });
 
@@ -68,7 +68,7 @@ describe('Character routes', () => {
     it('returns 401 when token is expired', async () => {
       vi.mocked(verifyToken).mockRejectedValue({ code: 'auth/id-token-expired' });
 
-      const res = await app.request(authedRequest('GET', '/api/characters'));
+      const res = await app.request(authedRequest('GET', '/characters'));
 
       expect(res.status).toBe(401);
       const body = (await res.json()) as { detail: string };
@@ -76,13 +76,13 @@ describe('Character routes', () => {
     });
   });
 
-  describe('GET /api/characters', () => {
+  describe('GET /characters', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
       vi.mocked(Characters.list).mockResolvedValue([FAKE_CHARACTER]);
-      res = await app.request(authedRequest('GET', '/api/characters'));
+      res = await app.request(authedRequest('GET', '/characters'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -110,7 +110,7 @@ describe('Character routes', () => {
     it('returns empty items when no characters exist', async () => {
       vi.mocked(Characters.list).mockResolvedValue([]);
 
-      const res = await app.request(authedRequest('GET', '/api/characters'));
+      const res = await app.request(authedRequest('GET', '/characters'));
 
       const body = (await res.json()) as CollectionDocument;
       expect(body.collection.items).toEqual([]);
@@ -119,7 +119,7 @@ describe('Character routes', () => {
     it('returns 500 when repository throws', async () => {
       vi.mocked(Characters.list).mockRejectedValue(new Error('Firestore unavailable'));
 
-      const res = await app.request(authedRequest('GET', '/api/characters'));
+      const res = await app.request(authedRequest('GET', '/characters'));
 
       expect(res.status).toBe(500);
       const body = (await res.json()) as { detail: string };
@@ -127,13 +127,13 @@ describe('Character routes', () => {
     });
   });
 
-  describe('GET /api/characters/:characterId', () => {
+  describe('GET /characters/:characterId', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
       vi.mocked(Characters.get).mockResolvedValue(FAKE_CHARACTER);
-      res = await app.request(authedRequest('GET', '/api/characters/albedo'));
+      res = await app.request(authedRequest('GET', '/characters/albedo'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -161,7 +161,7 @@ describe('Character routes', () => {
     it('returns 404 when character not in collection', async () => {
       vi.mocked(Characters.get).mockResolvedValue(null);
 
-      const res = await app.request(authedRequest('GET', '/api/characters/albedo'));
+      const res = await app.request(authedRequest('GET', '/characters/albedo'));
 
       expect(res.status).toBe(404);
       const body = (await res.json()) as { detail: string };
@@ -169,7 +169,7 @@ describe('Character routes', () => {
     });
   });
 
-  describe('PUT /api/characters/:characterId', () => {
+  describe('PUT /characters/:characterId', () => {
     beforeEach(() => {
       vi.mocked(getCharacterById).mockReturnValue({
         id: 'albedo',
@@ -186,7 +186,7 @@ describe('Character routes', () => {
         created: true,
       });
       res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2 }),
+        authedRequest('PUT', '/characters/albedo', { constellationLevel: 2 }),
       );
       body = (await res.json()) as CollectionDocument;
     });
@@ -219,7 +219,7 @@ describe('Character routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2 }),
+        authedRequest('PUT', '/characters/albedo', { constellationLevel: 2 }),
       );
 
       expect(res.status).toBe(200);
@@ -229,7 +229,7 @@ describe('Character routes', () => {
       vi.mocked(getCharacterById).mockReturnValue(undefined);
 
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/not-a-character', { constellationLevel: 0 }),
+        authedRequest('PUT', '/characters/not-a-character', { constellationLevel: 0 }),
       );
 
       expect(res.status).toBe(400);
@@ -239,7 +239,7 @@ describe('Character routes', () => {
 
     it('returns 400 when body is not valid JSON', async () => {
       const res = await app.request(
-        new Request('http://localhost/api/characters/albedo', {
+        new Request('http://localhost/characters/albedo', {
           method: 'PUT',
           headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
           body: 'not-json',
@@ -250,14 +250,14 @@ describe('Character routes', () => {
     });
 
     it('returns 422 when constellationLevel is missing', async () => {
-      const res = await app.request(authedRequest('PUT', '/api/characters/albedo', {}));
+      const res = await app.request(authedRequest('PUT', '/characters/albedo', {}));
 
       expect(res.status).toBe(422);
     });
 
     it('returns 422 when constellationLevel is not a number', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 'high' }),
+        authedRequest('PUT', '/characters/albedo', { constellationLevel: 'high' }),
       );
 
       expect(res.status).toBe(422);
@@ -265,7 +265,7 @@ describe('Character routes', () => {
 
     it('returns 422 when constellationLevel is below minimum', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', {
+        authedRequest('PUT', '/characters/albedo', {
           constellationLevel: MIN_CONSTELLATION_LEVEL - 1,
         }),
       );
@@ -275,7 +275,7 @@ describe('Character routes', () => {
 
     it('returns 422 when constellationLevel is above maximum', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', {
+        authedRequest('PUT', '/characters/albedo', {
           constellationLevel: MAX_CONSTELLATION_LEVEL + 1,
         }),
       );
@@ -285,7 +285,7 @@ describe('Character routes', () => {
 
     it('returns 422 when constellationLevel is not an integer', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2.5 }),
+        authedRequest('PUT', '/characters/albedo', { constellationLevel: 2.5 }),
       );
 
       expect(res.status).toBe(422);
@@ -293,7 +293,7 @@ describe('Character routes', () => {
 
     it('returns 422 when body contains extra properties', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', { constellationLevel: 2, extra: true }),
+        authedRequest('PUT', '/characters/albedo', { constellationLevel: 2, extra: true }),
       );
 
       expect(res.status).toBe(422);
@@ -306,7 +306,7 @@ describe('Character routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', {
+        authedRequest('PUT', '/characters/albedo', {
           constellationLevel: MIN_CONSTELLATION_LEVEL,
         }),
       );
@@ -321,7 +321,7 @@ describe('Character routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/characters/albedo', {
+        authedRequest('PUT', '/characters/albedo', {
           constellationLevel: MAX_CONSTELLATION_LEVEL,
         }),
       );
@@ -330,11 +330,11 @@ describe('Character routes', () => {
     });
   });
 
-  describe('DELETE /api/characters/:characterId', () => {
+  describe('DELETE /characters/:characterId', () => {
     it('returns 204 with no body', async () => {
       vi.mocked(Characters.remove).mockResolvedValue();
 
-      const res = await app.request(authedRequest('DELETE', '/api/characters/albedo'));
+      const res = await app.request(authedRequest('DELETE', '/characters/albedo'));
 
       expect(res.status).toBe(204);
       expect(await res.text()).toBe('');
@@ -343,7 +343,7 @@ describe('Character routes', () => {
     it('returns 204 when character does not exist', async () => {
       vi.mocked(Characters.remove).mockResolvedValue();
 
-      const res = await app.request(authedRequest('DELETE', '/api/characters/nonexistent'));
+      const res = await app.request(authedRequest('DELETE', '/characters/nonexistent'));
 
       expect(res.status).toBe(204);
     });

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -38,7 +38,7 @@ type SaveCharacterBody = FromSchema<typeof characterPutRequestV1.schema> & {
   constellationLevel: ConstellationLevel;
 };
 
-// GET /api/characters — List user's character collection
+// GET /characters — List user's character collection
 characters.get('/', async (c) => {
   const userId = c.get('user').uid;
   const items = await Characters.list(userId);
@@ -48,7 +48,7 @@ characters.get('/', async (c) => {
     JSON.stringify(
       serialiseCollection(
         characterRepresentation,
-        `${baseUrl}/api/characters`,
+        `${baseUrl}/characters`,
         items.map((item) => serialiseCharacter(item, baseUrl)),
       ),
     ),
@@ -58,7 +58,7 @@ characters.get('/', async (c) => {
   );
 });
 
-// GET /api/characters/:characterId — Get specific character record
+// GET /characters/:characterId — Get specific character record
 characters.get('/:characterId', async (c) => {
   const userId = c.get('user').uid;
   const { characterId } = c.req.param();
@@ -83,7 +83,7 @@ characters.get('/:characterId', async (c) => {
   );
 });
 
-// PUT /api/characters/:characterId — Save/update character (idempotent upsert)
+// PUT /characters/:characterId — Save/update character (idempotent upsert)
 characters.put(
   '/:characterId',
   negotiateRequestSchema([characterPutRequestV1]),
@@ -111,7 +111,7 @@ characters.put(
   },
 );
 
-// DELETE /api/characters/:characterId — Remove from collection
+// DELETE /characters/:characterId — Remove from collection
 characters.delete('/:characterId', async (c) => {
   const userId = c.get('user').uid;
   const { characterId } = c.req.param();

--- a/apps/api/src/routes/characters.ts
+++ b/apps/api/src/routes/characters.ts
@@ -3,7 +3,12 @@
 
 import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
 import type { ConstellationLevel } from '@genshin/domain';
-import { characterItemHref, characterRepresentation, serialiseCharacter } from '@genshin/domain';
+import {
+  characterCollectionHref,
+  characterItemHref,
+  characterRepresentation,
+  serialiseCharacter,
+} from '@genshin/domain';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { FromSchema } from 'json-schema-to-ts';
@@ -48,7 +53,7 @@ characters.get('/', async (c) => {
     JSON.stringify(
       serialiseCollection(
         characterRepresentation,
-        `${baseUrl}/characters`,
+        characterCollectionHref(baseUrl),
         items.map((item) => serialiseCharacter(item, baseUrl)),
       ),
     ),

--- a/apps/api/src/routes/root.test.ts
+++ b/apps/api/src/routes/root.test.ts
@@ -31,9 +31,9 @@ describe('GET /', () => {
     const body = (await res.json()) as { links: Record<string, { href: string }> };
     expect(body.links).toEqual(
       expect.objectContaining({
-        characters: { href: '/api/characters' },
-        profile: { href: '/api/profile' },
-        weapons: { href: '/api/weapons' },
+        characters: { href: '/characters' },
+        profile: { href: '/profile' },
+        weapons: { href: '/weapons' },
         health: { href: '/health' },
       }),
     );

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -12,7 +12,7 @@ import { rootGetResponseV1 } from '@/profiles/json-schema/root/get-response-v1.j
 /**
  * Discover top-level resource paths from the app's registered routes.
  * Returns GET-accessible paths that have a discrete handler (e.g.
- * `/api/characters`, `/health`).
+ * `/characters`, `/health`).
  *
  * Excludes the root path itself, wildcard catch-all routes (like
  * `/profiles/json-schema/*` and `/profiles/alps/*`), and sub-resource
@@ -33,7 +33,6 @@ function discoverLinks<E extends Env>(app: HonoApp<E>): Record<string, { href: s
     if (seen.has(path)) continue;
     seen.add(path);
 
-    // Derive a name from the last path segment: /api/characters → characters
     const segments = path.split('/').filter(Boolean);
     const name = segments[segments.length - 1];
     links[name] = { href: path };

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -87,13 +87,13 @@ describe('Team routes', () => {
     vi.restoreAllMocks();
   });
 
-  describe('GET /api/teams', () => {
+  describe('GET /teams', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
       vi.mocked(Teams.list).mockResolvedValue([FAKE_TEAM, FAKE_EMPTY_TEAM]);
-      res = await app.request(authedRequest('GET', '/api/teams'));
+      res = await app.request(authedRequest('GET', '/teams'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -121,7 +121,7 @@ describe('Team routes', () => {
     it('returns empty items when no teams exist', async () => {
       vi.mocked(Teams.list).mockResolvedValue([]);
 
-      const res = await app.request(authedRequest('GET', '/api/teams'));
+      const res = await app.request(authedRequest('GET', '/teams'));
 
       const body = (await res.json()) as CollectionDocument;
       expect(body.collection.items).toEqual([]);
@@ -130,7 +130,7 @@ describe('Team routes', () => {
     it('returns 500 when repository throws', async () => {
       vi.mocked(Teams.list).mockRejectedValue(new Error('Firestore unavailable'));
 
-      const res = await app.request(authedRequest('GET', '/api/teams'));
+      const res = await app.request(authedRequest('GET', '/teams'));
 
       expect(res.status).toBe(500);
       const body = (await res.json()) as { detail: string };
@@ -138,13 +138,13 @@ describe('Team routes', () => {
     });
   });
 
-  describe('GET /api/teams/:slot', () => {
+  describe('GET /teams/:slot', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
       vi.mocked(Teams.get).mockResolvedValue(FAKE_TEAM);
-      res = await app.request(authedRequest('GET', '/api/teams/1'));
+      res = await app.request(authedRequest('GET', '/teams/1'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -172,7 +172,7 @@ describe('Team routes', () => {
     it('returns 404 when team not found', async () => {
       vi.mocked(Teams.get).mockResolvedValue(null);
 
-      const res = await app.request(authedRequest('GET', '/api/teams/1'));
+      const res = await app.request(authedRequest('GET', '/teams/1'));
 
       expect(res.status).toBe(404);
       const body = (await res.json()) as { detail: string };
@@ -180,7 +180,7 @@ describe('Team routes', () => {
     });
 
     it('returns 404 for invalid slot', async () => {
-      const res = await app.request(authedRequest('GET', '/api/teams/5'));
+      const res = await app.request(authedRequest('GET', '/teams/5'));
 
       expect(res.status).toBe(404);
       const body = (await res.json()) as { detail: string };
@@ -188,25 +188,25 @@ describe('Team routes', () => {
     });
 
     it('returns 404 for non-numeric slot', async () => {
-      const res = await app.request(authedRequest('GET', '/api/teams/abc'));
+      const res = await app.request(authedRequest('GET', '/teams/abc'));
 
       expect(res.status).toBe(404);
     });
 
     it('returns 404 for slot with trailing characters', async () => {
-      const res = await app.request(authedRequest('GET', '/api/teams/1abc'));
+      const res = await app.request(authedRequest('GET', '/teams/1abc'));
 
       expect(res.status).toBe(404);
     });
 
     it('returns 404 for non-canonical slot like 01', async () => {
-      const res = await app.request(authedRequest('GET', '/api/teams/01'));
+      const res = await app.request(authedRequest('GET', '/teams/01'));
 
       expect(res.status).toBe(404);
     });
   });
 
-  describe('PUT /api/teams/:slot', () => {
+  describe('PUT /teams/:slot', () => {
     beforeEach(() => {
       mockCharacterOwned();
       mockWeaponOwned();
@@ -222,7 +222,7 @@ describe('Team routes', () => {
         created: true,
       });
       res = await app.request(
-        authedRequest('PUT', '/api/teams/1', {
+        authedRequest('PUT', '/teams/1', {
           name: 'Team 1',
           members: FAKE_TEAM.members,
         }),
@@ -258,7 +258,7 @@ describe('Team routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/teams/1', {
+        authedRequest('PUT', '/teams/1', {
           name: 'Updated Team',
         }),
       );
@@ -267,7 +267,7 @@ describe('Team routes', () => {
     });
 
     it('returns 404 for invalid slot', async () => {
-      const res = await app.request(authedRequest('PUT', '/api/teams/5', { name: 'Team' }));
+      const res = await app.request(authedRequest('PUT', '/teams/5', { name: 'Team' }));
 
       expect(res.status).toBe(404);
       const body = (await res.json()) as { detail: string };
@@ -280,7 +280,7 @@ describe('Team routes', () => {
         created: false,
       });
 
-      const res = await app.request(authedRequest('PUT', '/api/teams/1', { name: 'Renamed' }));
+      const res = await app.request(authedRequest('PUT', '/teams/1', { name: 'Renamed' }));
 
       expect(res.status).toBe(200);
     });
@@ -292,7 +292,7 @@ describe('Team routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/teams/1', { members: [null, null, null, null] }),
+        authedRequest('PUT', '/teams/1', { members: [null, null, null, null] }),
       );
 
       expect(res.status).toBe(200);
@@ -313,7 +313,7 @@ describe('Team routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/teams/1', {
+        authedRequest('PUT', '/teams/1', {
           members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }, null, null, null],
         }),
       );
@@ -331,7 +331,7 @@ describe('Team routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PUT', '/api/teams/1', {
+        authedRequest('PUT', '/teams/1', {
           members: [{ characterId: 'hu-tao' }, null, null, null],
         }),
       );
@@ -341,7 +341,7 @@ describe('Team routes', () => {
 
     it('returns 422 when members array has more than 4', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/teams/1', {
+        authedRequest('PUT', '/teams/1', {
           members: [
             { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
             { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
@@ -357,7 +357,7 @@ describe('Team routes', () => {
 
     it('returns 422 when members array has fewer than 4', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/teams/1', {
+        authedRequest('PUT', '/teams/1', {
           members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }],
         }),
       );
@@ -367,7 +367,7 @@ describe('Team routes', () => {
 
     it('returns 422 when body contains extra properties', async () => {
       const res = await app.request(
-        authedRequest('PUT', '/api/teams/1', { name: 'Team', extra: true }),
+        authedRequest('PUT', '/teams/1', { name: 'Team', extra: true }),
       );
 
       expect(res.status).toBe(422);
@@ -375,7 +375,7 @@ describe('Team routes', () => {
 
     it('returns 400 when body is not valid JSON', async () => {
       const res = await app.request(
-        new Request('http://localhost/api/teams/1', {
+        new Request('http://localhost/teams/1', {
           method: 'PUT',
           headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
           body: 'not-json',
@@ -388,7 +388,7 @@ describe('Team routes', () => {
     describe('ownership validation', () => {
       it('returns 400 for duplicate character IDs', async () => {
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
               { characterId: 'hu-tao', weaponInstanceId: 'uuid-2' },
@@ -407,7 +407,7 @@ describe('Team routes', () => {
         vi.mocked(Characters.get).mockResolvedValue(null);
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
@@ -426,7 +426,7 @@ describe('Team routes', () => {
         vi.mocked(Weapons.get).mockResolvedValue(null);
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
@@ -443,7 +443,7 @@ describe('Team routes', () => {
 
       it('returns 400 when duplicate weapon instance IDs in same team', async () => {
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-1' },
@@ -473,7 +473,7 @@ describe('Team routes', () => {
         ]);
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }, null, null, null],
           }),
         );
@@ -510,7 +510,7 @@ describe('Team routes', () => {
         });
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [{ characterId: 'hu-tao', weaponInstanceId: 'uuid-1' }, null, null, null],
           }),
         );
@@ -520,7 +520,7 @@ describe('Team routes', () => {
 
       it('returns 400 for unknown artifact set', async () => {
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               {
                 characterId: 'hu-tao',
@@ -548,7 +548,7 @@ describe('Team routes', () => {
 
       it('returns 400 when priority and secondary minor affixes overlap', async () => {
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               {
                 characterId: 'hu-tao',
@@ -581,7 +581,7 @@ describe('Team routes', () => {
         });
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               {
                 characterId: 'hu-tao',
@@ -612,7 +612,7 @@ describe('Team routes', () => {
         });
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               {
                 characterId: 'hu-tao',
@@ -640,7 +640,7 @@ describe('Team routes', () => {
         });
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               {
                 characterId: 'hu-tao',
@@ -666,7 +666,7 @@ describe('Team routes', () => {
         });
 
         const res = await app.request(
-          authedRequest('PUT', '/api/teams/1', {
+          authedRequest('PUT', '/teams/1', {
             members: [
               {
                 characterId: 'hu-tao',
@@ -685,11 +685,11 @@ describe('Team routes', () => {
     });
   });
 
-  describe('DELETE /api/teams/:slot', () => {
+  describe('DELETE /teams/:slot', () => {
     it('returns 204 with no body', async () => {
       vi.mocked(Teams.remove).mockResolvedValue();
 
-      const res = await app.request(authedRequest('DELETE', '/api/teams/1'));
+      const res = await app.request(authedRequest('DELETE', '/teams/1'));
 
       expect(res.status).toBe(204);
       expect(await res.text()).toBe('');
@@ -698,13 +698,13 @@ describe('Team routes', () => {
     it('returns 204 when team does not exist', async () => {
       vi.mocked(Teams.remove).mockResolvedValue();
 
-      const res = await app.request(authedRequest('DELETE', '/api/teams/4'));
+      const res = await app.request(authedRequest('DELETE', '/teams/4'));
 
       expect(res.status).toBe(204);
     });
 
     it('returns 404 for invalid slot', async () => {
-      const res = await app.request(authedRequest('DELETE', '/api/teams/5'));
+      const res = await app.request(authedRequest('DELETE', '/teams/5'));
 
       expect(res.status).toBe(404);
       const body = (await res.json()) as { detail: string };

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -54,7 +54,7 @@ function parseSlot(param: string): TeamSlot {
   return slot;
 }
 
-// GET /api/teams — List user's teams
+// GET /teams — List user's teams
 teams.get('/', async (c) => {
   const userId = c.get('user').uid;
   const items = await Teams.list(userId);
@@ -65,7 +65,7 @@ teams.get('/', async (c) => {
   });
 });
 
-// GET /api/teams/:slot — Get specific team
+// GET /teams/:slot — Get specific team
 teams.get('/:slot', async (c) => {
   const userId = c.get('user').uid;
   const slot = parseSlot(c.req.param('slot'));
@@ -83,7 +83,7 @@ teams.get('/:slot', async (c) => {
   });
 });
 
-// PUT /api/teams/:slot — Create or update team composition (idempotent upsert)
+// PUT /teams/:slot — Create or update team composition (idempotent upsert)
 teams.put(
   '/:slot',
   negotiateRequestSchema([teamPutRequestV1]),
@@ -123,7 +123,7 @@ teams.put(
   },
 );
 
-// DELETE /api/teams/:slot — Remove team
+// DELETE /teams/:slot — Remove team
 teams.delete('/:slot', async (c) => {
   const userId = c.get('user').uid;
   const slot = parseSlot(c.req.param('slot'));

--- a/apps/api/src/routes/user-profile.test.ts
+++ b/apps/api/src/routes/user-profile.test.ts
@@ -59,13 +59,13 @@ describe('Profile routes', () => {
 
   describe('authentication', () => {
     it('returns 401 without Authorization header', async () => {
-      const res = await app.request('/api/profile');
+      const res = await app.request('/profile');
 
       expect(res.status).toBe(401);
     });
 
     it('returns 401 with malformed Authorization header', async () => {
-      const res = await app.request('/api/profile', {
+      const res = await app.request('/profile', {
         headers: { Authorization: 'NotBearer token' },
       });
 
@@ -75,7 +75,7 @@ describe('Profile routes', () => {
     it('returns 401 when token is expired', async () => {
       vi.mocked(verifyToken).mockRejectedValue({ code: 'auth/id-token-expired' });
 
-      const res = await app.request(authedRequest('GET', '/api/profile'));
+      const res = await app.request(authedRequest('GET', '/profile'));
 
       expect(res.status).toBe(401);
       const body = (await res.json()) as { detail: string };
@@ -83,11 +83,11 @@ describe('Profile routes', () => {
     });
   });
 
-  describe('GET /api/profile', () => {
+  describe('GET /profile', () => {
     it('returns 200 with a response matching the profile schema', async () => {
       vi.mocked(Profile.get).mockResolvedValue(FAKE_PROFILE);
 
-      const res = await app.request(authedRequest('GET', '/api/profile'));
+      const res = await app.request(authedRequest('GET', '/profile'));
 
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toBe(EXPECTED_CONTENT_TYPE);
@@ -99,7 +99,7 @@ describe('Profile routes', () => {
     it('returns 404 when profile does not exist', async () => {
       vi.mocked(Profile.get).mockResolvedValue(null);
 
-      const res = await app.request(authedRequest('GET', '/api/profile'));
+      const res = await app.request(authedRequest('GET', '/profile'));
 
       expect(res.status).toBe(404);
       const body = (await res.json()) as { detail: string };
@@ -109,7 +109,7 @@ describe('Profile routes', () => {
     it('returns 500 when repository throws', async () => {
       vi.mocked(Profile.get).mockRejectedValue(new Error('Firestore unavailable'));
 
-      const res = await app.request(authedRequest('GET', '/api/profile'));
+      const res = await app.request(authedRequest('GET', '/profile'));
 
       expect(res.status).toBe(500);
       const body = (await res.json()) as { detail: string };
@@ -117,12 +117,12 @@ describe('Profile routes', () => {
     });
   });
 
-  describe('PATCH /api/profile', () => {
+  describe('PATCH /profile', () => {
     it('returns 200 with a response matching the profile schema', async () => {
       const updated = { ...FAKE_PROFILE, name: 'Aether' };
       vi.mocked(Profile.update).mockResolvedValue(updated);
 
-      const res = await app.request(authedRequest('PATCH', '/api/profile', { name: 'Aether' }));
+      const res = await app.request(authedRequest('PATCH', '/profile', { name: 'Aether' }));
 
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toBe(EXPECTED_CONTENT_TYPE);
@@ -132,14 +132,14 @@ describe('Profile routes', () => {
     });
 
     it('rejects empty body', async () => {
-      const res = await app.request(authedRequest('PATCH', '/api/profile', {}));
+      const res = await app.request(authedRequest('PATCH', '/profile', {}));
 
       expect(res.status).toBe(422);
     });
 
     it('rejects auth-managed fields', async () => {
       const res = await app.request(
-        authedRequest('PATCH', '/api/profile', { email: 'hacked@example.com' }),
+        authedRequest('PATCH', '/profile', { email: 'hacked@example.com' }),
       );
 
       expect(res.status).toBe(422);
@@ -147,7 +147,7 @@ describe('Profile routes', () => {
 
     it('rejects system-managed fields', async () => {
       const res = await app.request(
-        authedRequest('PATCH', '/api/profile', { createdAt: '2020-01-01T00:00:00.000Z' }),
+        authedRequest('PATCH', '/profile', { createdAt: '2020-01-01T00:00:00.000Z' }),
       );
 
       expect(res.status).toBe(422);
@@ -155,7 +155,7 @@ describe('Profile routes', () => {
 
     it('rejects unknown fields', async () => {
       const res = await app.request(
-        authedRequest('PATCH', '/api/profile', { name: 'Aether', role: 'admin' }),
+        authedRequest('PATCH', '/profile', { name: 'Aether', role: 'admin' }),
       );
 
       expect(res.status).toBe(422);
@@ -163,7 +163,7 @@ describe('Profile routes', () => {
 
     it('rejects request without JSON body', async () => {
       const res = await app.request(
-        new Request('http://localhost/api/profile', {
+        new Request('http://localhost/profile', {
           method: 'PATCH',
           headers: { Authorization: 'Bearer valid-token' },
         }),

--- a/apps/api/src/routes/user-profile.ts
+++ b/apps/api/src/routes/user-profile.ts
@@ -42,7 +42,7 @@ userProfile.use(
 // @genshin/domain handles building the composite response from an AuthIdentity
 // and a UserProfile.
 
-// GET /api/profile — Return the authenticated user's composite profile
+// GET /profile — Return the authenticated user's composite profile
 userProfile.get('/', async (c) => {
   const decoded = c.get('user');
   const profile = await Profile.get(decoded.uid);
@@ -56,7 +56,7 @@ userProfile.get('/', async (c) => {
   });
 });
 
-// PATCH /api/profile — Partial update of mutable profile fields
+// PATCH /profile — Partial update of mutable profile fields
 userProfile.patch(
   '/',
   negotiateRequestSchema([profilePatchRequestV1]),

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -60,13 +60,13 @@ describe('Weapon routes', () => {
     vi.restoreAllMocks();
   });
 
-  describe('GET /api/weapons', () => {
+  describe('GET /weapons', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
       vi.mocked(Weapons.list).mockResolvedValue([FAKE_WEAPON]);
-      res = await app.request(authedRequest('GET', '/api/weapons'));
+      res = await app.request(authedRequest('GET', '/weapons'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -92,13 +92,13 @@ describe('Weapon routes', () => {
     });
 
     it('sets collection.href without query string', () => {
-      expect(body.collection.href).toBe('http://localhost/api/weapons');
+      expect(body.collection.href).toBe('http://localhost/weapons');
     });
 
     it('returns empty items when no weapons exist', async () => {
       vi.mocked(Weapons.list).mockResolvedValue([]);
 
-      const res = await app.request(authedRequest('GET', '/api/weapons'));
+      const res = await app.request(authedRequest('GET', '/weapons'));
 
       const body = (await res.json()) as CollectionDocument;
       expect(body.collection.items).toEqual([]);
@@ -107,7 +107,7 @@ describe('Weapon routes', () => {
     it('returns 500 when repository throws', async () => {
       vi.mocked(Weapons.list).mockRejectedValue(new Error('Firestore unavailable'));
 
-      const res = await app.request(authedRequest('GET', '/api/weapons'));
+      const res = await app.request(authedRequest('GET', '/weapons'));
 
       expect(res.status).toBe(500);
       const body = (await res.json()) as { detail: string };
@@ -115,7 +115,7 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('GET /api/weapons?weaponId=', () => {
+  describe('GET /weapons?weaponId=', () => {
     let res: Response;
     let body: CollectionDocument;
 
@@ -125,7 +125,7 @@ describe('Weapon routes', () => {
         name: 'Mistsplitter Reforged',
       } as ReturnType<typeof getWeaponById>);
       vi.mocked(Weapons.list).mockResolvedValue([FAKE_WEAPON]);
-      res = await app.request(authedRequest('GET', '/api/weapons?weaponId=mistsplitter-reforged'));
+      res = await app.request(authedRequest('GET', '/weapons?weaponId=mistsplitter-reforged'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -151,16 +151,14 @@ describe('Weapon routes', () => {
     });
 
     it('sets collection.href with query string', () => {
-      expect(body.collection.href).toBe(
-        'http://localhost/api/weapons?weaponId=mistsplitter-reforged',
-      );
+      expect(body.collection.href).toBe('http://localhost/weapons?weaponId=mistsplitter-reforged');
     });
 
     it('returns empty items when no instances exist', async () => {
       vi.mocked(Weapons.list).mockResolvedValue([]);
 
       const res = await app.request(
-        authedRequest('GET', '/api/weapons?weaponId=mistsplitter-reforged'),
+        authedRequest('GET', '/weapons?weaponId=mistsplitter-reforged'),
       );
 
       const body = (await res.json()) as CollectionDocument;
@@ -170,7 +168,7 @@ describe('Weapon routes', () => {
     it('returns 400 for unknown weapon ID', async () => {
       vi.mocked(getWeaponById).mockReturnValue(undefined);
 
-      const res = await app.request(authedRequest('GET', '/api/weapons?weaponId=not-a-weapon'));
+      const res = await app.request(authedRequest('GET', '/weapons?weaponId=not-a-weapon'));
 
       expect(res.status).toBe(400);
       const body = (await res.json()) as { detail: string };
@@ -178,7 +176,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns 400 for empty weaponId', async () => {
-      const res = await app.request(authedRequest('GET', '/api/weapons?weaponId='));
+      const res = await app.request(authedRequest('GET', '/weapons?weaponId='));
 
       expect(res.status).toBe(400);
       const body = (await res.json()) as { detail: string };
@@ -186,7 +184,7 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('POST /api/weapons', () => {
+  describe('POST /weapons', () => {
     let res: Response;
     let body: CollectionDocument;
 
@@ -197,7 +195,7 @@ describe('Weapon routes', () => {
       } as ReturnType<typeof getWeaponById>);
       vi.mocked(Weapons.create).mockResolvedValue(FAKE_WEAPON);
       res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: 1,
         }),
@@ -214,7 +212,7 @@ describe('Weapon routes', () => {
     });
 
     it('returns Location header pointing to created instance', () => {
-      expect(res.headers.get('location')).toBe('http://localhost/api/weapons/instance-uuid-1');
+      expect(res.headers.get('location')).toBe('http://localhost/weapons/instance-uuid-1');
     });
 
     it('returns single-item collection', () => {
@@ -229,7 +227,7 @@ describe('Weapon routes', () => {
       vi.mocked(getWeaponById).mockReturnValue(undefined);
 
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'not-a-weapon',
           refinementLevel: 1,
         }),
@@ -242,7 +240,7 @@ describe('Weapon routes', () => {
 
     it('returns 400 when body is not valid JSON', async () => {
       const res = await app.request(
-        new Request('http://localhost/api/weapons', {
+        new Request('http://localhost/weapons', {
           method: 'POST',
           headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
           body: 'not-json',
@@ -254,7 +252,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when weaponId is missing', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           refinementLevel: 1,
         }),
       );
@@ -264,7 +262,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is missing', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
         }),
       );
@@ -274,7 +272,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is not a number', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: 'R5',
         }),
@@ -285,7 +283,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is below minimum', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: MIN_REFINEMENT_LEVEL - 1,
         }),
@@ -296,7 +294,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is above maximum', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: MAX_REFINEMENT_LEVEL + 1,
         }),
@@ -307,7 +305,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is not an integer', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: 2.5,
         }),
@@ -318,7 +316,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when body contains extra properties', async () => {
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: 1,
           extra: true,
@@ -335,7 +333,7 @@ describe('Weapon routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: MIN_REFINEMENT_LEVEL,
         }),
@@ -351,7 +349,7 @@ describe('Weapon routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('POST', '/api/weapons', {
+        authedRequest('POST', '/weapons', {
           weaponId: 'mistsplitter-reforged',
           refinementLevel: MAX_REFINEMENT_LEVEL,
         }),
@@ -361,13 +359,13 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('GET /api/weapons/:weaponInstanceId', () => {
+  describe('GET /weapons/:weaponInstanceId', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
       vi.mocked(Weapons.get).mockResolvedValue(FAKE_WEAPON);
-      res = await app.request(authedRequest('GET', '/api/weapons/instance-uuid-1'));
+      res = await app.request(authedRequest('GET', '/weapons/instance-uuid-1'));
       body = (await res.json()) as CollectionDocument;
     });
 
@@ -390,7 +388,7 @@ describe('Weapon routes', () => {
     it('returns 404 when weapon instance not found', async () => {
       vi.mocked(Weapons.get).mockResolvedValue(null);
 
-      const res = await app.request(authedRequest('GET', '/api/weapons/nonexistent'));
+      const res = await app.request(authedRequest('GET', '/weapons/nonexistent'));
 
       expect(res.status).toBe(404);
       const body = (await res.json()) as { detail: string };
@@ -398,14 +396,14 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('PATCH /api/weapons/:weaponInstanceId', () => {
+  describe('PATCH /weapons/:weaponInstanceId', () => {
     let res: Response;
     let body: CollectionDocument;
 
     beforeEach(async () => {
       vi.mocked(Weapons.update).mockResolvedValue(FAKE_WEAPON);
       res = await app.request(
-        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
+        authedRequest('PATCH', '/weapons/instance-uuid-1', {
           refinementLevel: 1,
         }),
       );
@@ -432,7 +430,7 @@ describe('Weapon routes', () => {
       vi.mocked(Weapons.update).mockResolvedValue(null);
 
       const res = await app.request(
-        authedRequest('PATCH', '/api/weapons/nonexistent', {
+        authedRequest('PATCH', '/weapons/nonexistent', {
           refinementLevel: 1,
         }),
       );
@@ -444,7 +442,7 @@ describe('Weapon routes', () => {
 
     it('returns 400 when body is not valid JSON', async () => {
       const res = await app.request(
-        new Request('http://localhost/api/weapons/instance-uuid-1', {
+        new Request('http://localhost/weapons/instance-uuid-1', {
           method: 'PATCH',
           headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
           body: 'not-json',
@@ -456,7 +454,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when refinementLevel is invalid', async () => {
       const res = await app.request(
-        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
+        authedRequest('PATCH', '/weapons/instance-uuid-1', {
           refinementLevel: 0,
         }),
       );
@@ -466,7 +464,7 @@ describe('Weapon routes', () => {
 
     it('returns 422 when body contains extra properties', async () => {
       const res = await app.request(
-        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
+        authedRequest('PATCH', '/weapons/instance-uuid-1', {
           refinementLevel: 1,
           extra: true,
         }),
@@ -482,7 +480,7 @@ describe('Weapon routes', () => {
       });
 
       const res = await app.request(
-        authedRequest('PATCH', '/api/weapons/instance-uuid-1', {
+        authedRequest('PATCH', '/weapons/instance-uuid-1', {
           refinementLevel: 3,
         }),
       );
@@ -491,11 +489,11 @@ describe('Weapon routes', () => {
     });
   });
 
-  describe('DELETE /api/weapons/:weaponInstanceId', () => {
+  describe('DELETE /weapons/:weaponInstanceId', () => {
     it('returns 204 with no body', async () => {
       vi.mocked(Weapons.remove).mockResolvedValue();
 
-      const res = await app.request(authedRequest('DELETE', '/api/weapons/instance-uuid-1'));
+      const res = await app.request(authedRequest('DELETE', '/weapons/instance-uuid-1'));
 
       expect(res.status).toBe(204);
       expect(await res.text()).toBe('');

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -3,7 +3,12 @@
 
 import { COLLECTION_JSON, serialiseCollection } from '@genshin/collection-json';
 import type { UUID } from '@genshin/domain';
-import { serialiseWeapon, weaponItemHref, weaponRepresentation } from '@genshin/domain';
+import {
+  serialiseWeapon,
+  weaponCollectionHref,
+  weaponItemHref,
+  weaponRepresentation,
+} from '@genshin/domain';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { FromSchema } from 'json-schema-to-ts';
@@ -53,7 +58,7 @@ weapons.get('/', async (c) => {
       JSON.stringify(
         serialiseCollection(
           weaponRepresentation,
-          `${baseUrl}/weapons?weaponId=${encodeURIComponent(weaponId)}`,
+          weaponCollectionHref(baseUrl, weaponId),
           instances.map((w) => serialiseWeapon(w, baseUrl)),
         ),
       ),
@@ -69,7 +74,7 @@ weapons.get('/', async (c) => {
     JSON.stringify(
       serialiseCollection(
         weaponRepresentation,
-        `${baseUrl}/weapons`,
+        weaponCollectionHref(baseUrl),
         items.map((w) => serialiseWeapon(w, baseUrl)),
       ),
     ),
@@ -93,7 +98,7 @@ weapons.post(
 
     return c.body(
       JSON.stringify(
-        serialiseCollection(weaponRepresentation, `${baseUrl}/weapons`, [
+        serialiseCollection(weaponRepresentation, weaponCollectionHref(baseUrl), [
           serialiseWeapon(weapon, baseUrl),
         ]),
       ),

--- a/apps/api/src/routes/weapons.ts
+++ b/apps/api/src/routes/weapons.ts
@@ -36,7 +36,7 @@ weapons.use('*', negotiateContent([{ mediaType: COLLECTION_JSON, profile: weapon
 type CreateWeaponBody = FromSchema<typeof weaponPostRequestV1.schema>;
 type UpdateWeaponBody = FromSchema<typeof weaponPatchRequestV1.schema>;
 
-// GET /api/weapons — List all weapon instances, optionally filtered by weaponId
+// GET /weapons — List all weapon instances, optionally filtered by weaponId
 weapons.get('/', async (c) => {
   const userId = c.get('user').uid;
   const weaponId = c.req.query('weaponId');
@@ -53,7 +53,7 @@ weapons.get('/', async (c) => {
       JSON.stringify(
         serialiseCollection(
           weaponRepresentation,
-          `${baseUrl}/api/weapons?weaponId=${encodeURIComponent(weaponId)}`,
+          `${baseUrl}/weapons?weaponId=${encodeURIComponent(weaponId)}`,
           instances.map((w) => serialiseWeapon(w, baseUrl)),
         ),
       ),
@@ -69,7 +69,7 @@ weapons.get('/', async (c) => {
     JSON.stringify(
       serialiseCollection(
         weaponRepresentation,
-        `${baseUrl}/api/weapons`,
+        `${baseUrl}/weapons`,
         items.map((w) => serialiseWeapon(w, baseUrl)),
       ),
     ),
@@ -79,7 +79,7 @@ weapons.get('/', async (c) => {
   );
 });
 
-// POST /api/weapons — Create new weapon instance
+// POST /weapons — Create new weapon instance
 weapons.post(
   '/',
   negotiateRequestSchema([weaponPostRequestV1]),
@@ -93,7 +93,7 @@ weapons.post(
 
     return c.body(
       JSON.stringify(
-        serialiseCollection(weaponRepresentation, `${baseUrl}/api/weapons`, [
+        serialiseCollection(weaponRepresentation, `${baseUrl}/weapons`, [
           serialiseWeapon(weapon, baseUrl),
         ]),
       ),
@@ -108,7 +108,7 @@ weapons.post(
   },
 );
 
-// GET /api/weapons/:weaponInstanceId — Get single weapon instance
+// GET /weapons/:weaponInstanceId — Get single weapon instance
 weapons.get('/:weaponInstanceId', async (c) => {
   const userId = c.get('user').uid;
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;
@@ -133,7 +133,7 @@ weapons.get('/:weaponInstanceId', async (c) => {
   );
 });
 
-// PATCH /api/weapons/:weaponInstanceId — Update weapon instance
+// PATCH /weapons/:weaponInstanceId — Update weapon instance
 weapons.patch(
   '/:weaponInstanceId',
   negotiateRequestSchema([weaponPatchRequestV1]),
@@ -165,7 +165,7 @@ weapons.patch(
   },
 );
 
-// DELETE /api/weapons/:weaponInstanceId — Delete weapon instance
+// DELETE /weapons/:weaponInstanceId — Delete weapon instance
 weapons.delete('/:weaponInstanceId', async (c) => {
   const userId = c.get('user').uid;
   const weaponInstanceId = c.req.param('weaponInstanceId') as UUID;

--- a/apps/web/src/features/collection/characters/use-character-collection-api.test.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-api.test.ts
@@ -23,7 +23,7 @@ const CHARACTER = 'skirk' as CharacterId;
 describe('useCharacterCollectionQuery', () => {
   it('returns the deserialised characters keyed by id', async () => {
     server.use(
-      http.get('http://localhost:8080/api/characters', () =>
+      http.get('http://localhost:8080/characters', () =>
         HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 2)])),
       ),
     );
@@ -43,7 +43,7 @@ describe('useAddCharacterMutation', () => {
   it('PUTs the minimum constellation level and returns the parsed entry', async () => {
     let putBody: unknown;
     server.use(
-      http.put('http://localhost:8080/api/characters/skirk', async ({ request }) => {
+      http.put('http://localhost:8080/characters/skirk', async ({ request }) => {
         putBody = await request.json();
         return HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 0)]));
       }),
@@ -68,11 +68,11 @@ describe('useAddCharacterMutation', () => {
   it('invalidates the collection query so it refetches after adding', async () => {
     let getCount = 0;
     server.use(
-      http.get('http://localhost:8080/api/characters', () => {
+      http.get('http://localhost:8080/characters', () => {
         getCount += 1;
         return HttpResponse.json(charactersDocument([]));
       }),
-      http.put('http://localhost:8080/api/characters/skirk', () =>
+      http.put('http://localhost:8080/characters/skirk', () =>
         HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 0)])),
       ),
     );
@@ -100,7 +100,7 @@ describe('useSetConstellationLevelMutation', () => {
   it('PUTs the requested level and returns the parsed entry', async () => {
     let putBody: unknown;
     server.use(
-      http.put('http://localhost:8080/api/characters/skirk', async ({ request }) => {
+      http.put('http://localhost:8080/characters/skirk', async ({ request }) => {
         putBody = await request.json();
         return HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 4)]));
       }),

--- a/apps/web/src/features/collection/characters/use-character-collection-api.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-api.ts
@@ -52,7 +52,7 @@ export function useCharacterCollectionQuery(
   return useQuery({
     queryKey: collectionKey(userId ?? ''),
     queryFn: async () => {
-      const response = await apiGet('/api/characters');
+      const response = await apiGet('/characters');
       return parseCollectionResponse(response);
     },
     enabled: userId !== undefined,
@@ -66,7 +66,7 @@ export function useAddCharacterMutation(
 
   return useMutation({
     mutationFn: async (characterId: CharacterId): Promise<MutationResult> => {
-      const response = await apiPut(`/api/characters/${encodeURIComponent(characterId)}`, {
+      const response = await apiPut(`/characters/${encodeURIComponent(characterId)}`, {
         constellationLevel: MIN_CONSTELLATION_LEVEL,
       });
       return parseSingleCharacterResponse(response);
@@ -84,7 +84,7 @@ export function useRemoveCharacterMutation(
 
   return useMutation({
     mutationFn: async (characterId: CharacterId) => {
-      await apiDelete(`/api/characters/${encodeURIComponent(characterId)}`);
+      await apiDelete(`/characters/${encodeURIComponent(characterId)}`);
     },
     onSuccess: () => {
       if (userId !== undefined) queryClient.invalidateQueries({ queryKey: collectionKey(userId) });
@@ -107,7 +107,7 @@ export function useSetConstellationLevelMutation(
       characterId,
       level,
     }: SetConstellationLevelVariables): Promise<MutationResult> => {
-      const response = await apiPut(`/api/characters/${encodeURIComponent(characterId)}`, {
+      const response = await apiPut(`/characters/${encodeURIComponent(characterId)}`, {
         constellationLevel: level,
       });
       return parseSingleCharacterResponse(response);

--- a/apps/web/src/features/collection/characters/use-character-collection.test.tsx
+++ b/apps/web/src/features/collection/characters/use-character-collection.test.tsx
@@ -36,10 +36,8 @@ describe('useCollection merge-on-first-login', () => {
 
     const putBodies: unknown[] = [];
     server.use(
-      http.get('http://localhost:8080/api/characters', () =>
-        HttpResponse.json(charactersDocument([])),
-      ),
-      http.put('http://localhost:8080/api/characters/skirk', async ({ request }) => {
+      http.get('http://localhost:8080/characters', () => HttpResponse.json(charactersDocument([]))),
+      http.put('http://localhost:8080/characters/skirk', async ({ request }) => {
         putBodies.push(await request.json());
         return HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)]));
       }),
@@ -61,11 +59,11 @@ describe('useCollection merge-on-first-login', () => {
     let getCount = 0;
     let putCount = 0;
     server.use(
-      http.get('http://localhost:8080/api/characters', () => {
+      http.get('http://localhost:8080/characters', () => {
         getCount += 1;
         return HttpResponse.json(charactersDocument([]));
       }),
-      http.put('http://localhost:8080/api/characters/skirk', () => {
+      http.put('http://localhost:8080/characters/skirk', () => {
         putCount += 1;
         return HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)]));
       }),
@@ -89,8 +87,8 @@ describe('useCollection merge-on-first-login', () => {
 
     let serverCharacters = charactersDocument([]);
     server.use(
-      http.get('http://localhost:8080/api/characters', () => HttpResponse.json(serverCharacters)),
-      http.put('http://localhost:8080/api/characters/skirk', () =>
+      http.get('http://localhost:8080/characters', () => HttpResponse.json(serverCharacters)),
+      http.put('http://localhost:8080/characters/skirk', () =>
         HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)])),
       ),
     );
@@ -132,11 +130,11 @@ describe('useCollection merge-on-first-login', () => {
 describe('useCollection mutations', () => {
   it('restores a removed character when the delete fails', async () => {
     server.use(
-      http.get('http://localhost:8080/api/characters', () =>
+      http.get('http://localhost:8080/characters', () =>
         HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)])),
       ),
       http.delete(
-        'http://localhost:8080/api/characters/skirk',
+        'http://localhost:8080/characters/skirk',
         () => new HttpResponse(null, { status: 500 }),
       ),
     );

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-api.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-api.test.ts
@@ -24,7 +24,7 @@ const INSTANCE_ID = 'weapon-instance-1' as CollectionWeaponId;
 describe('useWeaponCollectionQuery', () => {
   it('returns the deserialised weapons keyed by instance id', async () => {
     server.use(
-      http.get('http://localhost:8080/api/weapons', () =>
+      http.get('http://localhost:8080/weapons', () =>
         HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 3)])),
       ),
     );
@@ -44,7 +44,7 @@ describe('useAddWeaponMutation', () => {
   it('POSTs the weapon id at the minimum refinement level', async () => {
     let postBody: unknown;
     server.use(
-      http.post('http://localhost:8080/api/weapons', async ({ request }) => {
+      http.post('http://localhost:8080/weapons', async ({ request }) => {
         postBody = await request.json();
         return HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]));
       }),
@@ -66,11 +66,11 @@ describe('useAddWeaponMutation', () => {
   it('invalidates the collection query so it refetches after adding', async () => {
     let getCount = 0;
     server.use(
-      http.get('http://localhost:8080/api/weapons', () => {
+      http.get('http://localhost:8080/weapons', () => {
         getCount += 1;
         return HttpResponse.json(weaponsDocument([]));
       }),
-      http.post('http://localhost:8080/api/weapons', () =>
+      http.post('http://localhost:8080/weapons', () =>
         HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
       ),
     );
@@ -95,7 +95,7 @@ describe('useSetRefinementLevelMutation', () => {
   it('PATCHes the requested refinement level and returns the parsed weapon', async () => {
     let patchBody: unknown;
     server.use(
-      http.patch('http://localhost:8080/api/weapons/weapon-instance-1', async ({ request }) => {
+      http.patch('http://localhost:8080/weapons/weapon-instance-1', async ({ request }) => {
         patchBody = await request.json();
         return HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 5)]));
       }),

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-api.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-api.ts
@@ -48,7 +48,7 @@ export function useWeaponCollectionQuery(
   return useQuery({
     queryKey: weaponCollectionKey(userId ?? ''),
     queryFn: async () => {
-      const response = await apiGet('/api/weapons');
+      const response = await apiGet('/weapons');
       return parseWeaponCollectionResponse(response);
     },
     enabled: userId !== undefined,
@@ -62,7 +62,7 @@ export function useAddWeaponMutation(
 
   return useMutation({
     mutationFn: async (weaponId: string): Promise<WeaponMutationResult> => {
-      const response = await apiPost('/api/weapons', {
+      const response = await apiPost('/weapons', {
         weaponId,
         refinementLevel: MIN_REFINEMENT_LEVEL,
       });
@@ -82,7 +82,7 @@ export function useRemoveWeaponMutation(
 
   return useMutation({
     mutationFn: async (collectionWeaponId: CollectionWeaponId) => {
-      await apiDelete(`/api/weapons/${encodeURIComponent(collectionWeaponId)}`);
+      await apiDelete(`/weapons/${encodeURIComponent(collectionWeaponId)}`);
     },
     onSuccess: () => {
       if (userId !== undefined)
@@ -108,7 +108,7 @@ export function useSetRefinementLevelMutation(
       collectionWeaponId: CollectionWeaponId;
       level: number;
     }): Promise<WeaponMutationResult> => {
-      const response = await apiPatch(`/api/weapons/${encodeURIComponent(collectionWeaponId)}`, {
+      const response = await apiPatch(`/weapons/${encodeURIComponent(collectionWeaponId)}`, {
         refinementLevel: level,
       });
       return parseSingleWeaponResponse(response);

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
@@ -37,8 +37,8 @@ describe('useWeaponCollection', () => {
     it('adds the server-confirmed weapon to the store', async () => {
       let serverWeapons = weaponsDocument([]);
       server.use(
-        http.get('http://localhost:8080/api/weapons', () => HttpResponse.json(serverWeapons)),
-        http.post('http://localhost:8080/api/weapons', () => {
+        http.get('http://localhost:8080/weapons', () => HttpResponse.json(serverWeapons)),
+        http.post('http://localhost:8080/weapons', () => {
           serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
           return HttpResponse.json(serverWeapons);
         }),
@@ -56,10 +56,10 @@ describe('useWeaponCollection', () => {
 
     it('creates another instance even when the weapon is already owned', async () => {
       server.use(
-        http.get('http://localhost:8080/api/weapons', () =>
+        http.get('http://localhost:8080/weapons', () =>
           HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
         ),
-        http.post('http://localhost:8080/api/weapons', () =>
+        http.post('http://localhost:8080/weapons', () =>
           HttpResponse.json(weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, 1)])),
         ),
       );
@@ -81,8 +81,8 @@ describe('useWeaponCollection', () => {
       let posts = 0;
       let serverWeapons = weaponsDocument([]);
       server.use(
-        http.get('http://localhost:8080/api/weapons', () => HttpResponse.json(serverWeapons)),
-        http.post('http://localhost:8080/api/weapons', () => {
+        http.get('http://localhost:8080/weapons', () => HttpResponse.json(serverWeapons)),
+        http.post('http://localhost:8080/weapons', () => {
           posts += 1;
           serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
           return HttpResponse.json(serverWeapons);
@@ -105,10 +105,10 @@ describe('useWeaponCollection', () => {
     it('does not add another instance when the weapon is already owned', async () => {
       let posts = 0;
       server.use(
-        http.get('http://localhost:8080/api/weapons', () =>
+        http.get('http://localhost:8080/weapons', () =>
           HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
         ),
-        http.post('http://localhost:8080/api/weapons', () => {
+        http.post('http://localhost:8080/weapons', () => {
           posts += 1;
           return HttpResponse.json(weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, 1)]));
         }),
@@ -128,11 +128,11 @@ describe('useWeaponCollection', () => {
   describe('removeWeapon', () => {
     it('restores a removed weapon when the delete fails', async () => {
       server.use(
-        http.get('http://localhost:8080/api/weapons', () =>
+        http.get('http://localhost:8080/weapons', () =>
           HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
         ),
         http.delete(
-          'http://localhost:8080/api/weapons/weapon-instance-1',
+          'http://localhost:8080/weapons/weapon-instance-1',
           () => new HttpResponse(null, { status: 500 }),
         ),
       );
@@ -154,11 +154,11 @@ describe('useWeaponCollection', () => {
   describe('setRefinementLevel', () => {
     it('reverts a refinement change when the update fails', async () => {
       server.use(
-        http.get('http://localhost:8080/api/weapons', () =>
+        http.get('http://localhost:8080/weapons', () =>
           HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
         ),
         http.patch(
-          'http://localhost:8080/api/weapons/weapon-instance-1',
+          'http://localhost:8080/weapons/weapon-instance-1',
           () => new HttpResponse(null, { status: 500 }),
         ),
       );

--- a/apps/web/src/features/teams/use-team-api.test.ts
+++ b/apps/web/src/features/teams/use-team-api.test.ts
@@ -18,7 +18,7 @@ const EMPTY_MEMBERS: CollectionTeamMembers = [null, null, null, null];
 describe('useTeamsQuery', () => {
   it('returns the deserialised teams from the collection document', async () => {
     server.use(
-      http.get('http://localhost:8080/api/teams', () =>
+      http.get('http://localhost:8080/teams', () =>
         HttpResponse.json(teamsDocument([makeTeam(1, { name: 'Alpha' })])),
       ),
     );
@@ -41,7 +41,7 @@ describe('useSaveTeamMutation', () => {
   it('sends a PUT to the slot path with the team payload', async () => {
     let putBody: unknown;
     server.use(
-      http.put('http://localhost:8080/api/teams/2', async ({ request }) => {
+      http.put('http://localhost:8080/teams/2', async ({ request }) => {
         putBody = await request.json();
         return new HttpResponse(null, { status: 204 });
       }),
@@ -65,11 +65,11 @@ describe('useSaveTeamMutation', () => {
   it('invalidates the teams query so it refetches after a save', async () => {
     let getCount = 0;
     server.use(
-      http.get('http://localhost:8080/api/teams', () => {
+      http.get('http://localhost:8080/teams', () => {
         getCount += 1;
         return HttpResponse.json(teamsDocument([makeTeam(1)]));
       }),
-      http.put('http://localhost:8080/api/teams/1', () => new HttpResponse(null, { status: 204 })),
+      http.put('http://localhost:8080/teams/1', () => new HttpResponse(null, { status: 204 })),
     );
 
     const { result } = renderHook(

--- a/apps/web/src/features/teams/use-team-api.ts
+++ b/apps/web/src/features/teams/use-team-api.ts
@@ -29,7 +29,7 @@ export function useTeamsQuery(userId: string | undefined): UseQueryResult<Collec
   return useQuery({
     queryKey: teamKey(userId ?? ''),
     queryFn: async () => {
-      const response = await apiGet('/api/teams');
+      const response = await apiGet('/teams');
       return parseTeamsResponse(response);
     },
     enabled: userId !== undefined,
@@ -43,7 +43,7 @@ export function useSaveTeamMutation(
 
   return useMutation({
     mutationFn: async ({ slot, name, members, description }: SaveTeamPayload) => {
-      await apiPut(`/api/teams/${encodeURIComponent(slot)}`, { name, members, description });
+      await apiPut(`/teams/${encodeURIComponent(slot)}`, { name, members, description });
     },
     onSuccess: () => {
       if (userId !== undefined) queryClient.invalidateQueries({ queryKey: teamKey(userId) });
@@ -58,7 +58,7 @@ export function useDeleteTeamMutation(
 
   return useMutation({
     mutationFn: async (slot: TeamSlot) => {
-      await apiDelete(`/api/teams/${encodeURIComponent(slot)}`);
+      await apiDelete(`/teams/${encodeURIComponent(slot)}`);
     },
     onSuccess: () => {
       if (userId !== undefined) queryClient.invalidateQueries({ queryKey: teamKey(userId) });

--- a/apps/web/src/features/teams/use-teams.test.ts
+++ b/apps/web/src/features/teams/use-teams.test.ts
@@ -27,8 +27,8 @@ beforeEach(() => {
 describe('useTeams (authenticated)', () => {
   it('rolls back an optimistic assignment when the save fails', async () => {
     server.use(
-      http.get('http://localhost:8080/api/teams', () => HttpResponse.json(teamsDocument([]))),
-      http.put('http://localhost:8080/api/teams/1', () => new HttpResponse(null, { status: 500 })),
+      http.get('http://localhost:8080/teams', () => HttpResponse.json(teamsDocument([]))),
+      http.put('http://localhost:8080/teams/1', () => new HttpResponse(null, { status: 500 })),
     );
 
     const { result } = renderHook(() => useTeams(), {
@@ -51,13 +51,10 @@ describe('useTeams (authenticated)', () => {
 
   it('restores a cleared team when the delete fails', async () => {
     server.use(
-      http.get('http://localhost:8080/api/teams', () =>
+      http.get('http://localhost:8080/teams', () =>
         HttpResponse.json(teamsDocument([makeTeam(1, { members: MEMBERS })])),
       ),
-      http.delete(
-        'http://localhost:8080/api/teams/1',
-        () => new HttpResponse(null, { status: 500 }),
-      ),
+      http.delete('http://localhost:8080/teams/1', () => new HttpResponse(null, { status: 500 })),
     );
 
     const { result } = renderHook(() => useTeams(), {
@@ -82,8 +79,8 @@ describe('useTeams (authenticated)', () => {
       releasePut = resolve;
     });
     server.use(
-      http.get('http://localhost:8080/api/teams', () => HttpResponse.json(teamsDocument([]))),
-      http.put('http://localhost:8080/api/teams/1', async () => {
+      http.get('http://localhost:8080/teams', () => HttpResponse.json(teamsDocument([]))),
+      http.put('http://localhost:8080/teams/1', async () => {
         await putGate;
         return new HttpResponse(null, { status: 204 });
       }),

--- a/apps/web/src/test/fixtures.ts
+++ b/apps/web/src/test/fixtures.ts
@@ -64,21 +64,21 @@ export function makeTeam(slot: TeamSlot, overrides: Partial<CollectionTeam> = {}
 // Collection+JSON envelope builders producing the wire format the hooks parse.
 export function charactersDocument(characters: CollectionCharacter[]): CollectionDocument {
   return buildCollection(
-    `${API_BASE_URL}/api/characters`,
+    `${API_BASE_URL}/characters`,
     characters.map((character) => serialiseCharacter(character, API_BASE_URL)),
   );
 }
 
 export function weaponsDocument(weapons: CollectionWeapon[]): CollectionDocument {
   return buildCollection(
-    `${API_BASE_URL}/api/weapons`,
+    `${API_BASE_URL}/weapons`,
     weapons.map((weapon) => serialiseWeapon(weapon, API_BASE_URL)),
   );
 }
 
 export function teamsDocument(teams: CollectionTeam[]): CollectionDocument {
   return buildCollection(
-    `${API_BASE_URL}/api/teams`,
+    `${API_BASE_URL}/teams`,
     teams.map((team) => serialiseTeam(team, API_BASE_URL)),
   );
 }

--- a/apps/web/src/test/fixtures.ts
+++ b/apps/web/src/test/fixtures.ts
@@ -13,10 +13,13 @@ import type {
   UUID,
 } from '@genshin/domain';
 import {
+  characterCollectionHref,
   createEmptyTeam,
   serialiseCharacter,
   serialiseTeam,
   serialiseWeapon,
+  teamCollectionHref,
+  weaponCollectionHref,
 } from '@genshin/domain';
 import type { WeaponId } from '@genshin/game-data';
 
@@ -64,21 +67,21 @@ export function makeTeam(slot: TeamSlot, overrides: Partial<CollectionTeam> = {}
 // Collection+JSON envelope builders producing the wire format the hooks parse.
 export function charactersDocument(characters: CollectionCharacter[]): CollectionDocument {
   return buildCollection(
-    `${API_BASE_URL}/characters`,
+    characterCollectionHref(API_BASE_URL),
     characters.map((character) => serialiseCharacter(character, API_BASE_URL)),
   );
 }
 
 export function weaponsDocument(weapons: CollectionWeapon[]): CollectionDocument {
   return buildCollection(
-    `${API_BASE_URL}/weapons`,
+    weaponCollectionHref(API_BASE_URL),
     weapons.map((weapon) => serialiseWeapon(weapon, API_BASE_URL)),
   );
 }
 
 export function teamsDocument(teams: CollectionTeam[]): CollectionDocument {
   return buildCollection(
-    `${API_BASE_URL}/teams`,
+    teamCollectionHref(API_BASE_URL),
     teams.map((team) => serialiseTeam(team, API_BASE_URL)),
   );
 }

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -38,7 +38,7 @@ See [JSONSchema2020-12]: <https://json-schema.org/draft/2020-12>
 Clients select a representation version with the `profile` parameter on `Accept`, naming the schema URI they expect. The API echoes the schema it used in the response `Content-Type`:
 
 ```http
-GET /api/profile HTTP/1.1
+GET /profile HTTP/1.1
 Accept: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/profile/get-response-v1.json"
 
 HTTP/1.1 200 OK
@@ -118,10 +118,10 @@ The API root (`GET /`) is a hypermedia entry point (HATEOAS) advertising availab
 ```json
 {
   "links": {
-    "characters": { "href": "/api/characters" },
-    "profile": { "href": "/api/profile" },
-    "teams": { "href": "/api/teams" },
-    "weapons": { "href": "/api/weapons" },
+    "characters": { "href": "/characters" },
+    "profile": { "href": "/profile" },
+    "teams": { "href": "/teams" },
+    "weapons": { "href": "/weapons" },
     "health": { "href": "/health" }
   }
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -42,6 +42,7 @@ export {
 export { isISOTimestamp, nowTimestamp, type ISOTimestamp } from './iso-timestamp.js';
 export type { ProblemDetail } from './problem-detail.js';
 export {
+  characterCollectionHref,
   characterItemHref,
   characterRepresentation,
   deserialiseCharacter,
@@ -50,6 +51,7 @@ export {
 export {
   deserialiseTeam,
   serialiseTeam,
+  teamCollectionHref,
   teamItemDocument,
   teamItemHref,
   teamListDocument,
@@ -58,6 +60,7 @@ export {
 export {
   deserialiseWeapon,
   serialiseWeapon,
+  weaponCollectionHref,
   weaponItemHref,
   weaponRepresentation,
 } from './representations/collection-json/weapons.js';

--- a/packages/domain/src/profile/user-profile.ts
+++ b/packages/domain/src/profile/user-profile.ts
@@ -16,7 +16,7 @@ export interface UserProfile {
   updatedAt: ISOTimestamp;
 }
 
-/** The shape accepted by PATCH /api/profile. */
+/** The shape accepted by PATCH /profile. */
 export type ProfileUpdate = Partial<Pick<UserProfile, 'name'>>;
 
 export function assertUserProfile(value: unknown): asserts value is UserProfile {

--- a/packages/domain/src/representations/collection-json/characters.test.ts
+++ b/packages/domain/src/representations/collection-json/characters.test.ts
@@ -26,7 +26,7 @@ describe('character serialisation round-trip', () => {
 
   it('serialises with the correct href', () => {
     const item = serialiseCharacter(VALID_CHARACTER, BASE_URL);
-    expect(item.href).toBe(`${BASE_URL}/api/characters/columbina`);
+    expect(item.href).toBe(`${BASE_URL}/characters/columbina`);
   });
 
   it('preserves constellation level through round-trip', () => {

--- a/packages/domain/src/representations/collection-json/characters.ts
+++ b/packages/domain/src/representations/collection-json/characters.ts
@@ -31,8 +31,12 @@ const CHARACTER_TEMPLATE: Template = {
   ],
 };
 
+export function characterCollectionHref(baseUrl: string): string {
+  return `${baseUrl}/characters`;
+}
+
 export function characterItemHref(baseUrl: string, character: CollectionCharacter): string {
-  return `${baseUrl}/characters/${character.characterId}`;
+  return `${characterCollectionHref(baseUrl)}/${character.characterId}`;
 }
 
 export function serialiseCharacter(character: CollectionCharacter, baseUrl: string): Item {

--- a/packages/domain/src/representations/collection-json/characters.ts
+++ b/packages/domain/src/representations/collection-json/characters.ts
@@ -32,7 +32,7 @@ const CHARACTER_TEMPLATE: Template = {
 };
 
 export function characterItemHref(baseUrl: string, character: CollectionCharacter): string {
-  return `${baseUrl}/api/characters/${character.characterId}`;
+  return `${baseUrl}/characters/${character.characterId}`;
 }
 
 export function serialiseCharacter(character: CollectionCharacter, baseUrl: string): Item {

--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -40,7 +40,7 @@ describe('team serialisation round-trip', () => {
 
   it('serialises with the correct href', () => {
     const item = serialiseTeam(VALID_TEAM, BASE_URL);
-    expect(item.href).toBe(`${BASE_URL}/api/teams/1`);
+    expect(item.href).toBe(`${BASE_URL}/teams/1`);
   });
 
   it('preserves all-null members through round-trip', () => {
@@ -105,7 +105,7 @@ describe('deserialiseTeam artifact plan validation', () => {
   function itemWithArtifactPlan(artifactPlan: unknown): Item {
     const members = [{ characterId: 'columbina', artifactPlan }, null, null, null];
     return {
-      href: `${BASE_URL}/api/teams/1`,
+      href: `${BASE_URL}/teams/1`,
       data: [
         { name: 'slot', value: 1 },
         { name: 'name', value: 'Team 1' },

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -38,7 +38,7 @@ const TEAM_TEMPLATE: Template = {
 };
 
 export function teamItemHref(baseUrl: string, team: CollectionTeam): string {
-  return `${baseUrl}/api/teams/${team.slot}`;
+  return `${baseUrl}/teams/${team.slot}`;
 }
 
 export function serialiseTeam(team: CollectionTeam, baseUrl: string): Item {
@@ -54,14 +54,14 @@ export function serialiseTeam(team: CollectionTeam, baseUrl: string): Item {
 
 export function teamListDocument(teams: CollectionTeam[], baseUrl: string): CollectionDocument {
   return buildCollection(
-    `${baseUrl}/api/teams`,
+    `${baseUrl}/teams`,
     teams.map((t) => serialiseTeam(t, baseUrl)),
     { template: TEAM_TEMPLATE },
   );
 }
 
 export function teamItemDocument(team: CollectionTeam, baseUrl: string): CollectionDocument {
-  return buildCollection(`${baseUrl}/api/teams/${team.slot}`, [serialiseTeam(team, baseUrl)], {
+  return buildCollection(`${baseUrl}/teams/${team.slot}`, [serialiseTeam(team, baseUrl)], {
     template: TEAM_TEMPLATE,
   });
 }

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -37,8 +37,12 @@ const TEAM_TEMPLATE: Template = {
   ],
 };
 
+export function teamCollectionHref(baseUrl: string): string {
+  return `${baseUrl}/teams`;
+}
+
 export function teamItemHref(baseUrl: string, team: CollectionTeam): string {
-  return `${baseUrl}/teams/${team.slot}`;
+  return `${teamCollectionHref(baseUrl)}/${team.slot}`;
 }
 
 export function serialiseTeam(team: CollectionTeam, baseUrl: string): Item {
@@ -54,14 +58,14 @@ export function serialiseTeam(team: CollectionTeam, baseUrl: string): Item {
 
 export function teamListDocument(teams: CollectionTeam[], baseUrl: string): CollectionDocument {
   return buildCollection(
-    `${baseUrl}/teams`,
+    teamCollectionHref(baseUrl),
     teams.map((t) => serialiseTeam(t, baseUrl)),
     { template: TEAM_TEMPLATE },
   );
 }
 
 export function teamItemDocument(team: CollectionTeam, baseUrl: string): CollectionDocument {
-  return buildCollection(`${baseUrl}/teams/${team.slot}`, [serialiseTeam(team, baseUrl)], {
+  return buildCollection(teamItemHref(baseUrl, team), [serialiseTeam(team, baseUrl)], {
     template: TEAM_TEMPLATE,
   });
 }

--- a/packages/domain/src/representations/collection-json/weapons.test.ts
+++ b/packages/domain/src/representations/collection-json/weapons.test.ts
@@ -28,7 +28,7 @@ describe('weapon serialisation round-trip', () => {
 
   it('serialises with the correct href', () => {
     const item = serialiseWeapon(VALID_WEAPON, BASE_URL);
-    expect(item.href).toBe(`${BASE_URL}/api/weapons/wep-001`);
+    expect(item.href).toBe(`${BASE_URL}/weapons/wep-001`);
   });
 
   it('includes a collection link for the weapon type', () => {

--- a/packages/domain/src/representations/collection-json/weapons.ts
+++ b/packages/domain/src/representations/collection-json/weapons.ts
@@ -32,15 +32,28 @@ const WEAPON_TEMPLATE: Template = {
   ],
 };
 
+/**
+ * The weapon collection, optionally narrowed to one weapon's instances.
+ *
+ * A player owns any number of instances of the same weapon, so the filtered
+ * form is a first-class collection: it is what an item's `collection` link
+ * points back to, and what the API serves for a `weaponId` query.
+ */
+export function weaponCollectionHref(baseUrl: string, weaponId?: string): string {
+  const collection = `${baseUrl}/weapons`;
+  if (weaponId === undefined) return collection;
+  return `${collection}?weaponId=${encodeURIComponent(weaponId)}`;
+}
+
 export function weaponItemHref(baseUrl: string, weapon: CollectionWeapon): string {
-  return `${baseUrl}/weapons/${weapon.weaponInstanceId}`;
+  return `${weaponCollectionHref(baseUrl)}/${weapon.weaponInstanceId}`;
 }
 
 export function serialiseWeapon(weapon: CollectionWeapon, baseUrl: string): Item {
   const links: Link[] = [
     {
       rel: 'collection',
-      href: `${baseUrl}/weapons?weaponId=${encodeURIComponent(weapon.weaponId)}`,
+      href: weaponCollectionHref(baseUrl, weapon.weaponId),
       prompt: `All instances of ${weapon.weaponId}`,
     },
   ];

--- a/packages/domain/src/representations/collection-json/weapons.ts
+++ b/packages/domain/src/representations/collection-json/weapons.ts
@@ -33,14 +33,14 @@ const WEAPON_TEMPLATE: Template = {
 };
 
 export function weaponItemHref(baseUrl: string, weapon: CollectionWeapon): string {
-  return `${baseUrl}/api/weapons/${weapon.weaponInstanceId}`;
+  return `${baseUrl}/weapons/${weapon.weaponInstanceId}`;
 }
 
 export function serialiseWeapon(weapon: CollectionWeapon, baseUrl: string): Item {
   const links: Link[] = [
     {
       rel: 'collection',
-      href: `${baseUrl}/api/weapons?weaponId=${encodeURIComponent(weapon.weaponId)}`,
+      href: `${baseUrl}/weapons?weaponId=${encodeURIComponent(weapon.weaponId)}`,
       prompt: `All instances of ${weapon.weaponId}`,
     },
   ];

--- a/packages/domain/src/representations/collection-json/weapons.ts
+++ b/packages/domain/src/representations/collection-json/weapons.ts
@@ -32,13 +32,6 @@ const WEAPON_TEMPLATE: Template = {
   ],
 };
 
-/**
- * The weapon collection, optionally narrowed to one weapon's instances.
- *
- * A player owns any number of instances of the same weapon, so the filtered
- * form is a first-class collection: it is what an item's `collection` link
- * points back to, and what the API serves for a `weaponId` query.
- */
 export function weaponCollectionHref(baseUrl: string, weaponId?: string): string {
   const collection = `${baseUrl}/weapons`;
   if (weaponId === undefined) return collection;

--- a/packages/domain/src/representations/json/profile.ts
+++ b/packages/domain/src/representations/json/profile.ts
@@ -18,7 +18,7 @@ export type { AuthIdentity } from '../../profile/auth-identity.js';
 /**
  * Wire format for the composite profile response.
  *
- * Matches the shape returned by GET /api/profile and the JSON Schema
+ * Matches the shape returned by GET /profile and the JSON Schema
  * in schemas/profile/get-response-v1.
  */
 export interface ProfileResponse {

--- a/tools/e2e/specs/fixtures.ts
+++ b/tools/e2e/specs/fixtures.ts
@@ -48,9 +48,9 @@ export function constellationLabel(character: Character, level: number): string 
  * separates the two: the HTTP method alongside it does.
  */
 export const apiPath = {
-  character: (character: Character) => `/api/characters/${encodeURIComponent(character.id)}`,
-  weapons: '/api/weapons',
-  team: (slot: number) => `/api/teams/${slot}`,
+  character: (character: Character) => `/characters/${encodeURIComponent(character.id)}`,
+  weapons: '/weapons',
+  team: (slot: number) => `/teams/${slot}`,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Resources mount bare on the API subdomain, so `api.develop.genshin.dungeon.studio/api/characters` stops repeating what the hostname already carries. A follow-up commit leaves each path with a single definition: item hrefs already had extracted builders, collection hrefs never did, so one URL sat at up to four sites.

Closes #460

## Gotchas

- Breaking, and it spans both apps — the web client hard-codes every path it calls, so it moved in the same commit or every request 404s.
- Extracting `weaponCollectionHref` closed a latent divergence: `${baseUrl}/weapons?weaponId=…` was built independently in `packages/domain` and in the weapons route, with nothing holding an item's `collection` link and that query's own response together.
- Web hooks still inline their paths. `use-character-collection-api.ts` and `use-weapon-collection-api.ts` belong to drafts #1055 and #1059; same extraction once they land.
- `apps/web/vite.config.ts` still proxies `/api`. It was dead before this change too — `apiGet` resolves against an absolute `VITE_API_BASE_URL` — so it wants a decision, not a fix.

## Verification

- The e2e `withApiWrite` helper matches API paths as URL substrings, which this shortens. Safe: it also filters on method, and the web app imports only Firebase Auth, so no Firestore document path can collide.
