### PR TITLE
refactor(lint): modernise flat configs and hash the shared base

### DIFF
--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import genshinConfig from '@genshin/eslint-config';
+import genshinConfig, { TYPESCRIPT_FILES } from '@genshin/eslint-config';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 
 export default defineConfig([
   genshinConfig(import.meta.dirname),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: TYPESCRIPT_FILES,
     languageOptions: {
       ecmaVersion: 2022,
       globals: globals.node,

--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import genshinConfig from '@genshin/eslint-config';
+import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 
-export default [
-  ...genshinConfig(import.meta.dirname),
+export default defineConfig([
+  genshinConfig(import.meta.dirname),
   {
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
@@ -13,4 +14,4 @@ export default [
       globals: globals.node,
     },
   },
-];
+]);

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -13,9 +13,9 @@ const TEST_FILES = ['**/*.{test,spec}.{ts,tsx}', 'src/test/**/*.{ts,tsx}'];
 const SHADCN_SCAFFOLDS = ['src/components/ui/**/*.{ts,tsx}'];
 
 /**
- * Both plugins implement these. `eslint-plugin-react-hooks` is first-party and
- * compiler-backed, so it keeps them; enabling both reports every hook violation
- * twice.
+ * `@eslint-react` and `eslint-plugin-react-hooks` both implement these.
+ * react-hooks is first-party and compiler-backed, so it keeps them; enabling
+ * both reports every hook violation twice.
  */
 const RULES_OWNED_BY_REACT_HOOKS = {
   '@eslint-react/error-boundaries': 'off',
@@ -29,9 +29,8 @@ const RULES_OWNED_BY_REACT_HOOKS = {
   '@eslint-react/use-memo': 'off',
 };
 
-// Scoping every block to `TYPESCRIPT_FILES` is deliberate, not leftover: this
-// workspace also lints `eslint.config.js`, `postcss.config.js`, and
-// `tailwind.config.js`, which none of the rules below apply to.
+// Rules here scope to `TYPESCRIPT_FILES` because this workspace also lints
+// plain-JavaScript config files, which none of them apply to.
 export default defineConfig([
   genshinConfig(import.meta.dirname),
   {
@@ -72,10 +71,10 @@ export default defineConfig([
     },
   },
   {
-    // `@eslint-react` takes no position on declaration syntax, so
-    // `function-component-definition` has no counterpart. The version pin
-    // avoids a `detect` path that calls an API ESLint 10 removed. Registered by
-    // hand because this plugin's only flat preset turns on 22 other rules.
+    // `@eslint-react` has no counterpart for `function-component-definition`,
+    // which is the only reason this plugin is here. Registered by hand because
+    // its flat preset would enable the whole recommended set, and the React
+    // version is set because `detect` calls an API ESLint 10 removed.
     files: TYPESCRIPT_FILES,
     plugins: { react },
     settings: { react: { version: '19' } },

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -3,6 +3,7 @@
 
 import eslintReact from '@eslint-react/eslint-plugin';
 import genshinConfig from '@genshin/eslint-config';
+import { defineConfig } from 'eslint/config';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
@@ -11,8 +12,6 @@ import globals from 'globals';
 const TS_FILES = ['**/*.{ts,tsx}'];
 const TEST_FILES = ['**/*.{test,spec}.{ts,tsx}', 'src/test/**/*.{ts,tsx}'];
 const SHADCN_SCAFFOLDS = ['src/components/ui/**/*.{ts,tsx}'];
-
-const eslintReactRecommended = eslintReact.configs['recommended-typescript'];
 
 /**
  * Both plugins implement these. `eslint-plugin-react-hooks` is first-party and
@@ -31,54 +30,28 @@ const RULES_OWNED_BY_REACT_HOOKS = {
   '@eslint-react/use-memo': 'off',
 };
 
-export default [
-  ...genshinConfig(import.meta.dirname),
+export default defineConfig([
+  genshinConfig(import.meta.dirname),
   {
+    // The glob is not redundant: `postcss.config.js` and `tailwind.config.js`
+    // are linted too, and the React rules have nothing to say about them.
     files: TS_FILES,
+    extends: [
+      eslintReact.configs['recommended-typescript'],
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
-  },
-  {
-    files: TS_FILES,
-    ...eslintReactRecommended,
     rules: {
-      ...eslintReactRecommended.rules,
       // Wants every `useRef` result named `*Ref`; ours hold mutable instance
       // state rather than element handles.
       '@eslint-react/naming-convention-ref-name': 'off',
-    },
-  },
-  {
-    files: TS_FILES,
-    plugins: { 'react-hooks': reactHooks },
-    rules: {
-      ...reactHooks.configs.recommended.rules,
       ...RULES_OWNED_BY_REACT_HOOKS,
-    },
-  },
-  {
-    // `@eslint-react` takes no position on declaration syntax, so
-    // `function-component-definition` has no counterpart. The version pin
-    // avoids a `detect` path that calls an API ESLint 10 removed.
-    files: TS_FILES,
-    plugins: { react },
-    settings: { react: { version: '19' } },
-    rules: {
-      'react/function-component-definition': ['error', { namedComponents: 'function-declaration' }],
-    },
-  },
-  {
-    files: TS_FILES,
-    plugins: { 'react-refresh': reactRefresh },
-    rules: {
+      // The Vite preset errors; a missed fast refresh costs a manual reload.
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-    },
-  },
-  {
-    files: TS_FILES,
-    rules: {
       '@typescript-eslint/naming-convention': [
         'error',
         {
@@ -91,6 +64,20 @@ export default [
     },
   },
   {
+    // `@eslint-react` takes no position on declaration syntax, so
+    // `function-component-definition` has no counterpart. The version pin
+    // avoids a `detect` path that calls an API ESLint 10 removed. Registered by
+    // hand because this plugin's only flat preset turns on 22 other rules.
+    files: TS_FILES,
+    plugins: { react },
+    settings: { react: { version: '19' } },
+    rules: {
+      'react/function-component-definition': ['error', { namedComponents: 'function-declaration' }],
+    },
+  },
+  {
+    // Upstream shadcn scaffolds are `const X = React.forwardRef(...)`, not
+    // function declarations; rewriting them would fight every regeneration.
     files: SHADCN_SCAFFOLDS,
     rules: {
       'react/function-component-definition': 'off',
@@ -104,4 +91,4 @@ export default [
       '@eslint-react/no-nested-component-definitions': 'off',
     },
   },
-];
+]);

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -58,8 +58,8 @@ export default defineConfig([
     },
   },
   {
-    // Kept out of the `extends` list above: this preset carries its own
-    // `languageOptions`, which would then resolve ahead of this workspace's.
+    // This preset brings its own `languageOptions`, which inside the `extends`
+    // list above would take precedence over this workspace's.
     files: TYPESCRIPT_FILES,
     extends: [jsxA11yX.configs.recommended],
   },
@@ -79,11 +79,12 @@ export default defineConfig([
   },
   {
     // `@eslint-react` has no counterpart for `function-component-definition`,
-    // which is the only reason this plugin is here. Registered by hand because
-    // its flat preset would enable the whole recommended set, and the React
-    // version is set because `detect` calls an API ESLint 10 removed.
+    // the only reason this plugin is here.
     files: TYPESCRIPT_FILES,
+    // Hand-registered because this plugin's flat preset would enable its whole
+    // recommended set.
     plugins: { react },
+    // Pinned because `detect` calls an API ESLint 10 removed.
     settings: { react: { version: '19' } },
     rules: {
       'react/function-component-definition': ['error', { namedComponents: 'function-declaration' }],

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -58,6 +58,8 @@ export default defineConfig([
     },
   },
   {
+    // Kept out of the `extends` list above: this preset carries its own
+    // `languageOptions`, which would then resolve ahead of this workspace's.
     files: TYPESCRIPT_FILES,
     extends: [jsxA11yX.configs.recommended],
   },
@@ -88,10 +90,10 @@ export default defineConfig([
     },
   },
   {
-    // Upstream shadcn scaffolds are `const X = React.forwardRef(...)`, not
-    // function declarations; rewriting them would fight every regeneration.
     files: SHADCN_SCAFFOLDS,
     rules: {
+      // Upstream scaffolds are `const X = React.forwardRef(...)`, not function
+      // declarations; rewriting them would fight every regeneration.
       'react/function-component-definition': 'off',
       // `CardTitle` spreads children into its `<h3>`, so content lives at the call site.
       'jsx-a11y-x/heading-has-content': 'off',

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import eslintReact from '@eslint-react/eslint-plugin';
-import genshinConfig from '@genshin/eslint-config';
+import genshinConfig, { TYPESCRIPT_FILES } from '@genshin/eslint-config';
 import { defineConfig } from 'eslint/config';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
 
-const TS_FILES = ['**/*.{ts,tsx}'];
 const TEST_FILES = ['**/*.{test,spec}.{ts,tsx}', 'src/test/**/*.{ts,tsx}'];
 const SHADCN_SCAFFOLDS = ['src/components/ui/**/*.{ts,tsx}'];
 
@@ -30,21 +29,25 @@ const RULES_OWNED_BY_REACT_HOOKS = {
   '@eslint-react/use-memo': 'off',
 };
 
+// Scoping every block to `TYPESCRIPT_FILES` is deliberate, not leftover: this
+// workspace also lints `eslint.config.js`, `postcss.config.js`, and
+// `tailwind.config.js`, which none of the rules below apply to.
 export default defineConfig([
   genshinConfig(import.meta.dirname),
   {
-    // The glob is not redundant: `postcss.config.js` and `tailwind.config.js`
-    // are linted too, and the React rules have nothing to say about them.
-    files: TS_FILES,
+    files: TYPESCRIPT_FILES,
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+  {
+    files: TYPESCRIPT_FILES,
     extends: [
       eslintReact.configs['recommended-typescript'],
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
-    languageOptions: {
-      ecmaVersion: 2020,
-      globals: globals.browser,
-    },
     rules: {
       // Wants every `useRef` result named `*Ref`; ours hold mutable instance
       // state rather than element handles.
@@ -52,6 +55,11 @@ export default defineConfig([
       ...RULES_OWNED_BY_REACT_HOOKS,
       // The Vite preset errors; a missed fast refresh costs a manual reload.
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  {
+    files: TYPESCRIPT_FILES,
+    rules: {
       '@typescript-eslint/naming-convention': [
         'error',
         {
@@ -68,7 +76,7 @@ export default defineConfig([
     // `function-component-definition` has no counterpart. The version pin
     // avoids a `detect` path that calls an API ESLint 10 removed. Registered by
     // hand because this plugin's only flat preset turns on 22 other rules.
-    files: TS_FILES,
+    files: TYPESCRIPT_FILES,
     plugins: { react },
     settings: { react: { version: '19' } },
     rules: {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -4,10 +4,14 @@
 import { resolve } from 'node:path';
 
 import js from '@eslint/js';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
 import importX from 'eslint-plugin-import-x';
 import unusedImports from 'eslint-plugin-unused-imports';
 import tseslint from 'typescript-eslint';
+
+const TYPESCRIPT_FILES = ['**/*.{ts,tsx}'];
+const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
 
 /**
  * Shared flat-config base for every workspace in the monorepo.
@@ -16,15 +20,19 @@ import tseslint from 'typescript-eslint';
  *   (`import.meta.dirname`). Used to resolve
  *   `import-x/no-extraneous-dependencies` against the workspace and the repo
  *   root, so it must be the consumer's path, not this package's.
- * @returns {import('eslint').Linter.Config[]} flat config entries to spread.
+ * @returns {import('eslint').Linter.Config[]} flat config entries; already
+ *   normalised, so consumers can nest the result inside their own
+ *   `defineConfig` call rather than spreading it.
  */
 export default function genshinConfig(packageDir) {
-  return [
-    { ignores: ['dist', 'node_modules'] },
+  return defineConfig([
+    globalIgnores(['dist', 'node_modules']),
     js.configs.recommended,
-    ...tseslint.configs.recommended,
+    // Left unscoped so the preset keeps its own file matching, which reaches
+    // `.mts`/`.cts` as well as `TYPESCRIPT_FILES`.
+    tseslint.configs.recommended,
     {
-      files: ['**/*.{ts,tsx}'],
+      files: TYPESCRIPT_FILES,
       rules: {
         '@typescript-eslint/no-explicit-any': 'error',
         '@typescript-eslint/no-non-null-assertion': 'error',
@@ -50,7 +58,7 @@ export default function genshinConfig(packageDir) {
       },
     },
     {
-      files: ['**/*.{ts,tsx,js,mjs,cjs}'],
+      files: LINTED_FILES,
       plugins: { 'import-x': importX, 'unused-imports': unusedImports },
       settings: {
         'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
@@ -91,5 +99,5 @@ export default function genshinConfig(packageDir) {
         ],
       },
     },
-  ];
+  ]);
 }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -10,16 +10,108 @@ import importX from 'eslint-plugin-import-x';
 import unusedImports from 'eslint-plugin-unused-imports';
 import tseslint from 'typescript-eslint';
 
-const TYPESCRIPT_FILES = ['**/*.{ts,tsx}'];
-const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
+/** Every file eslint reads in a workspace. */
+export const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
+
+/**
+ * The TypeScript subset of {@link LINTED_FILES}. Exported so workspaces scope
+ * their own overrides to the same set instead of respelling the glob.
+ */
+export const TYPESCRIPT_FILES = ['**/*.{ts,tsx}'];
+
+/** Paths whose imports may legitimately come from `devDependencies`. */
+const DEV_DEPENDENCY_FILES = [
+  '**/*.{test,spec}.{ts,tsx}',
+  '**/test/**',
+  '**/scripts/**',
+  'eslint.config.js',
+  '*.config.{ts,js,mjs,cjs}',
+];
+
+/** Rules tightening `tseslint.configs.recommended` past its defaults. */
+const TYPESCRIPT_STRICTNESS = {
+  files: TYPESCRIPT_FILES,
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'error',
+    '@typescript-eslint/explicit-module-boundary-types': [
+      'error',
+      {
+        allowArgumentsExplicitlyTypedAsAny: false,
+        allowDirectConstAssertionInArrowFunctions: true,
+        allowHigherOrderFunctions: true,
+      },
+    ],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
+    ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'TSEnumDeclaration',
+        message: 'Use const objects or union types instead of enums.',
+      },
+    ],
+  },
+};
+
+/**
+ * Import hygiene. The only part of the base that varies per workspace, because
+ * `no-extraneous-dependencies` has to know which `package.json` files may
+ * satisfy an import.
+ *
+ * @param {string} packageDir - the consuming workspace's directory.
+ * @returns {import('eslint').Linter.Config} a single flat config entry.
+ */
+function importDiscipline(packageDir) {
+  // Every workspace sits exactly two levels down, and the root `package.json`
+  // holds the tooling dependencies they all share.
+  const repoRoot = resolve(packageDir, '../..');
+
+  return {
+    files: LINTED_FILES,
+    plugins: { 'import-x': importX, 'unused-imports': unusedImports },
+    settings: {
+      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
+    },
+    rules: {
+      'import-x/no-extraneous-dependencies': [
+        'error',
+        {
+          devDependencies: DEV_DEPENDENCY_FILES,
+          packageDir: [packageDir, repoRoot],
+        },
+      ],
+      'import-x/order': [
+        'error',
+        {
+          groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
+          'newlines-between': 'always',
+          alphabetize: { order: 'asc', caseInsensitive: true },
+        },
+      ],
+      'import-x/no-duplicates': 'error',
+      'import-x/newline-after-import': 'error',
+      // `unused-imports` owns unused-symbol reporting so removals are
+      // autofixable; the recommended `no-unused-vars` rules are disabled to
+      // avoid double-reporting.
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': [
+        'error',
+        { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
+      ],
+    },
+  };
+}
 
 /**
  * Shared flat-config base for every workspace in the monorepo.
  *
  * @param {string} packageDir - the consuming workspace's directory
- *   (`import.meta.dirname`). Used to resolve
- *   `import-x/no-extraneous-dependencies` against the workspace and the repo
- *   root, so it must be the consumer's path, not this package's.
+ *   (`import.meta.dirname`), not this package's.
  * @returns {import('eslint').Linter.Config[]} flat config entries; already
  *   normalised, so consumers can nest the result inside their own
  *   `defineConfig` call rather than spreading it.
@@ -31,73 +123,7 @@ export default function genshinConfig(packageDir) {
     // Left unscoped so the preset keeps its own file matching, which reaches
     // `.mts`/`.cts` as well as `TYPESCRIPT_FILES`.
     tseslint.configs.recommended,
-    {
-      files: TYPESCRIPT_FILES,
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'error',
-        '@typescript-eslint/no-non-null-assertion': 'error',
-        '@typescript-eslint/explicit-module-boundary-types': [
-          'error',
-          {
-            allowArgumentsExplicitlyTypedAsAny: false,
-            allowDirectConstAssertionInArrowFunctions: true,
-            allowHigherOrderFunctions: true,
-          },
-        ],
-        '@typescript-eslint/consistent-type-imports': [
-          'error',
-          { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
-        ],
-        'no-restricted-syntax': [
-          'error',
-          {
-            selector: 'TSEnumDeclaration',
-            message: 'Use const objects or union types instead of enums.',
-          },
-        ],
-      },
-    },
-    {
-      files: LINTED_FILES,
-      plugins: { 'import-x': importX, 'unused-imports': unusedImports },
-      settings: {
-        'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-      },
-      rules: {
-        'import-x/no-extraneous-dependencies': [
-          'error',
-          {
-            devDependencies: [
-              '**/*.{test,spec}.{ts,tsx}',
-              '**/test/**',
-              '**/scripts/**',
-              'eslint.config.js',
-              '*.config.{ts,js,mjs,cjs}',
-            ],
-            packageDir: [packageDir, resolve(packageDir, '../..')],
-          },
-        ],
-        'import-x/order': [
-          'error',
-          {
-            groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
-            'newlines-between': 'always',
-            alphabetize: { order: 'asc', caseInsensitive: true },
-          },
-        ],
-        'import-x/no-duplicates': 'error',
-        'import-x/newline-after-import': 'error',
-        // `unused-imports` owns unused-symbol reporting so removals are
-        // autofixable; the recommended `no-unused-vars` rules are disabled to
-        // avoid double-reporting.
-        'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
-        'unused-imports/no-unused-imports': 'error',
-        'unused-imports/no-unused-vars': [
-          'error',
-          { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
-        ],
-      },
-    },
+    TYPESCRIPT_STRICTNESS,
+    importDiscipline(packageDir),
   ]);
 }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -11,7 +11,7 @@ import unusedImports from 'eslint-plugin-unused-imports';
 import tseslint from 'typescript-eslint';
 
 /** Every file eslint reads in a workspace. */
-export const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
+const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
 
 /**
  * The TypeScript subset of {@link LINTED_FILES}. Workspaces scope their own

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,8 +14,8 @@ import tseslint from 'typescript-eslint';
 const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
 
 /**
- * The TypeScript subset of {@link LINTED_FILES}. Workspaces scope their own
- * overrides to it.
+ * The TypeScript subset of the files eslint reads. Workspaces scope their own
+ * overrides to this.
  */
 export const TYPESCRIPT_FILES = ['**/*.{ts,tsx}'];
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,12 +14,12 @@ import tseslint from 'typescript-eslint';
 export const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
 
 /**
- * The TypeScript subset of {@link LINTED_FILES}. Exported so workspaces scope
- * their own overrides to the same set instead of respelling the glob.
+ * The TypeScript subset of {@link LINTED_FILES}. Workspaces scope their own
+ * overrides to it.
  */
 export const TYPESCRIPT_FILES = ['**/*.{ts,tsx}'];
 
-/** Paths whose imports may legitimately come from `devDependencies`. */
+/** Paths allowed to import `devDependencies`. */
 const DEV_DEPENDENCY_FILES = [
   '**/*.{test,spec}.{ts,tsx}',
   '**/test/**',
@@ -28,7 +28,7 @@ const DEV_DEPENDENCY_FILES = [
   '*.config.{ts,js,mjs,cjs}',
 ];
 
-/** Rules tightening `tseslint.configs.recommended` past its defaults. */
+/** Rules tightening `tseslint.configs.recommended`. */
 const TYPESCRIPT_STRICTNESS = {
   files: TYPESCRIPT_FILES,
   rules: {
@@ -57,16 +57,15 @@ const TYPESCRIPT_STRICTNESS = {
 };
 
 /**
- * Import hygiene. The only part of the base that varies per workspace, because
- * `no-extraneous-dependencies` has to know which `package.json` files may
- * satisfy an import.
+ * Parameterised because `no-extraneous-dependencies` has to know which
+ * `package.json` files may satisfy an import.
  *
  * @param {string} packageDir - the consuming workspace's directory.
- * @returns {import('eslint').Linter.Config} a single flat config entry.
+ * @returns {import('eslint').Linter.Config}
  */
 function importDiscipline(packageDir) {
-  // Every workspace sits exactly two levels down, and the root `package.json`
-  // holds the tooling dependencies they all share.
+  // Workspaces sit two levels below the root, whose `package.json` holds the
+  // tooling dependencies they all share.
   const repoRoot = resolve(packageDir, '../..');
 
   return {
@@ -112,16 +111,15 @@ function importDiscipline(packageDir) {
  *
  * @param {string} packageDir - the consuming workspace's directory
  *   (`import.meta.dirname`), not this package's.
- * @returns {import('eslint').Linter.Config[]} flat config entries; already
- *   normalised, so consumers can nest the result inside their own
- *   `defineConfig` call rather than spreading it.
+ * @returns {import('eslint').Linter.Config[]} flat config entries, already
+ *   normalised, so consumers can nest the result in their own `defineConfig`.
  */
 export default function genshinConfig(packageDir) {
   return defineConfig([
     globalIgnores(['dist', 'node_modules']),
     js.configs.recommended,
-    // Left unscoped so the preset keeps its own file matching, which reaches
-    // `.mts`/`.cts` as well as `TYPESCRIPT_FILES`.
+    // Unscoped: the preset's own file matching reaches `.mts` and `.cts`, which
+    // `TYPESCRIPT_FILES` does not.
     tseslint.configs.recommended,
     TYPESCRIPT_STRICTNESS,
     importDiscipline(packageDir),

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,8 @@
       "persistent": true
     },
     "lint": {
-      "inputs": ["**/*.{ts,tsx}", "package.json", "eslint.config.*"]
+      "dependsOn": ["^lint"],
+      "inputs": ["**/*.{ts,tsx,js,mjs,cjs}", "package.json"]
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Most of #814 already landed: the shared base came with #818, and #1196
regrouped `apps/web`. What's left is the idiom — `defineConfig`, and `extends`
so each React preset registers its own plugin instead of a hand-stitched
`plugins: {}` plus a `.rules` spread. No rule changes.

Two of the issue's bullets came out differently, each explained in a comment
where it lands: the `**/*.{ts,tsx}` filters stay because `apps/web` lints
plain-JavaScript config files too, and `eslint-plugin-react` keeps its
hand-built registration because its only flat preset enables the whole
recommended set.

Also fixes a cache bug the base was hiding. `lint.inputs` never included
`packages/eslint-config/index.js`, so editing a shared rule gave cache hits in
all nine workspaces and skipped re-linting; `^lint` carries the invalidation,
which turbo won't do from an internal dependency without a task edge.

## Gotchas

`eslint-plugin-react-hooks` keeps its flat preset at `configs.flat.recommended`
— plain `configs.recommended` is the eslintrc form (`plugins: ['react-hooks']`,
an array of names), which is why the plugin was wired by hand before.

`^lint` makes a failure in the shared base abort the other eight tasks instead
of reporting nine independent results.

The jsx-a11y-x block from #1199 stays its own element rather than joining the
`extends` list beside it: that preset carries `languageOptions`, which there
would outrank this workspace's.

The React Compiler rules #810 asks for are already on — v7's
`configs.recommended` ships them and the config already spread it before this
PR. Same shape for #812: its `import-x` and `unused-imports` rules have been in
the shared base since #818. Both look closable as already shipped.

## Verification

`eslint --print-config` is byte-identical to develop across ten probe files,
covering rules, plugins, settings, globals, `parserOptions`, and the resolved
parser. The `eslint` pre-commit hook still matches zero files (#888), so
`turbo run lint` is the only thing exercising any of this.

Closes #814
