### PR TITLE
feat(infra): add prod Terraform environment workspace

### DIFF
--- a/infrastructure/terraform/environments/core/dns_record_set_develop.tf
+++ b/infrastructure/terraform/environments/core/dns_record_set_develop.tf
@@ -8,7 +8,7 @@ resource "google_dns_record_set" "web_develop" {
   managed_zone = google_dns_managed_zone.genshin_dungeon_studio.name
   type         = "CNAME"
   ttl          = 3600
-  project      = var.gcp_core_project_id
+  project      = var.project_id
 
   rrdatas = ["dungeon-studio-genshin-dev.web.app."]
 }
@@ -20,7 +20,7 @@ resource "google_dns_record_set" "api_develop" {
   managed_zone = google_dns_managed_zone.genshin_dungeon_studio.name
   type         = "CNAME"
   ttl          = 3600
-  project      = var.gcp_core_project_id
+  project      = var.project_id
 
   rrdatas = ["ghs.googlehosted.com."]
 }

--- a/infrastructure/terraform/environments/core/dns_zone_genshin_dungeon_studio.tf
+++ b/infrastructure/terraform/environments/core/dns_zone_genshin_dungeon_studio.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 resource "google_project_service" "dns" {
-  project = var.gcp_core_project_id
+  project = var.project_id
   service = "dns.googleapis.com"
 
   disable_on_destroy = false
@@ -12,7 +12,7 @@ resource "google_dns_managed_zone" "genshin_dungeon_studio" {
   name        = "genshin-dungeon-studio"
   dns_name    = "genshin.dungeon.studio."
   description = "DNS zone for genshin.dungeon.studio domain"
-  project     = var.gcp_core_project_id
+  project     = var.project_id
 
   dnssec_config {
     state = "on"

--- a/infrastructure/terraform/environments/core/main.tf
+++ b/infrastructure/terraform/environments/core/main.tf
@@ -12,10 +12,6 @@ terraform {
 }
 
 provider "google" {
-  project = var.gcp_core_project_id
+  project = var.project_id
   region  = "europe-west1"
-}
-
-data "google_project" "core" {
-  project_id = var.gcp_core_project_id
 }

--- a/infrastructure/terraform/environments/core/terraform.tfvars
+++ b/infrastructure/terraform/environments/core/terraform.tfvars
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT
 # Non-sensitive values for core environment
 
-gcp_core_project_id = "dungeon-studio-genshin-core"
+project_id = "dungeon-studio-genshin-core"

--- a/infrastructure/terraform/environments/core/variables.tf
+++ b/infrastructure/terraform/environments/core/variables.tf
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-variable "gcp_core_project_id" {
+variable "project_id" {
   type        = string
   description = "GCP Project ID for core infrastructure"
 
   validation {
-    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.gcp_core_project_id)) && length(var.gcp_core_project_id) >= 6 && length(var.gcp_core_project_id) <= 30
+    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.project_id)) && length(var.project_id) >= 6 && length(var.project_id) <= 30
     error_message = "Project ID must be 6-30 characters, start with lowercase letter, contain only lowercase letters/digits/hyphens, and not end with hyphen."
   }
 }

--- a/infrastructure/terraform/environments/dev/api.tf
+++ b/infrastructure/terraform/environments/dev/api.tf
@@ -8,20 +8,20 @@ locals {
   # NOTE: Cloud Run domain mappings expect a bare domain name without a
   # trailing dot. The corresponding DNS CNAME record in core intentionally
   # uses an FQDN with a trailing dot.
-  api_domain_name = "api.develop.genshin.dungeon.studio"
+  api_domain_name = "api.${local.web_domain}"
   api_route_name  = "api"
 }
 
 # Enable APIs required for API image storage and runtime deployment
 resource "google_project_service" "artifactregistry" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   service = "artifactregistry.googleapis.com"
 
   disable_on_destroy = false
 }
 
 resource "google_project_service" "cloudrun" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   service = "run.googleapis.com"
 
   disable_on_destroy = false
