### PR TITLE
ci: check pull request titles are conventional

### DIFF
--- a/.github/workflows/pull-request-metadata.yml
+++ b/.github/workflows/pull-request-metadata.yml
@@ -8,10 +8,6 @@ name: Pull Request Metadata
 # every title or description tweak. `synchronize` keeps a result on each head
 # commit, which a required status check needs.
 # See docs/reference/workflow-conventions.md.
-#
-# Labelling belongs to this same when but stays in labels.yml until #1211
-# makes it idempotent; the autolabeler only adds, so running it on `edited`
-# leaves the superseded category label behind.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -26,7 +22,7 @@ concurrency:
 jobs:
   # Squash is the only merge method enabled and the repository takes the squash
   # commit title from the pull request title, so this title is the commit
-  # message that lands on develop. Local commits stay unvalidated.
+  # message that lands on develop.
   title:
     name: Check pull request title
     runs-on: ubuntu-latest
@@ -57,6 +53,6 @@ jobs:
           requireScope: false
 
           subjectPattern: '^(?![A-Z]).*[^.\s]$'
-          subjectPatternError: |
-            The subject "{subject}" in the title "{title}" must start with a
-            lowercase character and must not end with a period.
+          subjectPatternError: >-
+            The subject "{subject}" must start with a lowercase character and
+            must not end with a period.

--- a/.github/workflows/pull-request-metadata.yml
+++ b/.github/workflows/pull-request-metadata.yml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+---
+name: Pull Request Metadata
+
+# Sensors that read the pull request itself rather than the code it carries, so
+# they need the `edited` trigger ci.yml deliberately omits: adding it there
+# would rerun the whole suite on every title or description tweak. The
+# `synchronize` run keeps a result attached to each head commit, which a
+# required status check reads. See docs/reference/workflow-conventions.md.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Squash is the only merge method enabled and the repository takes the squash
+  # commit title from the pull request title, so this title is the commit
+  # message that lands on develop. Local commits stay unvalidated.
+  title:
+    name: Check pull request title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # The same set .github/release-drafter.yml strips from release note
+          # bullets; the two lists have to move together.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+
+          # Scope is the workspace package a change is confined to, so the
+          # allowed set grows with the workspace and stays unenforced. Subject
+          # length is unenforced for the same reason CONTRIBUTING.md states it
+          # as a target rather than a limit.
+          requireScope: false
+
+          subjectPattern: '^(?![A-Z]).*[^.\s]$'
+          subjectPatternError: |
+            The subject "{subject}" in the title "{title}" must start with a
+            lowercase character and must not end with a period.

--- a/.github/workflows/pull-request-metadata.yml
+++ b/.github/workflows/pull-request-metadata.yml
@@ -3,11 +3,15 @@
 ---
 name: Pull Request Metadata
 
-# Sensors that read the pull request itself rather than the code it carries, so
-# they need the `edited` trigger ci.yml deliberately omits: adding it there
-# would rerun the whole suite on every title or description tweak. The
-# `synchronize` run keeps a result attached to each head commit, which a
-# required status check reads. See docs/reference/workflow-conventions.md.
+# Checks that read the pull request's own metadata, so they take the `edited`
+# trigger ci.yml omits: carrying `edited` there would rerun the whole suite on
+# every title or description tweak. `synchronize` keeps a result on each head
+# commit, which a required status check needs.
+# See docs/reference/workflow-conventions.md.
+#
+# Labelling belongs to this same when but stays in labels.yml until #1211
+# makes it idempotent; the autolabeler only adds, so running it on `edited`
+# leaves the superseded category label behind.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -50,10 +54,6 @@ jobs:
             chore
             revert
 
-          # Scope is the workspace package a change is confined to, so the
-          # allowed set grows with the workspace and stays unenforced. Subject
-          # length is unenforced for the same reason CONTRIBUTING.md states it
-          # as a target rather than a limit.
           requireScope: false
 
           subjectPattern: '^(?![A-Z]).*[^.\s]$'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ workspace dependencies first. Turbo handles dependency ordering via `^build`.
 
 - Every source file needs SPDX headers. See `docs/how-tos/add-spdx-headers.md`.
   For files without comment syntax, declare them in `.reuse/dep5`.
-- Conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`,
-  `style:`, `chore:`.
+- Conventional commits: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`,
+  `perf:`, `test:`, `build:`, `ci:`, `chore:`, `revert:`. CI checks the PR
+  title, not local commits; subject starts lowercase, no trailing period.
 - Never bypass pre-commit with `--no-verify`; fix root causes.
 - Never use `git commit --amend` or `git push --force`.
 - Fixes after hook failures should be new commits; squash merge handles cleanup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ workspace dependencies first. Turbo handles dependency ordering via `^build`.
 
 - Every source file needs SPDX headers. See `docs/how-tos/add-spdx-headers.md`.
   For files without comment syntax, declare them in `.reuse/dep5`.
