### PR TITLE
refactor(bootstrap): replace deployer predefined roles with custom ones

### DIFF
--- a/docs/explanation/dsgep-001-wif-architecture.md
+++ b/docs/explanation/dsgep-001-wif-architecture.md
@@ -175,18 +175,7 @@ This ensures only workflows from this repository can impersonate service account
 
 ### Cross-project permissions
 
-The dev environment has read-only access to core project resources:
-
-```hcl
-# In bootstrap/dev.tf
-resource "google_project_iam_member" "dev_ro_to_core" {
-  project = module.core.project_id
-  role    = "roles/viewer"
-  member  = "serviceAccount:${module.dev.github_deployer_ro_email}"
-}
-```
-
-This lets dev workflows reference core resources like DNS zones without write access.
+The non-core environments read core project resources through `core_cross_project_reader`, a custom role limited to reading DNS zones and record sets. This lets their workflows resolve core resources without write access.
 
 ## Related documents
 

--- a/docs/explanation/dsgep-001-wif-architecture.md
+++ b/docs/explanation/dsgep-001-wif-architecture.md
@@ -175,7 +175,18 @@ This ensures only workflows from this repository can impersonate service account
 
 ### Cross-project permissions
 
-The non-core environments read core project resources through `core_cross_project_reader`, a custom role limited to reading DNS zones and record sets. This lets their workflows resolve core resources without write access.
+The dev environment has read-only access to core project resources:
+
+```hcl
+# In bootstrap/dev.tf
+resource "google_project_iam_member" "dev_ro_to_core" {
+  project = module.core.project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${module.dev.github_deployer_ro_email}"
+}
+```
+
+This lets dev workflows reference core resources like DNS zones without write access.
 
 ## Related documents
 

--- a/infrastructure/terraform/bootstrap/dev.tf
+++ b/infrastructure/terraform/bootstrap/dev.tf
@@ -6,12 +6,12 @@
 module "dev" {
   source = "./modules/project_bootstrap"
 
-  environment        = "dev"
-  project_id         = "dungeon-studio-genshin-dev"
-  project_name       = "DS Genshin Development"
-  billing_account_id = var.billing_account_id
-  state_bucket_name  = data.google_storage_bucket.state.name
-  enable_cloud_run   = true
+  environment                 = "dev"
+  project_id                  = "dungeon-studio-genshin-dev"
+  project_name                = "DS Genshin Development"
+  billing_account_id          = var.billing_account_id
+  state_bucket_name           = data.google_storage_bucket.state.name
+  grant_cloud_run_permissions = true
 
   depends_on = [module.shared, module.core]
 }

--- a/infrastructure/terraform/bootstrap/dev.tf
+++ b/infrastructure/terraform/bootstrap/dev.tf
@@ -11,6 +11,7 @@ module "dev" {
   project_name       = "DS Genshin Development"
   billing_account_id = var.billing_account_id
   state_bucket_name  = data.google_storage_bucket.state.name
+  enable_cloud_run   = true
 
   depends_on = [module.shared, module.core]
 }
@@ -45,15 +46,4 @@ resource "google_project_iam_member" "dev_rw_viewer_core" {
   member  = "serviceAccount:${module.dev.github_deployer_rw_email}"
 
   depends_on = [module.dev, module.core, google_project_iam_custom_role.core_cross_project_reader]
-}
-
-# In-project: Allow dev RW SA to manage Cloud Run service IAM policies.
-# Required for environment Terraform resources such as
-# `google_cloud_run_service_iam_member` in dev.
-resource "google_project_iam_member" "dev_rw_run_admin" {
-  project = module.dev.project_id
-  role    = "roles/run.admin"
-  member  = "serviceAccount:${module.dev.github_deployer_rw_email}"
-
-  depends_on = [module.dev]
 }

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -5,7 +5,6 @@ locals {
   github_deployer_ro_member = "serviceAccount:${google_service_account.github_deployer_ro.email}"
 }
 
