### PR TITLE
chore(ci): scope devcontainer job to the toolchain

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,7 @@ per-repository instruction file either tool loads.
 - Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't automatically build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
 - The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. The build config extends `tsconfig.json`, so compiler options stay in sync automatically; only the exclude patterns differ.
 - When `tsconfig.json` uses project references, type-check with `tsc -b --noEmit`. Plain `tsc --noEmit` won't follow references.
-- A new project-wide check belongs in `.pre-commit-config.yaml`, which `ci.yml` runs over the whole tree. The `runCmd` chain in `devcontainer.yml` isn't the place for one. That chain exercises the built image's toolchain, so it takes a command only when nothing else in the chain runs that tool.
+- A new project-wide check belongs in `.pre-commit-config.yaml`, which `ci.yml` runs over the whole tree. The `runCmd` chain in `devcontainer.yml` exercises the built image's toolchain instead, so it takes a command only when nothing else in the chain runs that tool.
 
 ## API design rules
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,6 +49,7 @@ per-repository instruction file either tool loads.
 - Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't automatically build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
 - The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. The build config extends `tsconfig.json`, so compiler options stay in sync automatically; only the exclude patterns differ.
 - When `tsconfig.json` uses project references, type-check with `tsc -b --noEmit`. Plain `tsc --noEmit` won't follow references.
+- A new project-wide check belongs in `.pre-commit-config.yaml`, which `ci.yml` runs over the whole tree. The `runCmd` chain in `devcontainer.yml` isn't the place for one. That chain exercises the built image's toolchain, so it takes a command only when nothing else in the chain runs that tool.
 
 ## API design rules
 

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -10,9 +10,7 @@ on:
   pull_request:
     paths: &paths
       - '.devcontainer/**'
-      - '.vscode/extensions.json'
       - 'scripts/install-reuse.sh'
-      - 'scripts/validate-workspace.ts'
       - '.github/workflows/devcontainer.yml'
       - 'package.json'
       - 'pnpm-lock.yaml'
@@ -28,8 +26,8 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate workspace
+  toolchain:
+    name: Verify toolchain
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -39,18 +37,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build devcontainer and run pnpm validate
+      # The chain exercises each toolchain the image installs — turbo, eslint,
+      # knip, and the pipx-installed reuse — so it asserts the image, not the
+      # code; ci.yml already gates the code with these same checks. Add a
+      # command only when it exercises a tool nothing here already does.
+      # Project-wide checks belong in .pre-commit-config.yaml instead.
+      - name: Build the image and run the toolchain
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           imageName: genshin-planner-devcontainer
           push: never
-          runCmd: pnpm validate
+          runCmd: pnpm lint && pnpm typecheck && pnpm knip && pnpm reuse:check
 
 # ---------------------------------------------------------------------------
 # Maintenance notes
 # - Cold devcontainer build (no cache) is the slow path. The job ceiling
 #   leaves headroom for first-time builds without retries.
-# - Runs pnpm validate (lint + typecheck + reuse + workspace consistency)
-#   inside the built image so devcontainer drift surfaces here, not in
-#   contributor terminals.
+# - Runs the toolchain inside the built image so devcontainer drift surfaces
+#   here, not in contributor terminals.
 # ---------------------------------------------------------------------------

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -38,12 +38,13 @@ jobs:
         with:
           persist-credentials: false
 
-      # Asserts the image, not the code: ci.yml already gates the code with
-      # these same checks. Add a command only when it reaches a tool nothing
-      # here already does; project-wide checks belong in .pre-commit-config.yaml.
-      - name: Build the image and run the toolchain
+      - name: Build the image and run the checks inside it
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           imageName: genshin-planner-devcontainer
           push: never
+          # Repeats ci.yml's checks on purpose: there they gate the code, here
+          # they prove the built image can still run them. Add a command only
+          # when it exercises a tool the others leave untouched; project-wide
+          # checks belong in .pre-commit-config.yaml.
           runCmd: pnpm lint && pnpm typecheck && pnpm knip && pnpm reuse:check

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -37,11 +37,11 @@ jobs:
         with:
           persist-credentials: false
 
