### PR TITLE
ci: gate the API image OCI labels on the published manifest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,32 +167,11 @@ jobs:
           printf '%s\n' "$IMAGE_TAGS"
           echo "Deploy image URI: $IMAGE_URI"
 
-      # Provenance labels are applied by BuildKit from the metadata step above,
-      # not by LABEL instructions, because a build-time --label overrides any
-      # LABEL of the same key. That puts them beyond the reach of a Dockerfile
-      # linter, so the published manifest is the only place they can be gated.
-      # Revision is compared rather than merely present: a label set that
-      # survives while pointing at the wrong commit is the failure that matters,
-      # since every consumer downstream reads it as this image's provenance.
       - name: Verify Image Labels
         env:
           IMAGE_URI: ${{ steps.image.outputs.image_uri }}
           EXPECTED_REVISION: ${{ github.sha }}
-        run: |
-          docker buildx imagetools inspect "$IMAGE_URI" \
-            --format '{{json .Image.Config.Labels}}' \
-            | jq -e --arg revision "$EXPECTED_REVISION" '
-                . as $labels
-                | $labels["org.opencontainers.image.revision"] as $actual
-                | ["source", "revision", "created", "licenses", "title", "description", "url"]
-                | map("org.opencontainers.image." + .)
-                | map(select(($labels[.] // "") == ""))
-                | if length > 0 then
-                    "image is missing OCI labels: \(join(", "))" | halt_error(1)
-                  elif $actual != $revision then
-                    "image revision \($actual) does not match \($revision)" | halt_error(1)
-                  else true end
-              ' > /dev/null
+        run: bash apps/api/scripts/verify-image-labels.sh "$IMAGE_URI" "$EXPECTED_REVISION"
 
       # Service lifecycle is intentionally CI-managed for fast app rollouts.
       # Terraform in dev manages supporting infra (APIs, Artifact Registry,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,6 +132,13 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha,prefix={{branch}}-,format=short
+          # The remaining OCI labels default to repository metadata, which is
+          # correct for source, revision, created, licenses, and url. Title and
+          # description are not: they default to naming the whole product, and
+          # this image is one service within it.
+          labels: |
+            org.opencontainers.image.title=genshin-api
+            org.opencontainers.image.description=HTTP API for genshin.dungeon.studio
 
       - name: Build & Push Image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -159,6 +166,33 @@ jobs:
           echo "Published image tags:"
           printf '%s\n' "$IMAGE_TAGS"
           echo "Deploy image URI: $IMAGE_URI"
+
+      # Provenance labels are applied by BuildKit from the metadata step above,
+      # not by LABEL instructions, because a build-time --label overrides any
+      # LABEL of the same key. That puts them beyond the reach of a Dockerfile
+      # linter, so the published manifest is the only place they can be gated.
+      # Revision is compared rather than merely present: a label set that
+      # survives while pointing at the wrong commit is the failure that matters,
+      # since every consumer downstream reads it as this image's provenance.
+      - name: Verify Image Labels
+        env:
+          IMAGE_URI: ${{ steps.image.outputs.image_uri }}
+          EXPECTED_REVISION: ${{ github.sha }}
+        run: |
+          docker buildx imagetools inspect "$IMAGE_URI" \
+            --format '{{json .Image.Config.Labels}}' \
+            | jq -e --arg revision "$EXPECTED_REVISION" '
+                . as $labels
+                | $labels["org.opencontainers.image.revision"] as $actual
+                | ["source", "revision", "created", "licenses", "title", "description", "url"]
+                | map("org.opencontainers.image." + .)
+                | map(select(($labels[.] // "") == ""))
+                | if length > 0 then
+                    "image is missing OCI labels: \(join(", "))" | halt_error(1)
+                  elif $actual != $revision then
+                    "image revision \($actual) does not match \($revision)" | halt_error(1)
+                  else true end
+              ' > /dev/null
 
       # Service lifecycle is intentionally CI-managed for fast app rollouts.
       # Terraform in dev manages supporting infra (APIs, Artifact Registry,

--- a/apps/api/scripts/verify-image-labels.sh
+++ b/apps/api/scripts/verify-image-labels.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Assert that a pushed image carries the OCI provenance labels, and that its
+# recorded revision is the commit it was built from.
+#
+# The labels are applied by BuildKit from docker/metadata-action rather than by
+# LABEL instructions, because a build-time --label overrides any LABEL of the
+# same key. That puts them beyond the reach of a Dockerfile linter, leaving the
+# published manifest as the only place they can be checked.
+
+set -euo pipefail
+
+IMAGE_URI="${1:?Error: image URI is required as first argument}"
+EXPECTED_REVISION="${2:?Error: expected revision is required as second argument}"
+
+REQUIRED_LABELS=(source revision created licenses title description url)
+
+LABELS=$(docker buildx imagetools inspect "$IMAGE_URI" --format '{{json .Image.Config.Labels}}')
+
+MISSING=$(jq -r --args '
+  . as $labels
+  | $ARGS.positional
+  | map("org.opencontainers.image." + .)
+  | map(select(($labels[.] // "") == ""))
+  | join(", ")
+' "${REQUIRED_LABELS[@]}" <<< "$LABELS")
+
+[ -z "$MISSING" ] || { echo "missing OCI labels: $MISSING" >&2; exit 1; }
+
+REVISION=$(jq -r '.["org.opencontainers.image.revision"]' <<< "$LABELS")
+
+# A complete label set pointing at the wrong commit is the failure that
+# matters, since consumers read this as the image's provenance.
+[ "$REVISION" = "$EXPECTED_REVISION" ] || {
+  echo "revision mismatch: image=$REVISION expected=$EXPECTED_REVISION" >&2
+  exit 1
+}


### PR DESCRIPTION
## Summary

#799 asked for OCI labels on the API image, enforced by hadolint. The
image already has them — `docker/metadata-action` has emitted the full
set since #289 — so this adds the part that was actually missing: a
check that stops them from silently disappearing, plus a fix for the two
labels that name the whole product rather than this service.

`apps/api/scripts/verify-image-labels.sh` reads the published manifest
between the build and the deploy, and compares `revision` against the
triggering commit instead of only requiring it to be present.

## Gotchas

hadolint cannot do this job, which is why the issue's original scope was
dropped. BuildKit's `--label` overrides a `LABEL` of the same key, so the
Dockerfile cannot be the source of truth for labels the build injects,
and hadolint cannot see the workflow that supplies them. It also cannot
validate `revision` or `created`, because it does not resolve `ARG`s —
the issue's proposed `LABEL …revision="${GIT_REVISION}"` fails its own
`label-schema` with DL3055. I rewrote the issue body to match.

`url` deliberately stays on the repository default rather than becoming
a homepage: dev is the only deployed environment (#782), and an
environment-specific URL would bake the wrong value into an image meant
to be promoted.

The check takes its arguments through `env:` rather than interpolating
`${{ }}` into `run:`, which zizmor flags as template injection.

## Verification

Ran the script against a local registry with buildx-pushed images.
Passes on a complete label set, exits 1 naming the absent keys when
labels are dropped, exits 1 on a revision mismatch, and rejects missing
arguments. Also confirmed `imagetools inspect --format '{{json
.Image.Config.Labels}}'` returns a flat map rather than a platform-keyed
one despite the default provenance attestation making the push an OCI
index.

Closes #799