-- Conventional commits: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`,
-  `perf:`, `test:`, `build:`, `ci:`, `chore:`, `revert:`. CI checks the PR
-  title, not local commits; subject starts lowercase, no trailing period.
+- Conventional commits, gated on the PR title only: `feat:`, `fix:`, `docs:`,
+  `style:`, `refactor:`, `perf:`, `test:`, `build:`, `ci:`, `chore:`,
+  `revert:`; subject lowercase, no trailing period.
 - Never bypass pre-commit with `--no-verify`; fix root causes.
 - Never use `git commit --amend` or `git push --force`.
 - Fixes after hook failures should be new commits; squash merge handles cleanup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ The pull request title becomes the commit message, so it carries these rules:
 - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
 - Write the subject in imperative mood ("add character filter," not "added" or "adds"), lowercase, under 50 characters, and with no trailing period
 
-The `Check pull request title` job in [`pull-request-metadata.yml`](.github/workflows/pull-request-metadata.yml) enforces the type and the subject's leading case and trailing period. Scope and subject length stay unenforced, so treat the length as a target. Local commits are never checked.
+A [CI check](.github/workflows/pull-request-metadata.yml) blocks the pull request on an unknown type, an uppercase first letter, or a trailing period. Scope, subject length, and local commits go unchecked, so treat the 50 characters as a target rather than a limit.
 
 Scope is the workspace package the change is confined to: `feat(web)` for `apps/web`, `fix(api)` for `apps/api`, `refactor(game-data)` for `packages/game-data`, `chore(domain)` for `packages/domain`, and `chore(infra)` for Terraform and infrastructure. Omit the scope for changes that span packages, including most `docs:` changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,8 +161,6 @@ The pull request title becomes the commit message, so it carries these rules:
 - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
 - Write the subject in imperative mood ("add character filter," not "added" or "adds"), lowercase, under 50 characters, and with no trailing period
 
-A [CI check](.github/workflows/pull-request-metadata.yml) blocks the pull request on an unknown type, an uppercase first letter, or a trailing period. Scope, subject length, and local commits go unchecked, so treat the 50 characters as a target rather than a limit.
-
 Scope is the workspace package the change is confined to: `feat(web)` for `apps/web`, `fix(api)` for `apps/api`, `refactor(game-data)` for `packages/game-data`, `chore(domain)` for `packages/domain`, and `chore(infra)` for Terraform and infrastructure. Omit the scope for changes that span packages, including most `docs:` changes.
 
 When a commit needs a body, separate it from the subject with a blank line, wrap it at 72 characters, and use it to explain what changed and why rather than how.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,8 +158,10 @@ For code conventions—comments, documentation strategy, naming, shared types, t
 The pull request title becomes the commit message, so it carries these rules:
 
 - Format: `type(scope): subject`
-- Types: `feat`, `fix`, `docs`, `test`, `refactor`, `style`, `chore`
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
 - Write the subject in imperative mood ("add character filter," not "added" or "adds"), lowercase, under 50 characters, and with no trailing period
+
+The `Check pull request title` job in [`pull-request-metadata.yml`](.github/workflows/pull-request-metadata.yml) enforces the type and the subject's leading case and trailing period. Scope and subject length stay unenforced, so treat the length as a target. Local commits are never checked.
 
 Scope is the workspace package the change is confined to: `feat(web)` for `apps/web`, `fix(api)` for `apps/api`, `refactor(game-data)` for `packages/game-data`, `chore(domain)` for `packages/domain`, and `chore(infra)` for Terraform and infrastructure. Omit the scope for changes that span packages, including most `docs:` changes.
 


### PR DESCRIPTION
The pull request title becomes the commit message on `develop` — squash is the only merge method and `squash_merge_commit_title` is `PR_TITLE` — and nothing checked it. This adds a `Check pull request title` job running `amannn/action-semantic-pull-request`, pinned to v6.1.1.

Three deviations from the specification in #159:

- **A new workflow file, not a `ci.yml` job.** The check needs `edited` so a corrected title clears without a push, and `edited` on `ci.yml` would rerun the whole suite on every description tweak.
- **A lowercase subject pattern.** The issue asked for `^[A-Z].+$`, which contradicts `CONTRIBUTING.md` and would reject every commit in this repo.
- **Eleven types, not seven.** `CONTRIBUTING.md` was missing `ci` despite eight merged commits using it, so it is corrected here to match the prefixes `release-drafter.yml` already strips.

Replaying the rules over the last 400 merged titles fails 10, all pre-convention or from the retired `pre-commit.ci` bot; every current Renovate title passes. The action ran green here, which also settles the org Actions allowlist that startup-failed #801.

Filed rather than folded in: #1209 (type and scope taxonomy), #1210 (the pull request template criterion), #1211 (the autolabeler leaves stale category labels, which is what blocks merging `labels.yml` into this file).

Closes #159