### PR TITLE
feat(web): add jsx-a11y lint via maintained fork

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -3,7 +3,7 @@
 
 import eslintReact from '@eslint-react/eslint-plugin';
 import genshinConfig from '@genshin/eslint-config';
-import jsxA11y from 'eslint-plugin-jsx-a11y-x';
+import jsxA11yX from 'eslint-plugin-jsx-a11y-x';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
@@ -14,8 +14,6 @@ const TEST_FILES = ['**/*.{test,spec}.{ts,tsx}', 'src/test/**/*.{ts,tsx}'];
 const SHADCN_SCAFFOLDS = ['src/components/ui/**/*.{ts,tsx}'];
 
 const eslintReactRecommended = eslintReact.configs['recommended-typescript'];
-
-const jsxA11yRecommended = jsxA11y.configs.recommended;
 
 /**
  * Both plugins implement these. `eslint-plugin-react-hooks` is first-party and
@@ -84,7 +82,7 @@ export default [
     // and peers at ESLint 9. This fork tracks it rule-for-rule under a
     // `jsx-a11y-x/` namespace and declares ESLint 10.
     files: TS_FILES,
-    ...jsxA11yRecommended,
+    ...jsxA11yX.configs.recommended,
   },
   {
     files: TS_FILES,

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -3,6 +3,7 @@
 
 import eslintReact from '@eslint-react/eslint-plugin';
 import genshinConfig from '@genshin/eslint-config';
+import jsxA11y from 'eslint-plugin-jsx-a11y-x';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
@@ -13,6 +14,8 @@ const TEST_FILES = ['**/*.{test,spec}.{ts,tsx}', 'src/test/**/*.{ts,tsx}'];
 const SHADCN_SCAFFOLDS = ['src/components/ui/**/*.{ts,tsx}'];
 
 const eslintReactRecommended = eslintReact.configs['recommended-typescript'];
