### PR TITLE
fix(api): serve problem documents as application/problem+json

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -121,9 +121,8 @@ describe('Allow header', () => {
   });
 });
 
-// RFC 9457 makes the media type how a client tells a problem document apart
-// from a successful representation, so `apps/web`'s api client branches on it.
-// Serving plain `application/json` would leave errors indistinguishable.
+// RFC 9457 makes the media type how a client tells a problem document from a
+// successful one; `apps/web`'s api client branches on exactly this string.
 describe('problem document media type', () => {
   it.each([
     ['a classified error', '/__test/problem-exception'],

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -121,6 +121,21 @@ describe('Allow header', () => {
   });
 });
 
+// RFC 9457 makes the media type how a client tells a problem document apart
+// from a successful representation, so `apps/web`'s api client branches on it.
+// Serving plain `application/json` would leave errors indistinguishable.
+describe('problem document media type', () => {
+  it.each([
+    ['a classified error', '/__test/problem-exception'],
+    ['an unclassified HTTPException', '/__test/http-exception'],
+    ['an unexpected error', '/__test/permission-denied'],
+    ['an unmatched route', '/api/not-a-resource'],
+  ])('marks the response from %s as problem+json', async (_case, path) => {
+    const res = await app.request(path);
+    expect(res.headers.get('content-type')).toBe('application/problem+json');
+  });
+});
+
 describe('onError problem type', () => {
   it('carries the type of a classified error into the problem document', async () => {
     const res = await app.request('/__test/problem-exception');

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -25,6 +25,10 @@ import { teams } from '@/routes/teams.js';
 import { userProfile } from '@/routes/user-profile.js';
 import { weapons } from '@/routes/weapons.js';
 
+// Handlers below serialise through `c.body()` rather than `c.json()`: given a
+// `ResponseInit`, `c.json()` layers its own `application/json` over the
+// Content-Type the init carried, and would silently downgrade these to plain
+// JSON. `c.body()` applies no default of its own.
 export const PROBLEM_JSON = { 'Content-Type': 'application/problem+json' };
 
 export const app = new Hono<{
@@ -59,38 +63,38 @@ app.onError((err, c) => {
     const headers: Record<string, string> = { ...PROBLEM_JSON };
     const retryAfter = retryAfterSeconds(resolved.status);
     if (retryAfter !== undefined) headers['Retry-After'] = String(retryAfter);
-    return c.json(
-      {
+    return c.body(
+      JSON.stringify({
         type: problemTypeOf(resolved),
         title: STATUS_CODES[resolved.status] ?? 'Unknown Error',
         status: resolved.status,
         detail: resolved.message,
-      } satisfies ProblemDetail,
+      } satisfies ProblemDetail),
       { status: resolved.status, headers },
     );
   }
 
   console.error('Unexpected error:', resolved);
-  return c.json(
-    {
+  return c.body(
+    JSON.stringify({
       type: ABOUT_BLANK,
       title: 'Internal Server Error',
       status: 500,
       detail: 'An unexpected error occurred',
-    } satisfies ProblemDetail,
+    } satisfies ProblemDetail),
     { status: 500, headers: PROBLEM_JSON },
   );
 });
 
 // 404 handler for unmatched routes — RFC 9457 Problem Details
 app.notFound((c) =>
-  c.json(
-    {
+  c.body(
+    JSON.stringify({
       type: ABOUT_BLANK,
       title: 'Not Found',
       status: 404,
       detail: 'The requested resource does not exist',
-    } satisfies ProblemDetail,
+    } satisfies ProblemDetail),
     { status: 404, headers: PROBLEM_JSON },
   ),
 );

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,15 +3,13 @@
 
 import { STATUS_CODES } from 'node:http';
 
-import type { ProblemDetail } from '@genshin/domain';
 import { GoogleError } from 'google-gax';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 
-import { ABOUT_BLANK, problemTypeOf } from '@/http/problem.js';
-import { retryAfterSeconds } from '@/http/retry-after.js';
+import { ABOUT_BLANK, problemResponse, problemTypeOf } from '@/http/problem.js';
 import { allow } from '@/middleware/allow.js';
 import type { AuthVariables } from '@/middleware/auth.js';
 import type { NegotiatedResponseContentVariables } from '@/middleware/negotiate-content.js';
@@ -24,12 +22,6 @@ import { root } from '@/routes/root.js';
 import { teams } from '@/routes/teams.js';
 import { userProfile } from '@/routes/user-profile.js';
 import { weapons } from '@/routes/weapons.js';
-
-// Handlers below serialise through `c.body()` rather than `c.json()`: given a
-// `ResponseInit`, `c.json()` layers its own `application/json` over the
-// Content-Type the init carried, and would silently downgrade these to plain
-// JSON. `c.body()` applies no default of its own.
-export const PROBLEM_JSON = { 'Content-Type': 'application/problem+json' };
 
 export const app = new Hono<{
   Variables: Partial<AuthVariables> & NegotiatedResponseContentVariables;
@@ -60,43 +52,31 @@ app.onError((err, c) => {
   const resolved = err instanceof GoogleError ? firestoreErrorToHttpException(err) : err;
 
   if (resolved instanceof HTTPException) {
-    const headers: Record<string, string> = { ...PROBLEM_JSON };
-    const retryAfter = retryAfterSeconds(resolved.status);
-    if (retryAfter !== undefined) headers['Retry-After'] = String(retryAfter);
-    return c.body(
-      JSON.stringify({
-        type: problemTypeOf(resolved),
-        title: STATUS_CODES[resolved.status] ?? 'Unknown Error',
-        status: resolved.status,
-        detail: resolved.message,
-      } satisfies ProblemDetail),
-      { status: resolved.status, headers },
-    );
+    return problemResponse(c, {
+      type: problemTypeOf(resolved),
+      title: STATUS_CODES[resolved.status] ?? 'Unknown Error',
+      status: resolved.status,
+      detail: resolved.message,
+    });
   }
 
   console.error('Unexpected error:', resolved);
-  return c.body(
-    JSON.stringify({
-      type: ABOUT_BLANK,
-      title: 'Internal Server Error',
-      status: 500,
-      detail: 'An unexpected error occurred',
-    } satisfies ProblemDetail),
-    { status: 500, headers: PROBLEM_JSON },
-  );
+  return problemResponse(c, {
+    type: ABOUT_BLANK,
+    title: 'Internal Server Error',
+    status: 500,
+    detail: 'An unexpected error occurred',
+  });
 });
 
 // 404 handler for unmatched routes — RFC 9457 Problem Details
 app.notFound((c) =>
-  c.body(
-    JSON.stringify({
-      type: ABOUT_BLANK,
-      title: 'Not Found',
-      status: 404,
-      detail: 'The requested resource does not exist',
-    } satisfies ProblemDetail),
-    { status: 404, headers: PROBLEM_JSON },
-  ),
+  problemResponse(c, {
+    type: ABOUT_BLANK,
+    title: 'Not Found',
+    status: 404,
+    detail: 'The requested resource does not exist',
+  }),
 );
 
 // Routes

--- a/apps/api/src/http/problem.ts
+++ b/apps/api/src/http/problem.ts
@@ -40,21 +40,15 @@ export function problemTypeOf(err: unknown): string {
   return err instanceof ProblemException ? err.type : ABOUT_BLANK;
 }
 
-/** A problem document, narrowed to the statuses permitted to carry a body. */
+/** `ProblemDetail` with the status type Hono requires of a response with a body. */
 type ProblemPayload = Omit<ProblemDetail, 'status'> & { status: ContentfulStatusCode };
 
 /**
  * The HTTP response carrying a problem document.
  *
- * Serialises through `c.body()` rather than `c.json()` because `c.json()`,
- * handed a `ResponseInit`, layers its own `application/json` over the
- * Content-Type that init carried — which would leave an error indistinguishable
- * from a success to a client branching on the media type. `c.body()` applies no
- * default of its own.
- *
- * Every problem response goes through here so that the media type and the
- * retry hint stay properties of a problem response rather than something each
- * call site has to remember.
+ * Uses `c.body()`, not `c.json()`: handed a `ResponseInit`, `c.json()` overwrites
+ * the Content-Type it carried with `application/json`, which would leave a client
+ * unable to tell an error from a success.
  */
 export function problemResponse(c: Context, problem: ProblemPayload): Response {
   const headers: Record<string, string> = { 'Content-Type': 'application/problem+json' };

--- a/apps/api/src/http/problem.ts
+++ b/apps/api/src/http/problem.ts
@@ -1,8 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { ProblemDetail } from '@genshin/domain';
+import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
+
+import { retryAfterSeconds } from './retry-after.js';
 
 /** RFC 9457's type for a problem with no classification beyond its status. */
 export const ABOUT_BLANK = 'about:blank';
@@ -34,4 +38,28 @@ export class ProblemException extends HTTPException {
 /** How an error classifies, which is `about:blank` unless it says otherwise. */
 export function problemTypeOf(err: unknown): string {
   return err instanceof ProblemException ? err.type : ABOUT_BLANK;
+}
+
+/** A problem document, narrowed to the statuses permitted to carry a body. */
+type ProblemPayload = Omit<ProblemDetail, 'status'> & { status: ContentfulStatusCode };
+
+/**
+ * The HTTP response carrying a problem document.
+ *
+ * Serialises through `c.body()` rather than `c.json()` because `c.json()`,
+ * handed a `ResponseInit`, layers its own `application/json` over the
+ * Content-Type that init carried — which would leave an error indistinguishable
+ * from a success to a client branching on the media type. `c.body()` applies no
+ * default of its own.
+ *
+ * Every problem response goes through here so that the media type and the
+ * retry hint stay properties of a problem response rather than something each
+ * call site has to remember.
+ */
+export function problemResponse(c: Context, problem: ProblemPayload): Response {
+  const headers: Record<string, string> = { 'Content-Type': 'application/problem+json' };
+  const retryAfter = retryAfterSeconds(problem.status);
+  if (retryAfter !== undefined) headers['Retry-After'] = String(retryAfter);
+
+  return c.body(JSON.stringify(problem), { status: problem.status, headers });
 }


### PR DESCRIPTION
The global `onError` and `notFound` handlers passed their problem+json Content-Type to `c.json()` through a `ResponseInit`, and Hono overwrote it — every API error response went out as `application/json`. RFC 9457 makes the media type how a client tells a problem document apart from a successful representation, and `apps/web`'s api client branches on exactly that string, so errors were shipping in a form clients could not recognise as errors.

Two commits: the fix, then a refactoring that removes the duplication which allowed the bug.

## Gotchas

Hono's `c.json()` honours a custom Content-Type in the three-argument form (`c.json(obj, status, headers)`) but silently discards it in the init-object form (`c.json(obj, { status, headers })`) — `#newResponse` applies `init.headers` first, then layers `setDefaultContentType('application/json', ...)` over it. These three handlers were the only init-object callers; every route already passes headers positionally and was unaffected, including the `profile="…"` parameter that carries response versioning.

Problem documents now serialise through `c.body()`, which applies no default Content-Type in either argument form and so cannot repeat the mistake.

`problemResponse` takes the Hono `Context` rather than returning a bare `Response` deliberately: `c.body()` carries forward headers already set on the context, so building a `new Response()` would drop CORS off every error.

Its payload type narrows `status` to `ContentfulStatusCode`. That is load-bearing, not decoration — `ProblemDetail.status` is a plain `number` and Hono constrains a `ResponseInit` status to `StatusCode`, so the plain type needs a cast.

Retry-After now derives inside the helper for all three responses instead of the `HTTPException` branch alone. No response changes: 404 and 500 carry no retry semantics.

No CHANGELOG entry — it tracks user-visible features under a single pre-release `Added` bucket, with no `Fixed` section yet.

## Verification

Four tests cover the classified, unclassified, unexpected, and unmatched-route paths; all four fail against the pre-fix handlers with `expected 'application/json' to be 'application/problem+json'`.

For the refactoring, status, headers, and body were captured across five error paths and diffed before and after — byte-identical. 222 API tests, typecheck, and lint pass.

Closes #461