-      # The chain exercises each toolchain the image installs — turbo, eslint,
-      # knip, and the pipx-installed reuse — so it asserts the image, not the
-      # code; ci.yml already gates the code with these same checks. Add a
-      # command only when it exercises a tool nothing here already does.
-      # Project-wide checks belong in .pre-commit-config.yaml instead.
+      # Asserts the image, not the code — ci.yml already gates the code with
+      # these same checks. The commands are chosen to reach what the image
+      # installs: the Node toolchain via turbo, and reuse via pipx. Add one
+      # only when it reaches a tool nothing here already does; project-wide
+      # checks belong in .pre-commit-config.yaml.
       - name: Build the image and run the toolchain
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
@@ -53,6 +53,4 @@ jobs:
 # Maintenance notes
 # - Cold devcontainer build (no cache) is the slow path. The job ceiling
 #   leaves headroom for first-time builds without retries.
-# - Runs the toolchain inside the built image so devcontainer drift surfaces
-#   here, not in contributor terminals.
 # ---------------------------------------------------------------------------

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -29,6 +29,7 @@ jobs:
   toolchain:
     name: Verify toolchain
     runs-on: ubuntu-latest
+    # Headroom for a cold build, which has no cache to fall back on.
     timeout-minutes: 30
 
     steps:
@@ -37,20 +38,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Asserts the image, not the code — ci.yml already gates the code with
-      # these same checks. The commands are chosen to reach what the image
-      # installs: the Node toolchain via turbo, and reuse via pipx. Add one
-      # only when it reaches a tool nothing here already does; project-wide
-      # checks belong in .pre-commit-config.yaml.
+      # Asserts the image, not the code: ci.yml already gates the code with
+      # these same checks. Add a command only when it reaches a tool nothing
+      # here already does; project-wide checks belong in .pre-commit-config.yaml.
       - name: Build the image and run the toolchain
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
           imageName: genshin-planner-devcontainer
           push: never
           runCmd: pnpm lint && pnpm typecheck && pnpm knip && pnpm reuse:check
-
-# ---------------------------------------------------------------------------
-# Maintenance notes
-# - Cold devcontainer build (no cache) is the slow path. The job ceiling
-#   leaves headroom for first-time builds without retries.
-# ---------------------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -170,9 +170,9 @@ repos:
         pass_filenames: false
         always_run: true
 
-      - id: workspace-extensions
-        name: devcontainer and workspace extensions in sync
-        entry: pnpm validate:workspace
+      - id: vscode-extensions
+        name: devcontainer and editor extensions in sync
+        entry: pnpm vscode-extensions:check
         language: system
         files: ^(\.vscode/extensions\.json|\.devcontainer/devcontainer\.json)$
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -170,6 +170,13 @@ repos:
         pass_filenames: false
         always_run: true
 
+      - id: workspace-extensions
+        name: devcontainer and workspace extensions in sync
+        entry: pnpm validate:workspace
+        language: system
+        files: ^(\.vscode/extensions\.json|\.devcontainer/devcontainer\.json)$
+        pass_filenames: false
+
       - id: syncpack
         name: exact dependency versions
         entry: pnpm exec syncpack lint

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -47,6 +47,7 @@ tooltip
 config
 configs
 formatters
+toolchain
 
 # Backend and database
 Firebase

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",
     "reuse:check": "reuse lint",