-# RO service account
 resource "google_service_account" "github_deployer_ro" {
   project      = google_project.env.project_id
   account_id   = "github-deployer-ro"
@@ -21,11 +20,8 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
   title       = "GitHub Deployer Planner"
   description = "Least-privilege read role for Terraform plan workflows"
 
-  # Keep this list limited to read/refresh permissions required by
-  # `infrastructure/terraform/environments/*` during `terraform plan`.
-  # When adding new environment resources, extend this role only for
-  # plan-time read failures and avoid broad predefined project roles.
-
+  # Scope to what `infrastructure/terraform/environments/*` needs during
+  # `terraform plan`. Extend this list rather than granting a predefined role.
   permissions = [
     "artifactregistry.repositories.get",
     "artifactregistry.repositories.list",

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -26,6 +26,8 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
     "artifactregistry.repositories.get",
     "artifactregistry.repositories.list",
     "datastore.databases.get",
+    # The Firestore Admin API checks getMetadata, not get, on databases.get.
+    "datastore.databases.getMetadata",
     "datastore.databases.list",
     "dns.managedZones.get",
     "dns.managedZones.list",
@@ -62,31 +64,6 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
 resource "google_project_iam_member" "github_deployer_ro_planner" {
   project = google_project.env.project_id
   role    = google_project_iam_custom_role.github_deployer_ro_planner.name
-  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
-}
-
-resource "google_project_iam_member" "github_deployer_ro_sa_viewer" {
-  project = google_project.env.project_id
-  role    = "roles/iam.serviceAccountViewer"
-  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
-}
-
-# Required for Terraform plan refresh of `google_firestore_database`.
-# The equivalent least-privilege custom permission set is currently insufficient
-# for provider read behavior; track tightening in a follow-up issue.
-resource "google_project_iam_member" "github_deployer_ro_datastore_viewer" {
-  project = google_project.env.project_id
-  role    = "roles/datastore.viewer"
-  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
-}
-
-# Required for Terraform plan refresh of `google_firebase_web_app`.
-# The custom role includes `firebase.clients.get` and `firebase.projects.get`,
-# but the google-beta provider requires additional permissions covered by this
-# predefined role; track tightening in a follow-up issue.
-resource "google_project_iam_member" "github_deployer_ro_firebase_viewer" {
-  project = google_project.env.project_id
-  role    = "roles/firebase.viewer"
   member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
 }
 

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_ro.tf
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
+locals {
+  github_deployer_ro_member = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+}
+
 # RO service account
 resource "google_service_account" "github_deployer_ro" {
   project      = google_project.env.project_id
@@ -64,17 +68,17 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
 resource "google_project_iam_member" "github_deployer_ro_planner" {
   project = google_project.env.project_id
   role    = google_project_iam_custom_role.github_deployer_ro_planner.name
-  member  = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+  member  = local.github_deployer_ro_member
 }
 
 resource "google_storage_bucket_iam_member" "github_deployer_ro_state_bucket" {
   bucket = var.state_bucket_name
   role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+  member = local.github_deployer_ro_member
 }
 
 resource "google_storage_bucket_iam_member" "github_deployer_ro_bucket_reader" {
   bucket = var.state_bucket_name
   role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+  member = local.github_deployer_ro_member
 }

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -4,10 +4,8 @@
 locals {
   github_deployer_rw_member = "serviceAccount:${google_service_account.github_deployer_rw.email}"
 
-  # Keep this list scoped to project-level mutate/read permissions needed by
-  # `infrastructure/terraform/environments/*` during `terraform apply`.
-  # Prefer adding narrowly scoped permissions here over granting broad roles
-  # such as `roles/editor`.
+  # Scope to what `infrastructure/terraform/environments/*` needs during
+  # `terraform apply`. Extend this list rather than granting a predefined role.
   github_deployer_rw_permissions = [
     "artifactregistry.repositories.create",
     "artifactregistry.repositories.delete",
@@ -50,9 +48,8 @@ locals {
     "firebasehosting.sites.get",
     "firebasehosting.sites.list",
     "firebasehosting.sites.update",
-    # The deploy workflow acts as the runtime service account when it rolls
-    # out Cloud Run; `roles/run.admin` carries no iam permissions, so actAs
-    # has no other source.
+    # The deploy workflow acts as the runtime service account to roll out
+    # Cloud Run.
     "iam.serviceAccounts.actAs",
     "iam.serviceAccounts.get",
     "iam.serviceAccounts.list",
@@ -86,12 +83,11 @@ locals {
   ]
 
   # Terraform owns the domain mapping and the invoker IAM policy; the deploy
-  # workflow owns the service itself, so both call paths are covered here.
+  # workflow owns the service itself.
   #
-  # `run.domainmappings.*` is absent from `roles/run.admin` and from
-  # `gcloud iam list-testable-permissions`, but is enforced on refresh and is
-  # accepted in a custom role. Neither source you would normally check is
-  # evidence these are unused.
+  # `run.domainmappings.*` appears in neither `roles/run.admin` nor
+  # `gcloud iam list-testable-permissions`, yet domain mapping refresh fails
+  # without it.
   github_deployer_rw_cloud_run_permissions = [
     "run.configurations.get",
     "run.configurations.list",
@@ -117,7 +113,6 @@ locals {
   ]
 }
 
-# RW service account
 resource "google_service_account" "github_deployer_rw" {
   project      = google_project.env.project_id
   account_id   = "github-deployer-rw"

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -1,28 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-# RW service account
-resource "google_service_account" "github_deployer_rw" {
-  project      = google_project.env.project_id
-  account_id   = "github-deployer-rw"
-  display_name = "GitHub Applier"
-  description  = "GitHub Actions service account with write access for deployments"
+locals {
+  github_deployer_rw_member = "serviceAccount:${google_service_account.github_deployer_rw.email}"
 
-  depends_on = [google_project_service.serviceusage]
-}
-
-resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
-  project     = google_project.env.project_id
-  role_id     = "githubDeployerApplier"
-  title       = "GitHub Deployer Applier"
-  description = "Least-privilege base role for Terraform apply workflows"
-
-  # Keep this role scoped to project-level mutate/read permissions needed by
+  # Keep this list scoped to project-level mutate/read permissions needed by
   # `infrastructure/terraform/environments/*` during `terraform apply`.
   # Prefer adding narrowly scoped permissions here over granting broad roles
   # such as `roles/editor`.
-
-  permissions = concat([
+  github_deployer_rw_permissions = [
     "artifactregistry.repositories.create",
     "artifactregistry.repositories.delete",
     "artifactregistry.repositories.downloadArtifacts",
@@ -64,6 +50,9 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "firebasehosting.sites.get",
     "firebasehosting.sites.list",
     "firebasehosting.sites.update",
+    # The deploy workflow acts as the runtime service account when it rolls
+    # out Cloud Run; `roles/run.admin` carries no iam permissions, so actAs
+    # has no other source.
     "iam.serviceAccounts.actAs",
     "iam.serviceAccounts.get",
     "iam.serviceAccounts.list",
@@ -93,13 +82,17 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "storage.objects.delete",
     "storage.objects.get",
     "storage.objects.list",
-    "storage.objects.update"
-    ], var.enable_cloud_run ? [
-    # Terraform owns the domain mapping and the invoker IAM policy; the deploy
-    # workflow owns the service itself, so both call paths are covered here.
-    # `run.domainmappings.*` is absent from `roles/run.admin` and from
-    # `gcloud iam list-testable-permissions`, but is enforced on refresh and is
-    # accepted in a custom role.
+    "storage.objects.update",
+  ]
+
+  # Terraform owns the domain mapping and the invoker IAM policy; the deploy
+  # workflow owns the service itself, so both call paths are covered here.
+  #
+  # `run.domainmappings.*` is absent from `roles/run.admin` and from
+  # `gcloud iam list-testable-permissions`, but is enforced on refresh and is
+  # accepted in a custom role. Neither source you would normally check is
+  # evidence these are unused.
+  github_deployer_rw_cloud_run_permissions = [
     "run.configurations.get",
     "run.configurations.list",
     "run.domainmappings.create",
@@ -121,7 +114,29 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "run.services.list",
     "run.services.setIamPolicy",
     "run.services.update",
-  ] : [])
+  ]
+}
+
+# RW service account
+resource "google_service_account" "github_deployer_rw" {
+  project      = google_project.env.project_id
+  account_id   = "github-deployer-rw"
+  display_name = "GitHub Applier"
+  description  = "GitHub Actions service account with write access for deployments"
+
+  depends_on = [google_project_service.serviceusage]
+}
+
+resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
+  project     = google_project.env.project_id
+  role_id     = "githubDeployerApplier"
+  title       = "GitHub Deployer Applier"
+  description = "Least-privilege role for Terraform apply and deploy workflows"
+
+  permissions = concat(
+    local.github_deployer_rw_permissions,
+    var.grant_cloud_run_permissions ? local.github_deployer_rw_cloud_run_permissions : [],
+  )
 
   depends_on = [google_project_service.serviceusage]
 }
@@ -129,17 +144,17 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
 resource "google_project_iam_member" "github_deployer_rw_applier" {
   project = google_project.env.project_id
   role    = google_project_iam_custom_role.github_deployer_rw_applier.name
-  member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
+  member  = local.github_deployer_rw_member
 }
 
 resource "google_storage_bucket_iam_member" "github_deployer_rw_state_bucket" {
   bucket = var.state_bucket_name
   role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${google_service_account.github_deployer_rw.email}"
+  member = local.github_deployer_rw_member
 }
 
 resource "google_storage_bucket_iam_member" "github_deployer_rw_bucket_reader" {
   bucket = var.state_bucket_name
   role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${google_service_account.github_deployer_rw.email}"
+  member = local.github_deployer_rw_member
 }

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/service_account_github_deployer_rw.tf
@@ -22,7 +22,7 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
   # Prefer adding narrowly scoped permissions here over granting broad roles
   # such as `roles/editor`.
 
-  permissions = [
+  permissions = concat([
     "artifactregistry.repositories.create",
     "artifactregistry.repositories.delete",
     "artifactregistry.repositories.downloadArtifacts",
@@ -30,8 +30,13 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "artifactregistry.repositories.list",
     "artifactregistry.repositories.uploadArtifacts",
     "artifactregistry.repositories.update",
+    "datastore.databases.create",
+    "datastore.databases.delete",
     "datastore.databases.get",
+    # The Firestore Admin API checks getMetadata, not get, on databases.get.
+    "datastore.databases.getMetadata",
     "datastore.databases.list",
+    "datastore.databases.update",
     "dns.changes.create",
     "dns.changes.get",
     "dns.changes.list",
@@ -59,6 +64,9 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "firebasehosting.sites.get",
     "firebasehosting.sites.list",
     "firebasehosting.sites.update",
+    "iam.serviceAccounts.actAs",
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.list",
     "resourcemanager.projects.get",
     "secretmanager.secrets.create",
     "secretmanager.secrets.delete",
@@ -86,7 +94,34 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
     "storage.objects.get",
     "storage.objects.list",
     "storage.objects.update"
-  ]
+    ], var.enable_cloud_run ? [
+    # Terraform owns the domain mapping and the invoker IAM policy; the deploy
+    # workflow owns the service itself, so both call paths are covered here.
+    # `run.domainmappings.*` is absent from `roles/run.admin` and from
+    # `gcloud iam list-testable-permissions`, but is enforced on refresh and is
+    # accepted in a custom role.
+    "run.configurations.get",
+    "run.configurations.list",
+    "run.domainmappings.create",
+    "run.domainmappings.delete",
+    "run.domainmappings.get",
+    "run.domainmappings.list",
+    "run.locations.list",
+    "run.operations.get",
+    "run.revisions.delete",
+    "run.revisions.get",
+    "run.revisions.list",
+    "run.routes.get",
+    # The deploy workflow mints an ID token to probe the service after rollout.
+    "run.routes.invoke",
+    "run.routes.list",
+    "run.services.create",
+    "run.services.get",
+    "run.services.getIamPolicy",
+    "run.services.list",
+    "run.services.setIamPolicy",
+    "run.services.update",
+  ] : [])
 
   depends_on = [google_project_service.serviceusage]
 }
@@ -94,28 +129,6 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
 resource "google_project_iam_member" "github_deployer_rw_applier" {
   project = google_project.env.project_id
   role    = google_project_iam_custom_role.github_deployer_rw_applier.name
-  member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
-}
-
-# Grant permission to create and manage service accounts in this project
-# Needed if environment terraform creates application service accounts
-resource "google_project_iam_member" "github_deployer_rw_sa_admin" {
-  project = google_project.env.project_id
-  role    = "roles/iam.serviceAccountAdmin"
-  member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
-}
-
-# Required for Cloud Run deploy to act as the default Compute Engine SA
-resource "google_project_iam_member" "github_deployer_rw_sa_user" {
-  project = google_project.env.project_id
-  role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
-}
-
-# Required for google_firestore_database (datastore.databases.create)
-resource "google_project_iam_member" "github_deployer_rw_datastore_owner" {
-  project = google_project.env.project_id
-  role    = "roles/datastore.owner"
   member  = "serviceAccount:${google_service_account.github_deployer_rw.email}"
 }
 

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/variables.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/variables.tf
@@ -42,7 +42,7 @@ variable "billing_account_id" {
   }
 }
 
-variable "enable_cloud_run" {
+variable "grant_cloud_run_permissions" {
   type        = bool
   description = "Add Cloud Run permissions to the RW service account's custom role"
   default     = false

--- a/infrastructure/terraform/bootstrap/modules/project_bootstrap/variables.tf
+++ b/infrastructure/terraform/bootstrap/modules/project_bootstrap/variables.tf
@@ -42,6 +42,12 @@ variable "billing_account_id" {
   }
 }
 
+variable "enable_cloud_run" {
+  type        = bool
+  description = "Add Cloud Run permissions to the RW service account's custom role"
+  default     = false
+}
+
 variable "state_bucket_name" {
   type        = string
   description = "Name of the GCS bucket for Terraform state storage"

--- a/infrastructure/terraform/bootstrap/prod.tf
+++ b/infrastructure/terraform/bootstrap/prod.tf
@@ -11,6 +11,7 @@ module "prod" {
   project_name       = "DS Genshin Production"
   billing_account_id = var.billing_account_id
   state_bucket_name  = data.google_storage_bucket.state.name
+  enable_cloud_run   = true
 
   depends_on = [module.shared, module.core]
 }
@@ -45,15 +46,4 @@ resource "google_project_iam_member" "prod_rw_viewer_core" {
   member  = "serviceAccount:${module.prod.github_deployer_rw_email}"
 
   depends_on = [module.prod, module.core, google_project_iam_custom_role.core_cross_project_reader]
-}
-
-# In-project: Allow prod RW SA to manage Cloud Run service IAM policies.
-# Required for environment Terraform resources such as
-# `google_cloud_run_service_iam_member` in prod.
-resource "google_project_iam_member" "prod_rw_run_admin" {
-  project = module.prod.project_id
-  role    = "roles/run.admin"
-  member  = "serviceAccount:${module.prod.github_deployer_rw_email}"
-
-  depends_on = [module.prod]
 }

--- a/infrastructure/terraform/bootstrap/prod.tf
+++ b/infrastructure/terraform/bootstrap/prod.tf
@@ -6,12 +6,12 @@
 module "prod" {
   source = "./modules/project_bootstrap"
 
-  environment        = "production"
-  project_id         = "dungeon-studio-genshin-prod"
-  project_name       = "DS Genshin Production"
-  billing_account_id = var.billing_account_id
-  state_bucket_name  = data.google_storage_bucket.state.name
-  enable_cloud_run   = true
+  environment                 = "production"
+  project_id                  = "dungeon-studio-genshin-prod"
+  project_name                = "DS Genshin Production"
+  billing_account_id          = var.billing_account_id
+  state_bucket_name           = data.google_storage_bucket.state.name
+  grant_cloud_run_permissions = true
 
   depends_on = [module.shared, module.core]
 }

--- a/infrastructure/terraform/bootstrap/staging.tf
+++ b/infrastructure/terraform/bootstrap/staging.tf
@@ -11,6 +11,7 @@ module "staging" {
   project_name       = "DS Genshin Staging"
   billing_account_id = var.billing_account_id
   state_bucket_name  = data.google_storage_bucket.state.name
+  enable_cloud_run   = true
 
   depends_on = [module.shared, module.core]
 }
@@ -45,15 +46,4 @@ resource "google_project_iam_member" "staging_rw_viewer_core" {
   member  = "serviceAccount:${module.staging.github_deployer_rw_email}"
 
   depends_on = [module.staging, module.core, google_project_iam_custom_role.core_cross_project_reader]
-}
-
-# In-project: Allow staging RW SA to manage Cloud Run service IAM policies.
-# Required for environment Terraform resources such as
-# `google_cloud_run_service_iam_member` in staging.
-resource "google_project_iam_member" "staging_rw_run_admin" {
-  project = module.staging.project_id
-  role    = "roles/run.admin"
-  member  = "serviceAccount:${module.staging.github_deployer_rw_email}"
-
-  depends_on = [module.staging]
 }

--- a/infrastructure/terraform/bootstrap/staging.tf
+++ b/infrastructure/terraform/bootstrap/staging.tf
@@ -6,12 +6,12 @@
 module "staging" {
   source = "./modules/project_bootstrap"
 
-  environment        = "staging"
-  project_id         = "dungeon-studio-genshin-staging"
-  project_name       = "DS Genshin Staging"
-  billing_account_id = var.billing_account_id
-  state_bucket_name  = data.google_storage_bucket.state.name
-  enable_cloud_run   = true
+  environment                 = "staging"
+  project_id                  = "dungeon-studio-genshin-staging"
+  project_name                = "DS Genshin Staging"
+  billing_account_id          = var.billing_account_id
+  state_bucket_name           = data.google_storage_bucket.state.name
+  grant_cloud_run_permissions = true
 
   depends_on = [module.shared, module.core]
 }


### PR DESCRIPTION
## Summary

Audits every predefined role on the two deployer service accounts and folds the survivors into the two custom roles. Each was added to unblock a specific plan or apply failure, and each brought far more reach than the failure justified.

| Grant | Was | Now |
| --- | --- | --- |
| `roles/firebase.viewer` → RO | 285 | removed, nothing needed it |
| `roles/datastore.viewer` → RO | 18 | `datastore.databases.getMetadata` |
| `roles/iam.serviceAccountViewer` → RO | 9 | removed, nothing reads SA keys |
| `roles/datastore.owner` → RW | 63 | 6 database lifecycle permissions |
| `roles/iam.serviceAccountAdmin` → RW | 19 | removed, unused |
| `roles/iam.serviceAccountUser` → RW | 5 | `iam.serviceAccounts.actAs` |
| `roles/run.admin` → RW (per-env) | 96 | 20, behind `grant_cloud_run_permissions` |

Nothing turned out to be unmovable, so the issue's "document what can't migrate" criterion comes out empty. Later commits name the permission groups and trim the comments the audit left behind.

## How this was measured

A throwaway service account in each project, holding only the candidate custom role, impersonated for a real `terraform plan` against dev, core, and staging. Probes were deleted afterwards; the deployer accounts were never touched. That covers reads only — everything already exists, so no plan exercises `datastore.databases.create` or `run.services.update`. For those and the deploy path I confirmed permission presence via `testIamPermissions`, including `actAs` on the runtime compute account.

`roles/firebase.viewer` deserves a second opinion: #459 added it in March for a `google_firebase_web_app` refresh 403 that no longer reproduces.

## Gotchas

`run.domainmappings.*` appears in neither `roles/run.admin` nor `gcloud iam list-testable-permissions`, yet domain mapping refresh 403s without it. Dropping those four would break dev apply with no warning from either source you would normally check.

Applying is one `terraform apply` — 10 role updates, 33 binding removals, no ordering guarantee between them, and propagation ran 60–90s in testing. Best applied when no CI terraform or deploy run is in flight. Bootstrap has no CI plan, since `terraform-plan.yml` only triggers on `environments/**`, so nothing exercises this before merge.

## Status

Parked pending #1193, which adds a `just` recipe for planning the bootstrap layer. Bootstrap has no CI path, so today verifying this diff means re-deriving the invocation by hand — including the undocumented `TF_VAR_billing_account_id`. #458 is marked blocked by it.

Ready to review on the substance; hold the apply until there is a repeatable plan command.

Closes #458

The audit also surfaced a stale cross-project example in DSGEP-001, filed as #1192 rather than amended here.
