### PR TITLE
ci: inline pre-commit run to drop unpinned action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,16 +258,14 @@ jobs:
             "${LYCHEE_URL}/lychee-v${LYCHEE_VERSION}/${LYCHEE_DIR}.tar.gz" \
             | sudo tar -xz -C /usr/local/bin --strip-components=1 "${LYCHEE_DIR}/lychee"
 
-      # Inlined rather than pre-commit/action, whose composite steps reference
-      # actions/cache by floating tag. The org policy requiring full-length SHA
-      # pins rejects that, and upstream has declined every pin request
-      # (pre-commit/action#230).
+      # Not pre-commit/action: its composite steps float actions/cache to a
+      # tag, which the org SHA-pin policy rejects, and upstream declines to
+      # pin (pre-commit/action#230).
       - name: Install pre-commit
         run: python -m pip install "pre-commit==${PRE_COMMIT_VERSION}"
 
-      # pre-commit health-checks a hook environment and rebuilds it when the
-      # interpreter no longer matches, so the key needs no Python component. It
-      # makes no such promise across its own store layout, hence the version.
+      # pre-commit promises nothing across changes to its own store layout,
+      # so a version bump has to miss the cache.
       - name: Cache pre-commit environments
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,16 +256,29 @@ jobs:
             "${LYCHEE_URL}/lychee-v${LYCHEE_VERSION}/${LYCHEE_DIR}.tar.gz" \
             | sudo tar -xz -C /usr/local/bin --strip-components=1 "${LYCHEE_DIR}/lychee"
 
+      # Inlined rather than pre-commit/action, whose composite steps reference
+      # actions/cache by floating tag. The org policy requiring full-length SHA
+      # pins rejects that, and upstream has declined every pin request
+      # (pre-commit/action#230).
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      # pre-commit health-checks a hook environment and rebuilds it when the
+      # interpreter no longer matches, so the key needs no Python component.
+      - name: Cache pre-commit environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: Run hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
         env:
           TRIVY_CONFIG: ${{ github.workspace }}/.trivy.yaml
           # no-commit-to-branch guards local commits against develop and main,
           # and a push-event checkout is attached to the very branch it guards,
           # so it would fail every merge.
           SKIP: no-commit-to-branch
-        with:
-          extra_args: --all-files
 
   # Verified-mode secret scanning: TruffleHog confirms a detected credential is
   # live before failing, so this gate is high-signal and needs no allowlist.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,8 @@ jobs:
       LYCHEE_VERSION: '0.24.2'
       # renovate: datasource=github-releases depName=aquasecurity/trivy extractVersion=^v(?<version>.+)$
       TRIVY_VERSION: '0.73.0'
+      # renovate: datasource=pypi depName=pre-commit
+      PRE_COMMIT_VERSION: '4.6.1'
 
     steps:
       - name: Checkout repository
@@ -261,15 +263,16 @@ jobs:
       # pins rejects that, and upstream has declined every pin request
       # (pre-commit/action#230).
       - name: Install pre-commit
-        run: python -m pip install pre-commit
+        run: python -m pip install "pre-commit==${PRE_COMMIT_VERSION}"
 
       # pre-commit health-checks a hook environment and rebuilds it when the
-      # interpreter no longer matches, so the key needs no Python component.
+      # interpreter no longer matches, so the key needs no Python component. It
+      # makes no such promise across its own store layout, hence the version.
       - name: Cache pre-commit environments
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ runner.os }}-pre-commit-${{ env.PRE_COMMIT_VERSION }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run hooks
         run: pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
Closed unmerged. Enabling SHA-pin enforcement is org state, so it moved to
[dungeon-studio-infrastructure#10](https://github.com/dungeon-studio/dungeon-studio-infrastructure/issues/10)
and #816 closed won't-do. This compliance work goes with it.

What it did, for whoever picks the thread up there: `pre-commit/action` is
a composite action whose steps float `actions/cache` to a tag. Our
reference to it was correctly SHA-pinned — the policy evaluates
transitively, so the violation sat one level down in a repository we do
not control. This inlined the action's three steps, which also dropped a
third-party dependency and let pre-commit's own version be pinned and
Renovate-tracked alongside the terraform, lychee, and trivy pins the same
job already carried.

It was green on every check, including `Run pre-commit hooks`. The
approach works; it is being closed on ownership grounds, not on merit, so
the diff is worth reading rather than rederiving when the org property
lands.

The audit behind it is recorded on the infrastructure issue: 26 pinned
references in this repo, one offender, and upstream has closed six pin
requests so a fork or an inline is the only way out.

Refs #816