-    "validate:workspace": "tsx scripts/validate-workspace.ts",
-    "validate": "pnpm lint && pnpm typecheck && pnpm knip && pnpm reuse:check && pnpm validate:workspace"
+    "validate:workspace": "tsx scripts/validate-workspace.ts"
   },
   "devDependencies": {
     "@ls-lint/ls-lint": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",
     "reuse:check": "reuse lint",
-    "validate:workspace": "tsx scripts/validate-workspace.ts"
+    "vscode-extensions:check": "tsx scripts/check-vscode-extensions.ts"
   },
   "devDependencies": {
     "@ls-lint/ls-lint": "2.3.1",

--- a/scripts/check-vscode-extensions.ts
+++ b/scripts/check-vscode-extensions.ts
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-// Workspace Configuration Validator.
+// VS Code extension parity check.
 //
 // Asserts that VS Code extension recommendations in .vscode/extensions.json
 // stay in lockstep with the extensions installed by .devcontainer/devcontainer.json.
 // Both files carry a MAINTENANCE comment pointing at the other; this check
 // enforces it.
 //
-// Usage: pnpm tsx scripts/validate-workspace.ts
+// Usage: pnpm vscode-extensions:check
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -51,12 +51,12 @@ const onlyRecommended = [...recommendedSet].filter((ext) => !installedSet.has(ex
 const onlyInstalled = [...installedSet].filter((ext) => !recommendedSet.has(ext)).sort();
 
 if (onlyRecommended.length === 0 && onlyInstalled.length === 0) {
-  console.log(`workspace: ${recommended.length} extensions in sync.`);
+  console.log(`vscode-extensions: ${recommended.length} extensions in sync.`);
   process.exit(0);
 }
 
 console.error(
-  'workspace: extensions out of sync between .vscode/extensions.json and .devcontainer/devcontainer.json',
+  'vscode-extensions: out of sync between .vscode/extensions.json and .devcontainer/devcontainer.json',
 );
 if (onlyRecommended.length > 0) {
   console.error(`  only in .vscode/extensions.json: ${onlyRecommended.join(', ')}`);

--- a/scripts/check-vscode-extensions.ts
+++ b/scripts/check-vscode-extensions.ts
@@ -1,14 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-// VS Code extension parity check.
-//
-// Asserts that VS Code extension recommendations in .vscode/extensions.json
-// stay in lockstep with the extensions installed by .devcontainer/devcontainer.json.
-// Both files carry a MAINTENANCE comment pointing at the other; this check
-// enforces it.
-//
-// Usage: pnpm vscode-extensions:check
+// Asserts that the VS Code extension recommendations in .vscode/extensions.json
+// stay in lockstep with the extensions .devcontainer/devcontainer.json installs.
+// Both files carry a MAINTENANCE comment pointing at the other; this enforces it.
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';


### PR DESCRIPTION
`pnpm validate` was the project-wide check chain (`lint`, `typecheck`, `knip`, `reuse:check`) plus the VS Code extension lockstep check, run inside the built devcontainer image. The generic name invited every new project-wide check into it — the misread that surfaced in #805 when deciding where `lint:names` went.

This splits the two jobs that script had fused. The extension lockstep check is a two-file JSON diff needing no container, so it becomes a pre-commit hook. The remaining chain moves inline into `devcontainer.yml`'s `runCmd`, which is what it always was: an assertion that the built image can run turbo, eslint, knip, and the pipx-installed reuse — not a gate on the code, which `ci.yml` already covers with these same checks. The boundary rule now sits beside the command it governs, since `package.json` can't carry comments.

The second commit finishes the rename one level down. "Workspace" reads as the pnpm package graph, but the check compares two lists of editor extensions — the same misleading-name problem, so `validate:workspace` becomes `vscode-extensions:check`, `scripts/validate-workspace.ts` becomes `scripts/check-vscode-extensions.ts`, and the script's own output drops its `workspace:` prefix.

## Gotchas

- The extension check now runs on **every** commit touching either JSON file, where before it only ran behind the workflow's path gate. That's the point, but it's a behavior change.
- `.vscode/extensions.json` and `scripts/validate-workspace.ts` leave the path gate, so editing them no longer triggers a ~5 minute image build. Everything that affects the image (`.devcontainer/**`, `install-reuse.sh`, `package.json`, `pnpm-lock.yaml`) still does.
- The job is renamed `Validate workspace` → `Verify toolchain`. Safe here: the develop ruleset has no `required_status_checks`, so no gate binds to the old name.
- The script keeps a `package.json` entry rather than being invoked as `tsx scripts/...` straight from the hook. That entry is what makes knip resolve both `tsx` and the script file; dropping it would trade one line for a knip `entry` plus an `ignoreDependencies` exemption.
- `lint:names` is dead (pre-commit calls `pnpm exec ls-lint` directly) but predates this change, so it stays for #1202 rather than widening this diff.

A broader pass over which tool owns which check — several pre-commit hooks need binaries CI installs first, so they aren't "quick and local" — is #1202 and deliberately out of scope here.

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnF1cYBcvSpfx73zAc1kiM