@@ -34,7 +34,7 @@ resource "google_project_service" "cloudrun" {
 
 # Artifact Registry repository for API container images
 resource "google_artifact_registry_repository" "api" {
-  project       = var.gcp_dev_project_id
+  project       = var.project_id
   location      = local.api_artifact_repository_location
   repository_id = local.api_artifact_repository_name
   format        = "DOCKER"
@@ -51,12 +51,12 @@ resource "google_artifact_registry_repository" "api" {
 resource "google_cloud_run_domain_mapping" "api" {
   count = var.enable_api_domain_mapping ? 1 : 0
 
-  project  = var.gcp_dev_project_id
+  project  = var.project_id
   location = local.api_cloud_run_location
   name     = local.api_domain_name
 
   metadata {
-    namespace = var.gcp_dev_project_id
+    namespace = var.project_id
   }
 
   spec {
@@ -73,7 +73,7 @@ resource "google_cloud_run_domain_mapping" "api" {
 resource "google_cloud_run_service_iam_member" "api_public_invoker" {
   count = var.enable_api_public_invoker ? 1 : 0
 
-  project  = var.gcp_dev_project_id
+  project  = var.project_id
   location = local.api_cloud_run_location
   service  = local.api_route_name
 

--- a/infrastructure/terraform/environments/dev/firebase_auth.tf
+++ b/infrastructure/terraform/environments/dev/firebase_auth.tf
@@ -3,7 +3,7 @@
 
 # Enable Firebase Management API for the project.
 resource "google_project_service" "firebase" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   service = "firebase.googleapis.com"
 
   disable_on_destroy = false
@@ -11,7 +11,7 @@ resource "google_project_service" "firebase" {
 
 # Enable Identity Toolkit API for Firebase Authentication.
 resource "google_project_service" "identitytoolkit" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   service = "identitytoolkit.googleapis.com"
 
   disable_on_destroy = false
@@ -19,14 +19,14 @@ resource "google_project_service" "identitytoolkit" {
 
 # Initialize Identity Platform (Firebase Authentication) project config.
 resource "google_identity_platform_config" "default" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
 
   autodelete_anonymous_users = true
 
   authorized_domains = [
-    "${var.gcp_dev_project_id}.firebaseapp.com",
-    "${var.gcp_dev_project_id}.web.app",
-    "genshin.dungeon.studio",
+    "${var.project_id}.firebaseapp.com",
+    "${var.project_id}.web.app",
+    local.base_domain,
   ]
 
   depends_on = [
@@ -37,21 +37,21 @@ resource "google_identity_platform_config" "default" {
 
 # Read the Google OAuth client ID from Secret Manager.
 data "google_secret_manager_secret_version" "firebase_auth_google_client_id" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   secret  = google_secret_manager_secret.firebase_auth_google_client_id.secret_id
   version = "latest"
 }
 
 # Read the Google OAuth client secret from Secret Manager.
 data "google_secret_manager_secret_version" "firebase_auth_google_client_secret" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   secret  = google_secret_manager_secret.firebase_auth_google_client_secret.secret_id
   version = "latest"
 }
 
 # Configure Google as a supported identity provider.
 resource "google_identity_platform_default_supported_idp_config" "google" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
 
   idp_id        = "google.com"
   client_id     = data.google_secret_manager_secret_version.firebase_auth_google_client_id.secret_data

--- a/infrastructure/terraform/environments/dev/firestore.tf
+++ b/infrastructure/terraform/environments/dev/firestore.tf
@@ -7,7 +7,7 @@ locals {
 
 # Enable Firestore API
 resource "google_project_service" "firestore" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   service = "firestore.googleapis.com"
 
   disable_on_destroy = false
@@ -15,7 +15,7 @@ resource "google_project_service" "firestore" {
 
 # Firestore database for application persistence
 resource "google_firestore_database" "default" {
-  project     = var.gcp_dev_project_id
+  project     = var.project_id
   name        = local.firestore_database_name
   location_id = var.firestore_location_id
   type        = "FIRESTORE_NATIVE"

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -16,13 +16,17 @@ terraform {
 }
 
 provider "google" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
 }
 
 provider "google-beta" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
 }
 
-data "google_project" "dev" {
-  project_id = var.gcp_dev_project_id
+# `web_domain` is this environment's own hostname; `base_domain` is the
+# registrable domain every environment shares, which is what Identity Platform
+# has to trust for sign-in redirects regardless of which environment serves.
+locals {
+  base_domain = "genshin.dungeon.studio"
+  web_domain  = "develop.${local.base_domain}"
 }

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -23,9 +23,8 @@ provider "google-beta" {
   project = var.project_id
 }
 
-# `web_domain` is this environment's own hostname; `base_domain` is the
-# registrable domain every environment shares, which is what Identity Platform
-# has to trust for sign-in redirects regardless of which environment serves.
+# Identity Platform must trust the registrable domain for sign-in redirects no
+# matter which environment serves, so it stays separate from the hostname.
 locals {
   base_domain = "genshin.dungeon.studio"
   web_domain  = "develop.${local.base_domain}"

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -35,8 +35,8 @@ output "firebase_web_app_config" {
   description = "Firebase Web App SDK config for the frontend build"
   value = {
     api_key             = data.google_firebase_web_app_config.web.api_key
-    auth_domain         = "${var.gcp_dev_project_id}.firebaseapp.com"
-    project_id          = var.gcp_dev_project_id
+    auth_domain         = "${var.project_id}.firebaseapp.com"
+    project_id          = var.project_id
     storage_bucket      = data.google_firebase_web_app_config.web.storage_bucket
     messaging_sender_id = data.google_firebase_web_app_config.web.messaging_sender_id
     app_id              = google_firebase_web_app.web.app_id

--- a/infrastructure/terraform/environments/dev/secret_manager.tf
+++ b/infrastructure/terraform/environments/dev/secret_manager.tf
@@ -3,7 +3,7 @@
 
 # Enable Secret Manager API for the project.
 resource "google_project_service" "secretmanager" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   service = "secretmanager.googleapis.com"
 
   disable_on_destroy = false
@@ -13,7 +13,7 @@ resource "google_project_service" "secretmanager" {
 # The actual value must be stored manually via GCP Console or gcloud CLI
 # after creating the OAuth consent screen.
 resource "google_secret_manager_secret" "firebase_auth_google_client_id" {
-  project   = var.gcp_dev_project_id
+  project   = var.project_id
   secret_id = "firebase-auth-google-client-id"
 
   labels = var.common_labels
@@ -29,7 +29,7 @@ resource "google_secret_manager_secret" "firebase_auth_google_client_id" {
 # The actual value must be stored manually via GCP Console or gcloud CLI
 # after creating the OAuth consent screen.
 resource "google_secret_manager_secret" "firebase_auth_google_client_secret" {
-  project   = var.gcp_dev_project_id
+  project   = var.project_id
   secret_id = "firebase-auth-google-client-secret"
 
   labels = var.common_labels

--- a/infrastructure/terraform/environments/dev/terraform.tfvars
+++ b/infrastructure/terraform/environments/dev/terraform.tfvars
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # Non-sensitive values for dev environment
 
-gcp_dev_project_id = "dungeon-studio-genshin-dev"
+project_id = "dungeon-studio-genshin-dev"
 
 common_labels = {
   environment = "dev"

--- a/infrastructure/terraform/environments/dev/variables.tf
+++ b/infrastructure/terraform/environments/dev/variables.tf
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-variable "gcp_dev_project_id" {
+variable "project_id" {
   type        = string
   description = "GCP Project ID for development environment"
 
   validation {
-    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.gcp_dev_project_id)) && length(var.gcp_dev_project_id) >= 6 && length(var.gcp_dev_project_id) <= 30
+    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.project_id)) && length(var.project_id) >= 6 && length(var.project_id) <= 30
     error_message = "Project ID must be 6-30 characters, start with lowercase letter, contain only lowercase letters/digits/hyphens, and not end with hyphen."
   }
 }

--- a/infrastructure/terraform/environments/dev/web.tf
+++ b/infrastructure/terraform/environments/dev/web.tf
@@ -4,14 +4,14 @@
 # Initialize Firebase on the GCP project
 resource "google_firebase_project" "default" {
   provider = google-beta
-  project  = var.gcp_dev_project_id
+  project  = var.project_id
 
   depends_on = [google_project_service.firebase]
 }
 
 # Enable Firebase Hosting API
 resource "google_project_service" "firebase_hosting" {
-  project = var.gcp_dev_project_id
+  project = var.project_id
   service = "firebasehosting.googleapis.com"
 
   disable_on_destroy = false
@@ -22,7 +22,7 @@ resource "google_project_service" "firebase_hosting" {
 # Firebase Hosting site for the web application
 resource "google_firebase_hosting_site" "web" {
   provider = google-beta
-  project  = var.gcp_dev_project_id
+  project  = var.project_id
   site_id  = "dungeon-studio-genshin-dev"
 
   depends_on = [
@@ -34,9 +34,9 @@ resource "google_firebase_hosting_site" "web" {
 # Custom domain for the Firebase Hosting site
 resource "google_firebase_hosting_custom_domain" "web" {
   provider      = google-beta
-  project       = var.gcp_dev_project_id
+  project       = var.project_id
   site_id       = google_firebase_hosting_site.web.site_id
-  custom_domain = "develop.genshin.dungeon.studio"
+  custom_domain = local.web_domain
 
   cert_preference       = "GROUPED"
   wait_dns_verification = false
@@ -48,7 +48,7 @@ resource "google_firebase_hosting_custom_domain" "web" {
 # The SDK config (API key, auth domain, etc.) is derived from this resource.
 resource "google_firebase_web_app" "web" {
   provider     = google-beta
-  project      = var.gcp_dev_project_id
+  project      = var.project_id
   display_name = "Genshin Planner (dev)"
 
   depends_on = [google_firebase_project.default]
@@ -57,6 +57,6 @@ resource "google_firebase_web_app" "web" {
 # Read the SDK config for the registered web app.
 data "google_firebase_web_app_config" "web" {
   provider   = google-beta
-  project    = var.gcp_dev_project_id
+  project    = var.project_id
   web_app_id = google_firebase_web_app.web.app_id
 }

--- a/infrastructure/terraform/environments/prod/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.43.0"
+  constraints = "7.43.0"
+  hashes = [
+    "h1:0y0ZvsbUGxBDIa18EQrspg4bri+kkOWsXEO5Zl+3eCA=",
+    "h1:2EZO7bntLiyBOYddCgpZrV9sGA5UPcMWUC6jFFw8UOc=",
+    "h1:2tJ1QBpteimiEM7OAIjHuGHwfRhSuBDfFMAPeS8h7s4=",
+    "h1:AwFYLjEh05Jog9DYlEQDacVk2Sjt5/QrKAsymAW0k/Q=",
+    "h1:BVeP1PlDuZuEkMuTvLyi53v9lrfyRlla8M2+3foxqG0=",
+    "h1:TSlFSHg4Z6z5F1MYoj5TgMDNk+QxtoMYgKprp9Y8/rQ=",
+    "h1:bevZG8tuthurhEcPZjASUSD3Z2TbofJPBqMeRPbkSIc=",
+    "h1:dIR6Y9L578t95OboIQ1Ui+K3reCuiRidM86pDW97zTw=",
+    "h1:eDlnfsmO5Bqjc+zJS06AjrNukuemIJ+LOlLQ72JNskk=",
+    "h1:oiNYwWzxjToOWwGtc59+Sxoa/Xkwh8t8deJ7lBDimuk=",
+    "h1:pt+TqGR7LH5Rn4/ZtxUpUQEhrUpC7pVR9ZcpQWyuEI0=",
+    "zh:0050abe670a076cfc110662ba3e9f8c25366a63df9389dfbe090b5dc5e73a4d2",
+    "zh:31769c27700334d11e652ddb2a0dfc9efd65df43dbc51a06afc04e10db645bbe",
+    "zh:33f7211886d44a31d9dc89fbe11f0d2e282da22b509ae25dcfb8c6533eeacff4",
+    "zh:3ee98b297ec00ad10b1080fddfddbe72c38dec00eece6d56e706fea1e871d648",
+    "zh:620683cba53b964a882a419c38d40ab4595459b44dc54b9ed18c5bb6b97fbceb",
+    "zh:7c118cc8ba4c245807b3cbcfd4f5bdb81b1afce83fa1528020208117f7c9518c",
+    "zh:8263f9aeab9c8bc661a8f6a4963e585ca0a86ed6662424d8f34923fd01c6de18",
+    "zh:d2ba502aa3da2dad62ae81dd32c97bc279c56a97b9ac3bb3f806303dc0af598d",
+    "zh:db37f9f900b801ffaad1b7194c4b89de9351879e753b752ca37e12f3e989691f",
+    "zh:eca80c71ef4a559b94a779365a8d8b91a33d7a805a27ca21c176720085c31d30",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fa91060bb31207fc91645e7de881fa61f106b9d0dfed2f444f158b9cd9420c58",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.42.0"
+  constraints = "7.42.0"
+  hashes = [
+    "h1:2Ak0ZJgi/UcW7rlvyf7WjqeWY3Dzo2VjQU7dG+ExMpU=",
+    "h1:2z+of+kRqido8EJRe9pr1EiAYyyzofWHasREYtHuWkE=",
+    "h1:7QkpKR4B/necvWAc3tlvCfKRVbcQX9zoCkXYmSscKL0=",
+    "h1:EOHacE7wpMtXaVbjIeLeW0naGCXhcdQglD93tQqaN8U=",
+    "h1:K/swjPfKJsbC4SjZ24lUUiLgOKHn/GlDiXrenMrAOYk=",
+    "h1:MyBSgvHydivnGFTXnd+zqxAQkoTChYXGXyT1s/8YnfQ=",
+    "h1:XrhJCSWu3T6UelLDPpVhY4KcPf8x1wKYq0s2okqY838=",
+    "h1:h5zcPjSN0AAq/Tcb4tA1B5QqZ/4VXacE2k1Tl1MYZ7c=",
+    "h1:iJ1tPLUALb+Um0w56f5iL8j+OEShMBe2tOmmy4Z6EwQ=",
+    "h1:rr+RgtabVDbLxg9/JYZFldB+Ov26DajLnaSY3Qge+qE=",
+    "h1:yftwfbqv5WmWvEbLpqzY+EfWusIZgDmaAwh5uRzHA+c=",
+    "zh:16afc2a1776af4fa79bfd764b92082e76cbb3645a7291dfe7c713ea7c3f63d7c",
+    "zh:298378171ec14d058c92f62b259cf22f6aaa36f13f99e01b74a173e596b6abc0",
+    "zh:42d60dfe8026a018b3b53e9ca8222d931d3d27b8dacd9fcdb9ddcae00fcd3c8c",
+    "zh:436ee002626dcd4c689b91107922136927ffb867e0bb7f56d30302a56c5792a2",
+    "zh:6ac35653e2aed7bd0cb16f5ddf75ab821f7f06b7647267e5b178e299aff729f0",
+    "zh:6b97a6fa8ae068abd945caa64d29e14b378f94e7d03907c7463ffa62b4502fea",
+    "zh:a2173204dde98a8ba4a7ff9c0e3f8b4343326a10dcd3e428637d06b27034f991",
+    "zh:a2dd28d4c95e4d4c5940486c0c5a0882f16d77e0b398e8a7a6e903c803cfb4d1",
+    "zh:b7e73395db6c16a8b28a8346d337698428b011145e3b632239ab1e99e2ad2855",
+    "zh:e02756b1f385aecb73b0800a53fbaeb1539e025618cf71dacb8ba09db217051d",
+    "zh:e9b3b3fbee897fa8fe3a0e8ebee1b98c01e9d29884a5599b4f5cb4b8e9bcf999",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/terraform/environments/prod/api.tf
+++ b/infrastructure/terraform/environments/prod/api.tf
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+locals {
+  api_artifact_repository_name     = "api"
+  api_artifact_repository_location = "europe-west1"
+  api_cloud_run_location           = "europe-west1"
+  # NOTE: Cloud Run domain mappings expect a bare domain name without a
+  # trailing dot. The corresponding DNS CNAME record in core intentionally
+  # uses an FQDN with a trailing dot.
+  api_domain_name = "api.genshin.dungeon.studio"
+  api_route_name  = "api"
+}
+
+# Enable APIs required for API image storage and runtime deployment
+resource "google_project_service" "artifactregistry" {
+  project = var.gcp_prod_project_id
+  service = "artifactregistry.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudrun" {
+  project = var.gcp_prod_project_id
+  service = "run.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# NOTE: The Cloud Run service resource is intentionally not managed here.
+# Deploy workflow (`.github/workflows/deploy.yml`) owns service creation and
+# rollout to keep application deploy cadence independent from Terraform applies.
+# Terraform in this module owns only supporting infrastructure.
+
+# Artifact Registry repository for API container images
+resource "google_artifact_registry_repository" "api" {
+  project       = var.gcp_prod_project_id
+  location      = local.api_artifact_repository_location
+  repository_id = local.api_artifact_repository_name
+  format        = "DOCKER"
+
+  labels = var.common_labels
+
+  depends_on = [google_project_service.artifactregistry]
+}
+
+# Cloud Run custom domain mapping for API service.
+# NOTE: The mapped service route (`api`) is created by CI/CD deploy,
+# so this resource has an external ordering dependency on a successful deploy.
+# Keep this in `prod` to avoid core->prod state dependencies.
+resource "google_cloud_run_domain_mapping" "api" {
+  count = var.enable_api_domain_mapping ? 1 : 0
+
+  project  = var.gcp_prod_project_id
+  location = local.api_cloud_run_location
+  name     = local.api_domain_name
+
+  metadata {
+    namespace = var.gcp_prod_project_id
+  }
+
+  spec {
+    route_name       = local.api_route_name
+    certificate_mode = "AUTOMATIC"
+  }
+
+  depends_on = [google_project_service.cloudrun]
+}
+
+# Cloud Run IAM policy binding for public API invocation.
+# NOTE: The Cloud Run service is created by CI/CD deploy, so this resource
+# has an external ordering dependency on a successful deploy.
+resource "google_cloud_run_service_iam_member" "api_public_invoker" {
+  count = var.enable_api_public_invoker ? 1 : 0
+
+  project  = var.gcp_prod_project_id
+  location = local.api_cloud_run_location
+  service  = local.api_route_name
+
+  role   = "roles/run.invoker"
+  member = "allUsers"
+
+  depends_on = [google_project_service.cloudrun]
+}

--- a/infrastructure/terraform/environments/prod/api.tf
+++ b/infrastructure/terraform/environments/prod/api.tf
@@ -8,20 +8,20 @@ locals {
   # NOTE: Cloud Run domain mappings expect a bare domain name without a
   # trailing dot. The corresponding DNS CNAME record in core intentionally
   # uses an FQDN with a trailing dot.
-  api_domain_name = "api.genshin.dungeon.studio"
+  api_domain_name = "api.${local.web_domain}"
   api_route_name  = "api"
 }
 
 # Enable APIs required for API image storage and runtime deployment
 resource "google_project_service" "artifactregistry" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   service = "artifactregistry.googleapis.com"
 
   disable_on_destroy = false
 }
 
 resource "google_project_service" "cloudrun" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   service = "run.googleapis.com"
 
   disable_on_destroy = false
@@ -34,7 +34,7 @@ resource "google_project_service" "cloudrun" {
 
 # Artifact Registry repository for API container images
 resource "google_artifact_registry_repository" "api" {
-  project       = var.gcp_prod_project_id
+  project       = var.project_id
   location      = local.api_artifact_repository_location
   repository_id = local.api_artifact_repository_name
   format        = "DOCKER"
@@ -51,12 +51,12 @@ resource "google_artifact_registry_repository" "api" {
 resource "google_cloud_run_domain_mapping" "api" {
   count = var.enable_api_domain_mapping ? 1 : 0
 
-  project  = var.gcp_prod_project_id
+  project  = var.project_id
   location = local.api_cloud_run_location
   name     = local.api_domain_name
 
   metadata {
-    namespace = var.gcp_prod_project_id
+    namespace = var.project_id
   }
 
   spec {
@@ -73,7 +73,7 @@ resource "google_cloud_run_domain_mapping" "api" {
 resource "google_cloud_run_service_iam_member" "api_public_invoker" {
   count = var.enable_api_public_invoker ? 1 : 0
 
-  project  = var.gcp_prod_project_id
+  project  = var.project_id
   location = local.api_cloud_run_location
   service  = local.api_route_name
 

--- a/infrastructure/terraform/environments/prod/backend.tf
+++ b/infrastructure/terraform/environments/prod/backend.tf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# State is stored in GCS bucket created during bootstrap
+terraform {
+  backend "gcs" {
+    bucket = "dungeon-studio-genshin-tfstate"
+    prefix = "environments/prod"
+  }
+}

--- a/infrastructure/terraform/environments/prod/firebase_auth.tf
+++ b/infrastructure/terraform/environments/prod/firebase_auth.tf
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Enable Firebase Management API for the project.
+resource "google_project_service" "firebase" {
+  project = var.gcp_prod_project_id
+  service = "firebase.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Enable Identity Toolkit API for Firebase Authentication.
+resource "google_project_service" "identitytoolkit" {
+  project = var.gcp_prod_project_id
+  service = "identitytoolkit.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Initialize Identity Platform (Firebase Authentication) project config.
+resource "google_identity_platform_config" "default" {
+  project = var.gcp_prod_project_id
+
+  autodelete_anonymous_users = true
+
+  authorized_domains = [
+    "${var.gcp_prod_project_id}.firebaseapp.com",
+    "${var.gcp_prod_project_id}.web.app",
+    "genshin.dungeon.studio",
+  ]
+
+  depends_on = [
+    google_project_service.firebase,
+    google_project_service.identitytoolkit,
+  ]
+}
+
+# Read the Google OAuth client ID from Secret Manager.
+# NOTE: Terraform creates the secret container but never its version, so the
+# first apply fails here until the OAuth credentials are stored out of band.
+data "google_secret_manager_secret_version" "firebase_auth_google_client_id" {
+  project = var.gcp_prod_project_id
+  secret  = google_secret_manager_secret.firebase_auth_google_client_id.secret_id
+  version = "latest"
+}
+
+# Read the Google OAuth client secret from Secret Manager.
+data "google_secret_manager_secret_version" "firebase_auth_google_client_secret" {
+  project = var.gcp_prod_project_id
+  secret  = google_secret_manager_secret.firebase_auth_google_client_secret.secret_id
+  version = "latest"
+}
+
+# Configure Google as a supported identity provider.
+resource "google_identity_platform_default_supported_idp_config" "google" {
+  project = var.gcp_prod_project_id
+
+  idp_id        = "google.com"
+  client_id     = data.google_secret_manager_secret_version.firebase_auth_google_client_id.secret_data
+  client_secret = data.google_secret_manager_secret_version.firebase_auth_google_client_secret.secret_data
+
+  enabled = true
+
+  depends_on = [google_identity_platform_config.default]
+}

--- a/infrastructure/terraform/environments/prod/firebase_auth.tf
+++ b/infrastructure/terraform/environments/prod/firebase_auth.tf
@@ -3,7 +3,7 @@
 
 # Enable Firebase Management API for the project.
 resource "google_project_service" "firebase" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   service = "firebase.googleapis.com"
 
   disable_on_destroy = false
@@ -11,7 +11,7 @@ resource "google_project_service" "firebase" {
 
 # Enable Identity Toolkit API for Firebase Authentication.
 resource "google_project_service" "identitytoolkit" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   service = "identitytoolkit.googleapis.com"
 
   disable_on_destroy = false
@@ -19,14 +19,14 @@ resource "google_project_service" "identitytoolkit" {
 
 # Initialize Identity Platform (Firebase Authentication) project config.
 resource "google_identity_platform_config" "default" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
 
   autodelete_anonymous_users = true
 
   authorized_domains = [
-    "${var.gcp_prod_project_id}.firebaseapp.com",
-    "${var.gcp_prod_project_id}.web.app",
-    "genshin.dungeon.studio",
+    "${var.project_id}.firebaseapp.com",
+    "${var.project_id}.web.app",
+    local.base_domain,
   ]
 
   depends_on = [
@@ -39,21 +39,21 @@ resource "google_identity_platform_config" "default" {
 # NOTE: Terraform creates the secret container but never its version, so the
 # first apply fails here until the OAuth credentials are stored out of band.
 data "google_secret_manager_secret_version" "firebase_auth_google_client_id" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   secret  = google_secret_manager_secret.firebase_auth_google_client_id.secret_id
   version = "latest"
 }
 
 # Read the Google OAuth client secret from Secret Manager.
 data "google_secret_manager_secret_version" "firebase_auth_google_client_secret" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   secret  = google_secret_manager_secret.firebase_auth_google_client_secret.secret_id
   version = "latest"
 }
 
 # Configure Google as a supported identity provider.
 resource "google_identity_platform_default_supported_idp_config" "google" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
 
   idp_id        = "google.com"
   client_id     = data.google_secret_manager_secret_version.firebase_auth_google_client_id.secret_data

--- a/infrastructure/terraform/environments/prod/firestore.tf
+++ b/infrastructure/terraform/environments/prod/firestore.tf
@@ -7,7 +7,7 @@ locals {
 
 # Enable Firestore API
 resource "google_project_service" "firestore" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   service = "firestore.googleapis.com"
 
   disable_on_destroy = false
@@ -15,7 +15,7 @@ resource "google_project_service" "firestore" {
 
 # Firestore database for application persistence
 resource "google_firestore_database" "default" {
-  project     = var.gcp_prod_project_id
+  project     = var.project_id
   name        = local.firestore_database_name
   location_id = var.firestore_location_id
   type        = "FIRESTORE_NATIVE"

--- a/infrastructure/terraform/environments/prod/firestore.tf
+++ b/infrastructure/terraform/environments/prod/firestore.tf
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+locals {
+  firestore_database_name = "(default)"
+}
+
+# Enable Firestore API
+resource "google_project_service" "firestore" {
+  project = var.gcp_prod_project_id
+  service = "firestore.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Firestore database for application persistence
+resource "google_firestore_database" "default" {
+  project     = var.gcp_prod_project_id
+  name        = local.firestore_database_name
+  location_id = var.firestore_location_id
+  type        = "FIRESTORE_NATIVE"
+
+  # Production holds the only copy of user collections, so refuse deletion at
+  # both layers: the API rejects the call, and Terraform refuses to plan one.
+  delete_protection_state = "DELETE_PROTECTION_ENABLED"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  depends_on = [google_project_service.firestore]
+}

--- a/infrastructure/terraform/environments/prod/firestore.tf
+++ b/infrastructure/terraform/environments/prod/firestore.tf
@@ -20,8 +20,7 @@ resource "google_firestore_database" "default" {
   location_id = var.firestore_location_id
   type        = "FIRESTORE_NATIVE"
 
-  # Production holds the only copy of user collections, so refuse deletion at
-  # both layers: the API rejects the call, and Terraform refuses to plan one.
+  # Production holds the only copy of user collections.
   delete_protection_state = "DELETE_PROTECTION_ENABLED"
 
   lifecycle {

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -1,11 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-# NOTE: This environment is `prod` everywhere it is addressable -- folder name,
-# state prefix, GitHub Actions environment, and the GCP_*_PROD_* secrets emitted
-# by bootstrap outputs. The bootstrap module labels the underlying project
-# `production` because its `environment` variable only accepts that spelling;
-# that label is not an addressing scheme and does not propagate here.
+# The bootstrap module labels this project `production` while everything
+# addressable here says `prod`. That label is not an addressing scheme, so the
+# mismatch is deliberate rather than drift.
 
 terraform {
   required_version = "1.15.8"
@@ -29,10 +27,8 @@ provider "google-beta" {
   project = var.project_id
 }
 
-# `web_domain` is this environment's own hostname; `base_domain` is the
-# registrable domain every environment shares, which is what Identity Platform
-# has to trust for sign-in redirects regardless of which environment serves.
-# Production serves the registrable domain itself, so the two coincide here.
+# Identity Platform must trust the registrable domain for sign-in redirects no
+# matter which environment serves, so it stays separate from the hostname.
 locals {
   base_domain = "genshin.dungeon.studio"
   web_domain  = local.base_domain

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# NOTE: This environment is `prod` everywhere it is addressable -- folder name,
+# state prefix, GitHub Actions environment, and the GCP_*_PROD_* secrets emitted
+# by bootstrap outputs. The bootstrap module labels the underlying project
+# `production` because its `environment` variable only accepts that spelling;
+# that label is not an addressing scheme and does not propagate here.
+
+terraform {
+  required_version = "1.15.8"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "7.43.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "7.42.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcp_prod_project_id
+}
+
+provider "google-beta" {
+  project = var.gcp_prod_project_id
+}
+
+data "google_project" "prod" {
+  project_id = var.gcp_prod_project_id
+}

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -22,13 +22,18 @@ terraform {
 }
 
 provider "google" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
 }
 
 provider "google-beta" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
 }
 
-data "google_project" "prod" {
-  project_id = var.gcp_prod_project_id
+# `web_domain` is this environment's own hostname; `base_domain` is the
+# registrable domain every environment shares, which is what Identity Platform
+# has to trust for sign-in redirects regardless of which environment serves.
+# Production serves the registrable domain itself, so the two coincide here.
+locals {
+  base_domain = "genshin.dungeon.studio"
+  web_domain  = local.base_domain
 }

--- a/infrastructure/terraform/environments/prod/outputs.tf
+++ b/infrastructure/terraform/environments/prod/outputs.tf
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+output "web_hosting_site_id" {
+  description = "Firebase Hosting site ID for the web application"
+  value       = google_firebase_hosting_site.web.site_id
+  sensitive   = false
+}
+
+output "api_artifact_repository_id" {
+  description = "Artifact Registry repository used for API container images (full resource ID)"
+  value       = google_artifact_registry_repository.api.id
+  sensitive   = false
+}
+
+output "firestore_database_name" {
+  description = "Firestore database name for the production environment"
+  value       = google_firestore_database.default.name
+  sensitive   = false
+}
+
+output "firestore_location_id" {
+  description = "Firestore location ID for the production environment"
+  value       = google_firestore_database.default.location_id
+  sensitive   = false
+}
+
+output "firebase_auth_config_name" {
+  description = "Identity Platform config resource name for the production environment"
+  value       = google_identity_platform_config.default.name
+  sensitive   = false
+}
+
+output "firebase_web_app_config" {
+  description = "Firebase Web App SDK config for the frontend build"
+  value = {
+    api_key             = data.google_firebase_web_app_config.web.api_key
+    auth_domain         = "${var.gcp_prod_project_id}.firebaseapp.com"
+    project_id          = var.gcp_prod_project_id
+    storage_bucket      = data.google_firebase_web_app_config.web.storage_bucket
+    messaging_sender_id = data.google_firebase_web_app_config.web.messaging_sender_id
+    app_id              = google_firebase_web_app.web.app_id
+  }
+  sensitive = true
+}

--- a/infrastructure/terraform/environments/prod/outputs.tf
+++ b/infrastructure/terraform/environments/prod/outputs.tf
@@ -35,8 +35,8 @@ output "firebase_web_app_config" {
   description = "Firebase Web App SDK config for the frontend build"
   value = {
     api_key             = data.google_firebase_web_app_config.web.api_key
-    auth_domain         = "${var.gcp_prod_project_id}.firebaseapp.com"
-    project_id          = var.gcp_prod_project_id
+    auth_domain         = "${var.project_id}.firebaseapp.com"
+    project_id          = var.project_id
     storage_bucket      = data.google_firebase_web_app_config.web.storage_bucket
     messaging_sender_id = data.google_firebase_web_app_config.web.messaging_sender_id
     app_id              = google_firebase_web_app.web.app_id

--- a/infrastructure/terraform/environments/prod/secret_manager.tf
+++ b/infrastructure/terraform/environments/prod/secret_manager.tf
@@ -3,7 +3,7 @@
 
 # Enable Secret Manager API for the project.
 resource "google_project_service" "secretmanager" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   service = "secretmanager.googleapis.com"
 
   disable_on_destroy = false
@@ -13,7 +13,7 @@ resource "google_project_service" "secretmanager" {
 # The actual value must be stored manually via GCP Console or gcloud CLI
 # after creating the OAuth consent screen.
 resource "google_secret_manager_secret" "firebase_auth_google_client_id" {
-  project   = var.gcp_prod_project_id
+  project   = var.project_id
   secret_id = "firebase-auth-google-client-id"
 
   labels = var.common_labels
@@ -29,7 +29,7 @@ resource "google_secret_manager_secret" "firebase_auth_google_client_id" {
 # The actual value must be stored manually via GCP Console or gcloud CLI
 # after creating the OAuth consent screen.
 resource "google_secret_manager_secret" "firebase_auth_google_client_secret" {
-  project   = var.gcp_prod_project_id
+  project   = var.project_id
   secret_id = "firebase-auth-google-client-secret"
 
   labels = var.common_labels

--- a/infrastructure/terraform/environments/prod/secret_manager.tf
+++ b/infrastructure/terraform/environments/prod/secret_manager.tf
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Enable Secret Manager API for the project.
+resource "google_project_service" "secretmanager" {
+  project = var.gcp_prod_project_id
+  service = "secretmanager.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# Secret container for the Google OAuth client ID.
+# The actual value must be stored manually via GCP Console or gcloud CLI
+# after creating the OAuth consent screen.
+resource "google_secret_manager_secret" "firebase_auth_google_client_id" {
+  project   = var.gcp_prod_project_id
+  secret_id = "firebase-auth-google-client-id"
+
+  labels = var.common_labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+# Secret container for the Google OAuth client secret.
+# The actual value must be stored manually via GCP Console or gcloud CLI
+# after creating the OAuth consent screen.
+resource "google_secret_manager_secret" "firebase_auth_google_client_secret" {
+  project   = var.gcp_prod_project_id
+  secret_id = "firebase-auth-google-client-secret"
+
+  labels = var.common_labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}

--- a/infrastructure/terraform/environments/prod/terraform.tfvars
+++ b/infrastructure/terraform/environments/prod/terraform.tfvars
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+# Non-sensitive values for prod environment
+
+gcp_prod_project_id = "dungeon-studio-genshin-prod"
+
+common_labels = {
+  environment = "prod"
+  managed_by  = "terraform"
+}
+
+# NOTE: The domain flags stay off until the matching records exist in `core`,
+# which today publishes only the `develop` names; enabling a domain resource
+# ahead of its CNAME leaves a permanently pending verification. Cutover order
+# per name: add the record in `core`, apply `core`, then flip the flag here.
+enable_api_domain_mapping = false
+enable_web_custom_domain  = false
+
+# The invoker binding names the Cloud Run service the deploy workflow creates,
+# so it stays off until production has been deployed at least once.
+enable_api_public_invoker = false
+
+firestore_location_id = "eur3"

--- a/infrastructure/terraform/environments/prod/terraform.tfvars
+++ b/infrastructure/terraform/environments/prod/terraform.tfvars
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # Non-sensitive values for prod environment
 
-gcp_prod_project_id = "dungeon-studio-genshin-prod"
+project_id = "dungeon-studio-genshin-prod"
 
 common_labels = {
   environment = "prod"

--- a/infrastructure/terraform/environments/prod/terraform.tfvars
+++ b/infrastructure/terraform/environments/prod/terraform.tfvars
@@ -9,15 +9,13 @@ common_labels = {
   managed_by  = "terraform"
 }
 
-# NOTE: The domain flags stay off until the matching records exist in `core`,
-# which today publishes only the `develop` names; enabling a domain resource
-# ahead of its CNAME leaves a permanently pending verification. Cutover order
-# per name: add the record in `core`, apply `core`, then flip the flag here.
+# Enabling a domain ahead of its CNAME leaves verification permanently pending.
+# Cutover per name: add the record in `core`, apply `core`, then flip the flag.
 enable_api_domain_mapping = false
 enable_web_custom_domain  = false
 
-# The invoker binding names the Cloud Run service the deploy workflow creates,
-# so it stays off until production has been deployed at least once.
+# The invoker binding names a Cloud Run service the deploy workflow creates, so
+# it cannot apply before the first deploy.
 enable_api_public_invoker = false
 
 firestore_location_id = "eur3"

--- a/infrastructure/terraform/environments/prod/variables.tf
+++ b/infrastructure/terraform/environments/prod/variables.tf
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+variable "gcp_prod_project_id" {
+  type        = string
+  description = "GCP Project ID for production environment"
+
+  validation {
+    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.gcp_prod_project_id)) && length(var.gcp_prod_project_id) >= 6 && length(var.gcp_prod_project_id) <= 30
+    error_message = "Project ID must be 6-30 characters, start with lowercase letter, contain only lowercase letters/digits/hyphens, and not end with hyphen."
+  }
+}
+
+variable "common_labels" {
+  type        = map(string)
+  description = "Common labels applied to all resources"
+}
+
+variable "enable_api_domain_mapping" {
+  type        = bool
+  description = "Whether to create the API Cloud Run custom domain mapping"
+  default     = false
+}
+
+variable "enable_api_public_invoker" {
+  type        = bool
+  description = "Whether to grant allUsers the Cloud Run invoker role for API service"
+  default     = false
+}
+
+variable "enable_web_custom_domain" {
+  type        = bool
+  description = "Whether to attach the custom domain to the web Firebase Hosting site"
+  default     = false
+}
+
+variable "firestore_location_id" {
+  type        = string
+  description = "Firestore location for the prod database"
+  default     = "eur3"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.firestore_location_id)) && length(var.firestore_location_id) >= 3 && length(var.firestore_location_id) <= 32
+    error_message = "firestore_location_id must be a valid Google Cloud location ID format (lowercase letters, digits, hyphens; 3-32 chars; must start with a letter)."
+  }
+}

--- a/infrastructure/terraform/environments/prod/variables.tf
+++ b/infrastructure/terraform/environments/prod/variables.tf
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-variable "gcp_prod_project_id" {
+variable "project_id" {
   type        = string
   description = "GCP Project ID for production environment"
 
   validation {
-    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.gcp_prod_project_id)) && length(var.gcp_prod_project_id) >= 6 && length(var.gcp_prod_project_id) <= 30
+    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.project_id)) && length(var.project_id) >= 6 && length(var.project_id) <= 30
     error_message = "Project ID must be 6-30 characters, start with lowercase letter, contain only lowercase letters/digits/hyphens, and not end with hyphen."
   }
 }

--- a/infrastructure/terraform/environments/prod/web.tf
+++ b/infrastructure/terraform/environments/prod/web.tf
@@ -4,14 +4,14 @@
 # Initialize Firebase on the GCP project
 resource "google_firebase_project" "default" {
   provider = google-beta
-  project  = var.gcp_prod_project_id
+  project  = var.project_id
 
   depends_on = [google_project_service.firebase]
 }
 
 # Enable Firebase Hosting API
 resource "google_project_service" "firebase_hosting" {
-  project = var.gcp_prod_project_id
+  project = var.project_id
   service = "firebasehosting.googleapis.com"
 
   disable_on_destroy = false
@@ -22,7 +22,7 @@ resource "google_project_service" "firebase_hosting" {
 # Firebase Hosting site for the web application
 resource "google_firebase_hosting_site" "web" {
   provider = google-beta
-  project  = var.gcp_prod_project_id
+  project  = var.project_id
   site_id  = "dungeon-studio-genshin-prod"
 
   depends_on = [
@@ -36,9 +36,9 @@ resource "google_firebase_hosting_custom_domain" "web" {
   count = var.enable_web_custom_domain ? 1 : 0
 
   provider      = google-beta
-  project       = var.gcp_prod_project_id
+  project       = var.project_id
   site_id       = google_firebase_hosting_site.web.site_id
-  custom_domain = "genshin.dungeon.studio"
+  custom_domain = local.web_domain
 
   cert_preference       = "GROUPED"
   wait_dns_verification = false
@@ -50,7 +50,7 @@ resource "google_firebase_hosting_custom_domain" "web" {
 # The SDK config (API key, auth domain, etc.) is derived from this resource.
 resource "google_firebase_web_app" "web" {
   provider     = google-beta
-  project      = var.gcp_prod_project_id
+  project      = var.project_id
   display_name = "Genshin Planner"
 
   depends_on = [google_firebase_project.default]
@@ -59,6 +59,6 @@ resource "google_firebase_web_app" "web" {
 # Read the SDK config for the registered web app.
 data "google_firebase_web_app_config" "web" {
   provider   = google-beta
-  project    = var.gcp_prod_project_id
+  project    = var.project_id
   web_app_id = google_firebase_web_app.web.app_id
 }

--- a/infrastructure/terraform/environments/prod/web.tf
+++ b/infrastructure/terraform/environments/prod/web.tf
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Initialize Firebase on the GCP project
+resource "google_firebase_project" "default" {
+  provider = google-beta
+  project  = var.gcp_prod_project_id
+
+  depends_on = [google_project_service.firebase]
+}
+
+# Enable Firebase Hosting API
+resource "google_project_service" "firebase_hosting" {
+  project = var.gcp_prod_project_id
+  service = "firebasehosting.googleapis.com"
+
+  disable_on_destroy = false
+
+  depends_on = [google_project_service.firebase]
+}
+
+# Firebase Hosting site for the web application
+resource "google_firebase_hosting_site" "web" {
+  provider = google-beta
+  project  = var.gcp_prod_project_id
+  site_id  = "dungeon-studio-genshin-prod"
+
+  depends_on = [
+    google_firebase_project.default,
+    google_project_service.firebase_hosting,
+  ]
+}
+
+# Custom domain for the Firebase Hosting site
+resource "google_firebase_hosting_custom_domain" "web" {
+  count = var.enable_web_custom_domain ? 1 : 0
+
+  provider      = google-beta
+  project       = var.gcp_prod_project_id
+  site_id       = google_firebase_hosting_site.web.site_id
+  custom_domain = "genshin.dungeon.studio"
+
+  cert_preference       = "GROUPED"
+  wait_dns_verification = false
+
+  depends_on = [google_firebase_hosting_site.web]
+}
+
+# Register a Firebase Web App for the frontend.
+# The SDK config (API key, auth domain, etc.) is derived from this resource.
+resource "google_firebase_web_app" "web" {
+  provider     = google-beta
+  project      = var.gcp_prod_project_id
+  display_name = "Genshin Planner"
+
+  depends_on = [google_firebase_project.default]
+}
+
+# Read the SDK config for the registered web app.
+data "google_firebase_web_app_config" "web" {
+  provider   = google-beta
+  project    = var.gcp_prod_project_id
+  web_app_id = google_firebase_web_app.web.app_id
+}

--- a/infrastructure/terraform/environments/staging/main.tf
+++ b/infrastructure/terraform/environments/staging/main.tf
@@ -12,9 +12,5 @@ terraform {
 }
 
 provider "google" {
-  project = var.gcp_staging_project_id
-}
-
-data "google_project" "staging" {
-  project_id = var.gcp_staging_project_id
+  project = var.project_id
 }

--- a/infrastructure/terraform/environments/staging/terraform.tfvars
+++ b/infrastructure/terraform/environments/staging/terraform.tfvars
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # Non-sensitive values for staging environment
 
-gcp_staging_project_id = "dungeon-studio-genshin-staging"
+project_id = "dungeon-studio-genshin-staging"
 
 common_labels = {
   environment = "staging"

--- a/infrastructure/terraform/environments/staging/variables.tf
+++ b/infrastructure/terraform/environments/staging/variables.tf
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-variable "gcp_staging_project_id" {
+variable "project_id" {
   type        = string
   description = "GCP Project ID for staging environment"
 
   validation {
-    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.gcp_staging_project_id)) && length(var.gcp_staging_project_id) >= 6 && length(var.gcp_staging_project_id) <= 30
+    condition     = can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.project_id)) && length(var.project_id) >= 6 && length(var.project_id) <= 30
     error_message = "Project ID must be 6-30 characters, start with lowercase letter, contain only lowercase letters/digits/hyphens, and not end with hyphen."
   }
 }


### PR DESCRIPTION
## Summary

Adds `infrastructure/terraform/environments/prod/` at parity with `dev`, so the prod service accounts and WIF bindings bootstrapped in #754 have a workspace to operate against. Covers Artifact Registry, Cloud Run enablement, Firestore, Identity Platform, the OAuth secret containers, and Firebase Hosting.

A second commit then applies three behaviour-preserving refactorings across all four environments: *Rename Variable* collapsing `gcp_{core,dev,staging,prod}_project_id` to `project_id`, *Remove Dead Code* dropping a `google_project` data source nothing referenced, and *Extract Variable* pulling the registrable domain out of three files into `base_domain`/`web_domain` locals.

Closes #780. Also closes #313, whose entire scope is this workspace's `firestore.tf`.

## Gotchas

**The refactoring commit touches `dev`, which is applied.** It is behaviour-preserving by construction — variables and locals are not state, and the removed data source was unreferenced — but the claim is worth checking rather than trusting. The Core, Dev, and Staging plan jobs are the evidence: if any reports a resource change, an interpolation is wrong. Locally I evaluated the real configs with `terraform console` and diffed all six derived domain values against their literals at HEAD; every one is byte-identical.

**Three resources ship disabled.** The API domain mapping and the web custom domain sit behind `enable_*` flags defaulting `false`, because `core` publishes only the `develop` DNS names — attaching a domain ahead of its CNAME leaves verification permanently pending. Cutover per name is: add the record in `core`, apply `core`, flip the flag. The public invoker binding names a Cloud Run service the deploy workflow has not created yet.

**The first prod apply will fail, by design.** `firebase_auth.tf` reads the OAuth client ID and secret from Secret Manager, but Terraform only creates the containers — never the versions. Prod needs the same out-of-band seeding dev got: apply, store the credentials, apply again.

**`prod` not `production`.** Everything addressable already says `prod` — the state prefix, the `github_environment` in the WIF binding, and the `GCP_*_PROD_*` secrets bootstrap emits. Only the bootstrap module's `environment` label says `production`, and it validates against a fixed set rather than naming a path. Recorded in a comment at the top of `main.tf`.

**Firestore is harder to delete than dev's.** `DELETE_PROTECTION_ENABLED` plus a `prevent_destroy` lifecycle, since production holds the only copy of user collections. Removing this environment later means lifting both.

## Verification

`terraform fmt`, `init -backend=false`, and `validate` pass for all four environments, and prod's committed lock file is byte-identical to dev's across all eleven platforms. The authenticated `terraform plan` against the prod project is **not** verified — prod is not in the plan matrix yet (that's #782), and bootstrap may not have been applied. Step 5 of `docs/how-tos/add-terraform-environment.md`, the workflow wiring, is deliberately left to #782.

The larger duplication — prod is ~89% identical to dev — is deliberately not addressed here and is filed as #1184, since extracting a shared module restructures the only applied environment and Rule of Three argues for waiting until `staging` is the third caller.