+
+const jsxA11yRecommended = jsxA11y.configs.recommended;
 
 /**
  * Both plugins implement these. `eslint-plugin-react-hooks` is first-party and
@@ -77,6 +80,13 @@ export default [
     },
   },
   {
+    // The canonical `eslint-plugin-jsx-a11y` has shipped nothing since 2024-10
+    // and peers at ESLint 9. This fork tracks it rule-for-rule under a
+    // `jsx-a11y-x/` namespace and declares ESLint 10.
+    files: TS_FILES,
+    ...jsxA11yRecommended,
+  },
+  {
     files: TS_FILES,
     rules: {
       '@typescript-eslint/naming-convention': [
@@ -94,6 +104,9 @@ export default [
     files: SHADCN_SCAFFOLDS,
     rules: {
       'react/function-component-definition': 'off',
+      // `CardTitle` forwards children into its `<h3>` through a props spread,
+      // so the heading's content is only knowable at the call site.
+      'jsx-a11y-x/heading-has-content': 'off',
     },
   },
   {

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -78,9 +78,6 @@ export default [
     },
   },
   {
-    // The canonical `eslint-plugin-jsx-a11y` has shipped nothing since 2024-10
-    // and peers at ESLint 9. This fork tracks it rule-for-rule under a
-    // `jsx-a11y-x/` namespace and declares ESLint 10.
     files: TS_FILES,
     ...jsxA11yX.configs.recommended,
   },
@@ -102,8 +99,7 @@ export default [
     files: SHADCN_SCAFFOLDS,
     rules: {
       'react/function-component-definition': 'off',
-      // `CardTitle` forwards children into its `<h3>` through a props spread,
-      // so the heading's content is only knowable at the call site.
+      // `CardTitle` spreads children into its `<h3>`, so content lives at the call site.
       'jsx-a11y-x/heading-has-content': 'off',
     },
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "@vitejs/plugin-react": "6.0.5",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.0",
+    "eslint-plugin-jsx-a11y-x": "0.2.0",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.3",

--- a/apps/web/src/components/ui/themed-icon.tsx
+++ b/apps/web/src/components/ui/themed-icon.tsx
@@ -18,8 +18,7 @@ interface ThemedIconProps {
 export function ThemedIcon({ lightSrc, darkSrc, alt, className }: ThemedIconProps): JSX.Element {
   const decorative = alt === '';
 
-  // `alt` stays an explicit attribute below rather than joining this object;
-  // static a11y checks cannot resolve it through a spread.
+  // `alt` stays explicit below; a11y lint cannot resolve it through a spread.
   const shared = {
     'aria-hidden': decorative || undefined,
     loading: 'lazy',

--- a/apps/web/src/components/ui/themed-icon.tsx
+++ b/apps/web/src/components/ui/themed-icon.tsx
@@ -18,8 +18,9 @@ interface ThemedIconProps {
 export function ThemedIcon({ lightSrc, darkSrc, alt, className }: ThemedIconProps): JSX.Element {
   const decorative = alt === '';
 
+  // `alt` stays an explicit attribute below rather than joining this object;
+  // static a11y checks cannot resolve it through a spread.
   const shared = {
-    alt,
     'aria-hidden': decorative || undefined,
     loading: 'lazy',
     decoding: 'async',
@@ -29,8 +30,8 @@ export function ThemedIcon({ lightSrc, darkSrc, alt, className }: ThemedIconProp
   // each variant's `dark:` utility trails to win the theme-active conflict.
   return (
     <>
-      <img {...shared} src={lightSrc} className={cn(className, 'dark:hidden')} />
-      <img {...shared} src={darkSrc} className={cn('hidden', className, 'dark:block')} />
+      <img {...shared} alt={alt} src={lightSrc} className={cn(className, 'dark:hidden')} />
+      <img {...shared} alt={alt} src={darkSrc} className={cn('hidden', className, 'dark:block')} />
     </>
   );
 }

--- a/apps/web/src/components/ui/themed-icon.tsx
+++ b/apps/web/src/components/ui/themed-icon.tsx
@@ -18,7 +18,7 @@ interface ThemedIconProps {
 export function ThemedIcon({ lightSrc, darkSrc, alt, className }: ThemedIconProps): JSX.Element {
   const decorative = alt === '';
 
-  // `alt` stays explicit below; a11y lint cannot resolve it through a spread.
+  // a11y lint cannot resolve `alt` through a spread.
   const shared = {
     'aria-hidden': decorative || undefined,
     loading: 'lazy',

--- a/apps/web/src/features/teams/artifact-planner/artifact-set-search.tsx
+++ b/apps/web/src/features/teams/artifact-planner/artifact-set-search.tsx
@@ -38,6 +38,9 @@ export function ArtifactSetSearch({
         <PopoverTrigger asChild>
           <button
             type="button"
+            // Radix clones the `asChild` trigger with `aria-controls` pointing
+            // at the popover content, which no static check can see.
+            // eslint-disable-next-line jsx-a11y-x/role-has-required-aria-props
             role="combobox"
             aria-expanded={open}
             aria-label={label}

--- a/apps/web/src/features/teams/artifact-planner/artifact-set-search.tsx
+++ b/apps/web/src/features/teams/artifact-planner/artifact-set-search.tsx
@@ -38,8 +38,7 @@ export function ArtifactSetSearch({
         <PopoverTrigger asChild>
           <button
             type="button"
-            // Radix clones the `asChild` trigger with `aria-controls` pointing
-            // at the popover content, which no static check can see.
+            // Radix adds `aria-controls` to the `asChild` trigger at runtime.
             // eslint-disable-next-line jsx-a11y-x/role-has-required-aria-props
             role="combobox"
             aria-expanded={open}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       eslint:
         specifier: 10.8.0
         version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-plugin-jsx-a11y-x:
+        specifier: 0.2.0
+        version: 0.2.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-react:
         specifier: 7.37.5
         version: 7.37.5(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
@@ -2927,6 +2930,14 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
@@ -3353,6 +3364,9 @@ packages:
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -3634,6 +3648,12 @@ packages:
         optional: true
       eslint-import-resolver-node:
         optional: true
+
+  eslint-plugin-jsx-a11y-x@0.2.0:
+    resolution: {integrity: sha512-O/VpKt2G38VCMlBgGCH8eJGWXM05z892zGKeuPfPATMPLDZOWeVtKS8SBt98ElaeFRKcJEv2bELub+Llo3m9zw==}
+    engines: {node: ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-dom@5.18.3:
     resolution: {integrity: sha512-iGZys8sreyijVkaWG41HBugjgduh4kSOu4Jyk2wLOjo7Ssn9hga2B6LOLoAP63IoFnHWs9TDVv7Tb0zEupvcSQ==}
@@ -4673,6 +4693,10 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jsx-ast-utils-x@0.1.0:
+    resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -4704,6 +4728,13 @@ packages:
 
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -9185,6 +9216,10 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  axe-core@4.13.0: {}
+
+  axobject-query@4.1.0: {}
+
   b4a@1.8.1: {}
 
   balanced-match@1.0.2: {}
@@ -9618,6 +9653,8 @@ snapshots:
 
   csv-parse@5.6.0: {}
 
+  damerau-levenshtein@1.0.8: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -9975,6 +10012,17 @@ snapshots:
       '@typescript-eslint/utils': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-jsx-a11y-x@0.2.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2)):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.13.0
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      jsx-ast-utils-x: 0.1.0
+      language-tags: 1.0.9
+      minimatch: 10.2.6
 
   eslint-plugin-react-dom@5.18.3(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
@@ -11428,6 +11476,8 @@ snapshots:
       ms: 2.1.3
       semver: 7.8.5
 
+  jsx-ast-utils-x@0.1.0: {}
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -11484,6 +11534,12 @@ snapshots:
       zod: 4.4.3
 
   kuler@2.0.0: {}
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   lazystream@1.0.1:
     dependencies:


### PR DESCRIPTION
Closes #813.

The issue's plan was to wait for `eslint-plugin-jsx-a11y` to declare ESLint 10 support. That wait looks open-ended: no release since 2024-10-26, `main` last pushed 2026-01-06, and the two community ESLint 10 pull requests ([#1079](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/1079), [#1081](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/1081)) have been open since February with no maintainer response on [#1075](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/1075). So this replaces the plugin instead of waiting for it, the same call #803 made.

`eslint-plugin-jsx-a11y-x` (es-tooling) ships all 36 rules under a `jsx-a11y-x/` namespace and peers `^9 || ^10`. The alternative considered was oxlint, which implements 29 of the rules and would mean a second linter runner and config file a week after #1196 standardized web on ESLint flat config.

## Gotchas

The Radix disable in `artifact-set-search.tsx` is a real blind spot, not a papered-over bug: `@radix-ui/react-popover@1.1.23` `dist/index.mjs:90-92` clones the `asChild` trigger with `aria-controls` when open, so the attribute the rule wants exists at runtime and cannot exist in the source.

`heading-has-content` goes off for all of `src/components/ui/`, which includes `themed-icon.tsx` — ours, not a vendored scaffold. No loss today since it renders no headings, but the glob doesn't distinguish. `alt-text` was deliberately left on there for the same reason.

None of these rules gate anything yet. The `eslint` pre-commit hook still matches zero files (#888), so they only run under `turbo run lint`.
