### PR TITLE
chore(ci): use upstream hadolint pre-commit hook

### DIFF
--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -51,7 +51,6 @@ run_verification() {
   verify "gcloud"               gcloud --version
   verify "pre-commit"           pre-commit --version
   verify "reuse"                reuse --version
-  verify "hadolint"             hadolint --version
   verify "lychee"               lychee --version
   verify "firebase"             firebase --version
   verify "playwright-cli"       pnpm --filter @genshin/e2e exec playwright --version
@@ -74,7 +73,6 @@ run_version_summary() {
   print_version "gcloud"     gcloud --version
   print_version "pre-commit" pre-commit --version
   print_version "reuse"      reuse --version
-  print_version "hadolint"   hadolint --version
   print_version "lychee"     lychee --version
   print_version "firebase"   firebase --version
   print_version "playwright" pnpm --filter @genshin/e2e exec playwright --version

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -50,19 +50,7 @@ step "Installing reuse-tool"
 "${REPO_ROOT}/scripts/install-reuse.sh"
 
 # ---------------------------------------------------------------------------
-# 6. Dockerfile linter
-# ---------------------------------------------------------------------------
-step "Installing hadolint"
-
-# renovate: datasource=github-releases depName=hadolint/hadolint
-HADOLINT_VERSION="v2.15.1"
-sudo curl -fsSL \
-  "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
-  -o /usr/local/bin/hadolint
-sudo chmod +x /usr/local/bin/hadolint
-
-# ---------------------------------------------------------------------------
-# 7. Link checker
+# 6. Link checker
 # ---------------------------------------------------------------------------
 step "Installing lychee"
 
@@ -75,7 +63,7 @@ curl -fsSL \
 sudo chmod +x /usr/local/bin/lychee
 
 # ---------------------------------------------------------------------------
-# 8. Playwright browsers (for the end-to-end suite and the Playwright MCP server)
+# 7. Playwright browsers (for the end-to-end suite and the Playwright MCP server)
 # ---------------------------------------------------------------------------
 step "Installing Playwright Chromium and Chrome"
 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -10,17 +10,11 @@ REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 # shellcheck source=lib.sh
 source "${SCRIPT_DIR}/lib.sh"
 
-# ---------------------------------------------------------------------------
-# Package manager
-# ---------------------------------------------------------------------------
 step "Installing pnpm via corepack"
 
 corepack enable
 corepack install
 
-# ---------------------------------------------------------------------------
-# Google Cloud SDK
-# ---------------------------------------------------------------------------
 step "Installing Google Cloud SDK"
 
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/cloud.google.gpg && \
@@ -28,31 +22,19 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
 sudo DEBIAN_FRONTEND=noninteractive apt-get update && \
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y google-cloud-sdk
 
-# ---------------------------------------------------------------------------
-# Project dependencies
-# ---------------------------------------------------------------------------
 step "Installing project dependencies"
 
 pnpm install
 
-# ---------------------------------------------------------------------------
-# Pre-commit hooks
-# ---------------------------------------------------------------------------
 step "Installing pre-commit hooks"
 
 pre-commit install
 
-# ---------------------------------------------------------------------------
-# SPDX license compliance checker
-# ---------------------------------------------------------------------------
-step "Installing reuse-tool"
+step "Installing reuse-tool for SPDX license compliance"
 
 "${REPO_ROOT}/scripts/install-reuse.sh"
 
-# ---------------------------------------------------------------------------
-# Link checker
-# ---------------------------------------------------------------------------
-step "Installing lychee"
+step "Installing lychee link checker"
 
 # renovate: datasource=github-releases depName=lycheeverse/lychee extractVersion=^lychee-v(?<version>.+)$
 LYCHEE_VERSION="0.24.2"
@@ -62,18 +44,12 @@ curl -fsSL \
   | sudo tar -xz -C /usr/local/bin --strip-components=1 "${LYCHEE_DIR}/lychee"
 sudo chmod +x /usr/local/bin/lychee
 
-# ---------------------------------------------------------------------------
-# Playwright browsers (for the end-to-end suite and the Playwright MCP server)
-# ---------------------------------------------------------------------------
 step "Installing Playwright Chromium and Chrome"
 
 # Through the workspace, so the browsers match the @playwright/test version
-# tools/e2e pins — the one the suite and the CI job run.
+# tools/e2e pins — the one the suite and the CI job run. The Playwright MCP
+# server uses them too.
 pnpm --filter @genshin/e2e exec playwright install --with-deps chromium chrome
-
-# ---------------------------------------------------------------------------
-# Verify and report
-# ---------------------------------------------------------------------------
 
 run_verification
 run_version_summary

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -11,7 +11,7 @@ REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 source "${SCRIPT_DIR}/lib.sh"
 
 # ---------------------------------------------------------------------------
-# 1. Package manager
+# Package manager
 # ---------------------------------------------------------------------------
 step "Installing pnpm via corepack"
 
@@ -19,7 +19,7 @@ corepack enable
 corepack install
 
 # ---------------------------------------------------------------------------
-# 2. Google Cloud SDK
+# Google Cloud SDK
 # ---------------------------------------------------------------------------
 step "Installing Google Cloud SDK"
 
@@ -29,28 +29,28 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get update && \
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y google-cloud-sdk
 
 # ---------------------------------------------------------------------------
-# 3. Project dependencies
+# Project dependencies
 # ---------------------------------------------------------------------------
 step "Installing project dependencies"
 
 pnpm install
 
 # ---------------------------------------------------------------------------
-# 4. Pre-commit hooks
+# Pre-commit hooks
 # ---------------------------------------------------------------------------
 step "Installing pre-commit hooks"
 
 pre-commit install
 
 # ---------------------------------------------------------------------------
-# 5. SPDX license compliance checker
+# SPDX license compliance checker
 # ---------------------------------------------------------------------------
 step "Installing reuse-tool"
 
 "${REPO_ROOT}/scripts/install-reuse.sh"
 
 # ---------------------------------------------------------------------------
-# 6. Link checker
+# Link checker
 # ---------------------------------------------------------------------------
 step "Installing lychee"
 
@@ -63,7 +63,7 @@ curl -fsSL \
 sudo chmod +x /usr/local/bin/lychee
 
 # ---------------------------------------------------------------------------
-# 7. Playwright browsers (for the end-to-end suite and the Playwright MCP server)
+# Playwright browsers (for the end-to-end suite and the Playwright MCP server)
 # ---------------------------------------------------------------------------
 step "Installing Playwright Chromium and Chrome"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,6 @@ jobs:
     env:
       # renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.+)$
       TERRAFORM_VERSION: '1.15.8'
-      # renovate: datasource=github-releases depName=hadolint/hadolint
-      HADOLINT_VERSION: 'v2.15.1'
       # renovate: datasource=github-releases depName=lycheeverse/lychee extractVersion=^lychee-v(?<version>.+)$
       LYCHEE_VERSION: '0.24.2'
       # renovate: datasource=github-releases depName=aquasecurity/trivy extractVersion=^v(?<version>.+)$
@@ -247,14 +245,6 @@ jobs:
           curl -fsSL \
             "${TRIVY_URL}/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
             | sudo tar -xz -C /usr/local/bin trivy
-
-      - name: Install hadolint
-        run: |
-          set -euo pipefail
-          sudo curl -fsSL \
-            "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
-            -o /usr/local/bin/hadolint
-          sudo chmod +x /usr/local/bin/hadolint
 
       # musl, so the binary is static and carries no glibc floor.
       - name: Install lychee

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,8 +94,8 @@ repos:
       - id: zizmor
         args: [--no-progress, --offline]
 
-  # Dockerfile linting. The -docker id carries its own linter; upstream's
-  # plain `hadolint` id expects a binary on PATH, which nothing installs.
+  # Dockerfile linting. Upstream's sibling `hadolint` id expects a binary on
+  # PATH, which nothing installs.
   - repo: https://github.com/hadolint/hadolint
     rev: v2.15.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,8 +94,7 @@ repos:
       - id: zizmor
         args: [--no-progress, --offline]
 
-  # Dockerfile linting. Upstream's sibling `hadolint` id expects a binary on
-  # PATH, which nothing installs.
+  # Dockerfile linting
   - repo: https://github.com/hadolint/hadolint
     rev: v2.15.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,8 +94,8 @@ repos:
       - id: zizmor
         args: [--no-progress, --offline]
 
-  # Dockerfile linting. The Docker-image hook carries its own linter, so
-  # neither CI nor the devcontainer installs a hadolint binary.
+  # Dockerfile linting. The -docker id carries its own linter; upstream's
+  # plain `hadolint` id expects a binary on PATH, which nothing installs.
   - repo: https://github.com/hadolint/hadolint
     rev: v2.15.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,13 @@ repos:
       - id: zizmor
         args: [--no-progress, --offline]
 
+  # Dockerfile linting. The Docker-image hook carries its own linter, so
+  # neither CI nor the devcontainer installs a hadolint binary.
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.15.1
+    hooks:
+      - id: hadolint-docker
+
   # Renovate config validation
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 44.13.1
@@ -142,12 +149,6 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-
-      - id: hadolint
-        name: hadolint
-        entry: hadolint
-        language: system
-        types: [dockerfile]
 
       # Offline resolves on-disk paths and makes no network request, so it
       # gates every commit and every pull request. The weekly external sweep

--- a/renovate.json
+++ b/renovate.json
@@ -41,11 +41,6 @@
       "groupName": "reuse"
     },
     {
-      "description": "Move hadolint in one pull request across the ci.yml pin and the devcontainer bootstrap script",
-      "matchDepNames": ["hadolint/hadolint"],
-      "groupName": "hadolint"
-    },
-    {
       "description": "Move the lychee binary in one pull request across the ci.yml pin and the devcontainer bootstrap script; lycheeverse/lychee-action versions separately and stays out of the group",
       "matchDepNames": ["lycheeverse/lychee"],
       "groupName": "lychee"


### PR DESCRIPTION
## Summary

Dockerfile linting runs from upstream's `hadolint-docker` hook, so neither CI
nor the devcontainer installs a hadolint binary and the two version pins that
had to move together collapse to a single `rev:`. The split-runner workaround
that forced `language: system` went away with #795.

Closes #797

## Gotchas

- Upstream's entry is `ghcr.io/hadolint/hadolint` with no tag, so `rev:` pins
  the hook definition while the linter itself tracks `:latest`. Renovate will
  keep opening `rev:` bumps that don't change which hadolint runs. Called out
  before implementing and accepted.
- Two deletions sit outside the issue's scope list, both because this change
  strands them: the renovate.json hadolint group (a lockstep rule over the two
  pins it names, now one reference), and the numbered section headers in
  `postCreateCommand.sh` (removing a step renumbered two unrelated headers, and
  the issue's own "step 6" now points at the link checker).
- The rest of that script's banners went with them, since each restated the
  `step` call beneath it. Two `step` labels absorb what their banner carried,
  so the devcontainer log lines change wording. `lib.sh` still uses the banner
  style and is left alone.

## Verification

- Inverted `trustedRegistries` in `.hadolint.yaml` and watched DL3026 fire,
  confirming the container still reads repo config rather than silently
  linting with defaults.
- `bash -n` on the rewritten bootstrap; the diff touches only comments and two
  `step` labels, no commands.