### PR TITLE
feat(lint): catch unresolved imports and dependency cycles

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -73,6 +73,11 @@ function importDiscipline(packageDir) {
     plugins: { 'import-x': importX, 'unused-imports': unusedImports },
     settings: {
       'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
+      // Load-bearing. Rules that follow an import into the *imported* file
+      // consult this list first and skip anything not on it, which defaults to
+      // `.js`/`.mjs`/`.cjs` — so without this `no-cycle` silently reports
+      // nothing across a TypeScript codebase rather than failing loudly.
+      'import-x/extensions': ['.ts', '.tsx', '.cts', '.mts', '.js', '.jsx', '.cjs', '.mjs'],
     },
     rules: {
       'import-x/no-extraneous-dependencies': [
@@ -92,6 +97,15 @@ function importDiscipline(packageDir) {
       ],
       'import-x/no-duplicates': 'error',
       'import-x/newline-after-import': 'error',
+      // Duplicates `tsc`, but `typecheck` is not a commit gate and `eslint` is,
+      // so this is where a broken import path gets caught first. Sibling
+      // workspaces are exempt: their entry points resolve through built
+      // `dist/`, so linting them would report build state, not import
+      // correctness, and would fail on any unbuilt checkout.
+      'import-x/no-unresolved': ['error', { ignore: ['^@genshin/'] }],
+      // `ignoreExternal` keeps the graph walk inside the repo; cycles in
+      // `node_modules` are not ours to break.
+      'import-x/no-cycle': ['error', { ignoreExternal: true }],
       // `unused-imports` owns unused-symbol reporting so removals are
       // autofixable; the recommended `no-unused-vars` rules are disabled to
       // avoid double-reporting.

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -10,12 +10,7 @@ import importX from 'eslint-plugin-import-x';
 import unusedImports from 'eslint-plugin-unused-imports';
 import tseslint from 'typescript-eslint';
 
-/**
- * Every file kind eslint reads in a workspace. Written once and reshaped
- * because two consumers want two shapes — eslint matches files by glob,
- * `import-x` by extension — and hand-maintained copies drift: a kind missing
- * from the `import-x` list is one `no-cycle` stops looking at, silently.
- */
+/** The file kinds this monorepo treats as modules. */
 const MODULE_EXTENSIONS = ['ts', 'tsx', 'cts', 'mts', 'js', 'jsx', 'cjs', 'mjs'];
 
 /** Every file eslint reads in a workspace. */
@@ -64,16 +59,14 @@ const TYPESCRIPT_STRICTNESS = {
   },
 };
 
-/** Import hygiene that reads the same in every workspace. */
+/** Import rules that need no workspace context. */
 const IMPORT_DISCIPLINE = {
   files: LINTED_FILES,
   plugins: { 'import-x': importX, 'unused-imports': unusedImports },
   settings: {
     'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-    // Load-bearing. Rules that follow an import into the *imported* file
-    // consult this list first and skip anything not on it, which defaults to
-    // `.js`/`.mjs`/`.cjs` — so without this `no-cycle` silently reports
-    // nothing across a TypeScript codebase rather than failing loudly.
+    // `import-x` parses an imported file only if its extension is listed, and
+    // the default omits TypeScript — which leaves `no-cycle` silently inert.
     'import-x/extensions': MODULE_EXTENSIONS.map((extension) => `.${extension}`),
   },
   rules: {
@@ -87,14 +80,10 @@ const IMPORT_DISCIPLINE = {
     ],
     'import-x/no-duplicates': 'error',
     'import-x/newline-after-import': 'error',
-    // Duplicates `tsc`, but `typecheck` is not a commit gate and `eslint` is,
-    // so this is where a broken import path gets caught first. Sibling
-    // workspaces are exempt: their entry points resolve through built
-    // `dist/`, so linting them would report build state, not import
-    // correctness, and would fail on any unbuilt checkout.
+    // Sibling workspaces resolve through built `dist/`, so checking them would
+    // report whether the repo is built, not whether the import is correct.
     'import-x/no-unresolved': ['error', { ignore: ['^@genshin/'] }],
-    // `ignoreExternal` keeps the graph walk inside the repo; cycles in
-    // `node_modules` are not ours to break.
+    // Cycles inside `node_modules` are not ours to break.
     'import-x/no-cycle': ['error', { ignoreExternal: true }],
     // `unused-imports` owns unused-symbol reporting so removals are
     // autofixable; the recommended `no-unused-vars` rules are disabled to
@@ -110,9 +99,8 @@ const IMPORT_DISCIPLINE = {
 };
 
 /**
- * The one import rule that cannot be shared verbatim:
- * `no-extraneous-dependencies` has to know which `package.json` files may
- * satisfy an import.
+ * Parameterised because `no-extraneous-dependencies` has to know which
+ * `package.json` files may satisfy an import.
  *
  * @param {string} packageDir - the consuming workspace's directory.
  * @returns {import('eslint').Linter.Config}

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -10,8 +10,16 @@ import importX from 'eslint-plugin-import-x';
 import unusedImports from 'eslint-plugin-unused-imports';
 import tseslint from 'typescript-eslint';
 
+/**
+ * Every file kind eslint reads in a workspace. Written once and reshaped
+ * because two consumers want two shapes — eslint matches files by glob,
+ * `import-x` by extension — and hand-maintained copies drift: a kind missing
+ * from the `import-x` list is one `no-cycle` stops looking at, silently.
+ */
+const MODULE_EXTENSIONS = ['ts', 'tsx', 'cts', 'mts', 'js', 'jsx', 'cjs', 'mjs'];
+
 /** Every file eslint reads in a workspace. */
-const LINTED_FILES = ['**/*.{ts,tsx,js,mjs,cjs}'];
+const LINTED_FILES = [`**/*.{${MODULE_EXTENSIONS.join(',')}}`];
 
 /**
  * The TypeScript subset of the files eslint reads. Workspaces scope their own
@@ -56,29 +64,66 @@ const TYPESCRIPT_STRICTNESS = {
   },
 };
 
+/** Import hygiene that reads the same in every workspace. */
+const IMPORT_DISCIPLINE = {
+  files: LINTED_FILES,
+  plugins: { 'import-x': importX, 'unused-imports': unusedImports },
+  settings: {
+    'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
+    // Load-bearing. Rules that follow an import into the *imported* file
+    // consult this list first and skip anything not on it, which defaults to
+    // `.js`/`.mjs`/`.cjs` — so without this `no-cycle` silently reports
+    // nothing across a TypeScript codebase rather than failing loudly.
+    'import-x/extensions': MODULE_EXTENSIONS.map((extension) => `.${extension}`),
+  },
+  rules: {
+    'import-x/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+      },
+    ],
+    'import-x/no-duplicates': 'error',
+    'import-x/newline-after-import': 'error',
+    // Duplicates `tsc`, but `typecheck` is not a commit gate and `eslint` is,
+    // so this is where a broken import path gets caught first. Sibling
+    // workspaces are exempt: their entry points resolve through built
+    // `dist/`, so linting them would report build state, not import
+    // correctness, and would fail on any unbuilt checkout.
+    'import-x/no-unresolved': ['error', { ignore: ['^@genshin/'] }],
+    // `ignoreExternal` keeps the graph walk inside the repo; cycles in
+    // `node_modules` are not ours to break.
+    'import-x/no-cycle': ['error', { ignoreExternal: true }],
+    // `unused-imports` owns unused-symbol reporting so removals are
+    // autofixable; the recommended `no-unused-vars` rules are disabled to
+    // avoid double-reporting.
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': [
+      'error',
+      { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
+    ],
+  },
+};
+
 /**
- * Parameterised because `no-extraneous-dependencies` has to know which
- * `package.json` files may satisfy an import.
+ * The one import rule that cannot be shared verbatim:
+ * `no-extraneous-dependencies` has to know which `package.json` files may
+ * satisfy an import.
  *
  * @param {string} packageDir - the consuming workspace's directory.
  * @returns {import('eslint').Linter.Config}
  */
-function importDiscipline(packageDir) {
+function declaredDependencies(packageDir) {
   // Workspaces sit two levels below the root, whose `package.json` holds the
   // tooling dependencies they all share.
   const repoRoot = resolve(packageDir, '../..');
 
   return {
     files: LINTED_FILES,
-    plugins: { 'import-x': importX, 'unused-imports': unusedImports },
-    settings: {
-      'import-x/resolver-next': [createTypeScriptImportResolver({ alwaysTryTypes: true })],
-      // Load-bearing. Rules that follow an import into the *imported* file
-      // consult this list first and skip anything not on it, which defaults to
-      // `.js`/`.mjs`/`.cjs` — so without this `no-cycle` silently reports
-      // nothing across a TypeScript codebase rather than failing loudly.
-      'import-x/extensions': ['.ts', '.tsx', '.cts', '.mts', '.js', '.jsx', '.cjs', '.mjs'],
-    },
     rules: {
       'import-x/no-extraneous-dependencies': [
         'error',
@@ -86,35 +131,6 @@ function importDiscipline(packageDir) {
           devDependencies: DEV_DEPENDENCY_FILES,
           packageDir: [packageDir, repoRoot],
         },
-      ],
-      'import-x/order': [
-        'error',
-        {
-          groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
-          'newlines-between': 'always',
-          alphabetize: { order: 'asc', caseInsensitive: true },
-        },
-      ],
-      'import-x/no-duplicates': 'error',
-      'import-x/newline-after-import': 'error',
-      // Duplicates `tsc`, but `typecheck` is not a commit gate and `eslint` is,
-      // so this is where a broken import path gets caught first. Sibling
-      // workspaces are exempt: their entry points resolve through built
-      // `dist/`, so linting them would report build state, not import
-      // correctness, and would fail on any unbuilt checkout.
-      'import-x/no-unresolved': ['error', { ignore: ['^@genshin/'] }],
-      // `ignoreExternal` keeps the graph walk inside the repo; cycles in
-      // `node_modules` are not ours to break.
-      'import-x/no-cycle': ['error', { ignoreExternal: true }],
-      // `unused-imports` owns unused-symbol reporting so removals are
-      // autofixable; the recommended `no-unused-vars` rules are disabled to
-      // avoid double-reporting.
-      'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
-      'unused-imports/no-unused-imports': 'error',
-      'unused-imports/no-unused-vars': [
-        'error',
-        { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
       ],
     },
   };
@@ -136,6 +152,7 @@ export default function genshinConfig(packageDir) {
     // `TYPESCRIPT_FILES` does not.
     tseslint.configs.recommended,
     TYPESCRIPT_STRICTNESS,
-    importDiscipline(packageDir),
+    IMPORT_DISCIPLINE,
+    declaredDependencies(packageDir),
   ]);
 }


### PR DESCRIPTION
## Summary

`import-x` and `unused-imports` have been installed and enabled since #818 and #868, so most of #812's acceptance criteria were already met on `develop`. What was missing were the two gaps the issue opens with: nothing reported an import path that fails to resolve, and nothing reported a dependency cycle. Both are on now. The repo has neither today, so this is a ratchet rather than a cleanup. Two follow-up commits tidy the config they live in and cut its comments back, neither changing behaviour.

## Gotchas

- **`no-cycle` does nothing without `import-x/extensions`.** `import-x` parses an imported file only if its extension is listed, and the default omits TypeScript — so the rule reports nothing rather than failing. Found by planting a two-module cycle in an `apps/` and a `packages/` workspace. `LINTED_FILES` and that extension list had also drifted apart in opposite directions, so both now derive from one constant.

- **Sibling `@genshin/*` imports are exempt from `no-unresolved`.** They resolve through built `dist/`, and `lint` has no `^build` dependency, so without the exemption it is 60+ errors on an unbuilt checkout — build state rather than import correctness.

- **None of this gates at commit time.** The `eslint` pre-commit hook matches zero files (#888), so these rules run under `turbo run lint` only. `no-unresolved` also makes #888 harder: it fails from a repo-root working directory, where the resolver finds no root `tsconfig.json` and every `@/*` alias reports unresolved. That rules out fixing #888 with `types_or:` alone, and I have noted it on that issue. The first commit's message calls `eslint` a commit gate — that is wrong, and this is the correction.

## Verification

Refactor equivalence was checked rather than assumed: `eslint --print-config` captured for 26 files spanning all nine workspaces, before and after, key-sorted and diffed. Identical throughout.

Closes #812