### PR TITLE
feat(lint): gate shell scripts on shellcheck and shfmt

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,10 @@
         // TypeScript enhancements
         "yoavbls.pretty-ts-errors",
 
+        // Shell scripts
+        "timonwong.shellcheck",
+        "foxundermoon.shell-format",
+
         // Documentation
         "chrischinchilla.vale-vscode",
 

--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -36,57 +36,67 @@ print_version() {
   echo "  ${label}: ${version}"
 }
 
+# The lifecycle scripts run under `set -x`, which drowns these reports in trace
+# output. Run the report with xtrace off and put the caller's setting back,
+# whatever it was — `shopt -po` prints the restoring command itself.
+quietly() {
+  local restore
+  restore="$(shopt -po xtrace 2>/dev/null)" || true
+  { set +x; } 2>/dev/null
+  "$@"
+  eval "${restore}"
+}
+
+# Applies an action to every tool the devcontainer installs, so verification and
+# the version summary cannot list different tools.
+for_each_tool() {
+  local action="$1"
+  "${action}" "node" node --version
+  "${action}" "pnpm" pnpm --version
+  "${action}" "gcloud" gcloud --version
+  "${action}" "pre-commit" pre-commit --version
+  "${action}" "reuse" reuse --version
+  "${action}" "lychee" lychee --version
+  "${action}" "firebase" firebase --version
+  "${action}" "playwright" pnpm --filter @genshin/e2e exec playwright --version
+}
+
 # ---------------------------------------------------------------------------
 # Verification
 # ---------------------------------------------------------------------------
 
-run_verification() {
-  local _xtrace
-  _xtrace="$(shopt -po xtrace 2>/dev/null)" || true
-  { set +x; } 2>/dev/null
+check_tools() {
   step "Verifying installed tools"
 
-  verify "node" node --version
-  verify "pnpm" pnpm --version
-  verify "gcloud" gcloud --version
-  verify "pre-commit" pre-commit --version
-  verify "reuse" reuse --version
-  verify "lychee" lychee --version
-  verify "firebase" firebase --version
-  verify "playwright-cli" pnpm --filter @genshin/e2e exec playwright --version
+  for_each_tool verify
+  # The browsers are a separate artifact from the CLI that only an install
+  # check can see, and they report no version, so they sit outside the table.
   verify "playwright-browsers" pnpm --filter @genshin/e2e exec playwright install --list
-  eval "${_xtrace}"
+}
+
+run_verification() {
+  quietly check_tools
 }
 
 # ---------------------------------------------------------------------------
 # Version summary
 # ---------------------------------------------------------------------------
 
-run_version_summary() {
-  local _xtrace
-  _xtrace="$(shopt -po xtrace 2>/dev/null)" || true
-  { set +x; } 2>/dev/null
+show_versions() {
   step "Environment versions"
 
-  print_version "node" node --version
-  print_version "pnpm" pnpm --version
-  print_version "gcloud" gcloud --version
-  print_version "pre-commit" pre-commit --version
-  print_version "reuse" reuse --version
-  print_version "lychee" lychee --version
-  print_version "firebase" firebase --version
-  print_version "playwright" pnpm --filter @genshin/e2e exec playwright --version
-  eval "${_xtrace}"
+  for_each_tool print_version
+}
+
+run_version_summary() {
+  quietly show_versions
 }
 
 # ---------------------------------------------------------------------------
 # Final status
 # ---------------------------------------------------------------------------
 
-run_status() {
-  local _xtrace
-  _xtrace="$(shopt -po xtrace 2>/dev/null)" || true
-  { set +x; } 2>/dev/null
+show_status() {
   echo ""
   if [[ ${#FAILURES[@]} -gt 0 ]]; then
     echo "Setup completed with failures:"
@@ -99,5 +109,8 @@ run_status() {
   fi
 
   echo "Setup complete — all tools verified."
-  eval "${_xtrace}"
+}
+
+run_status() {
+  quietly show_status
 }

--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -37,8 +37,8 @@ print_version() {
 }
 
 # The lifecycle scripts run under `set -x`, which drowns these reports in trace
-# output. Run the report with xtrace off and put the caller's setting back,
-# whatever it was — `shopt -po` prints the restoring command itself.
+# output. `shopt -po` prints the command that restores the caller's setting,
+# whatever it was.
 quietly() {
   local restore
   restore="$(shopt -po xtrace 2>/dev/null)" || true
@@ -47,8 +47,8 @@ quietly() {
   eval "${restore}"
 }
 
-# Applies an action to every tool the devcontainer installs, so verification and
-# the version summary cannot list different tools.
+# Verification and the version summary have to cover the same tools; one list
+# is what stops them drifting apart.
 for_each_tool() {
   local action="$1"
   "${action}" "node" node --version
@@ -69,8 +69,8 @@ check_tools() {
   step "Verifying installed tools"
 
   for_each_tool verify
-  # The browsers are a separate artifact from the CLI that only an install
-  # check can see, and they report no version, so they sit outside the table.
+  # The browsers install separately from the CLI and report no version, so
+  # only an install check can see them.
   verify "playwright-browsers" pnpm --filter @genshin/e2e exec playwright install --list
 }
 

--- a/.devcontainer/lib.sh
+++ b/.devcontainer/lib.sh
@@ -20,7 +20,7 @@ step() {
 verify() {
   local label="$1"
   shift
-  if "$@" > /dev/null 2>&1; then
+  if "$@" >/dev/null 2>&1; then
     echo "  [ok] ${label}"
   else
     echo "  [FAIL] ${label}"
@@ -46,15 +46,15 @@ run_verification() {
   { set +x; } 2>/dev/null
   step "Verifying installed tools"
 
-  verify "node"                 node --version
-  verify "pnpm"                 pnpm --version
-  verify "gcloud"               gcloud --version
-  verify "pre-commit"           pre-commit --version
-  verify "reuse"                reuse --version
-  verify "lychee"               lychee --version
-  verify "firebase"             firebase --version
-  verify "playwright-cli"       pnpm --filter @genshin/e2e exec playwright --version
-  verify "playwright-browsers"  pnpm --filter @genshin/e2e exec playwright install --list
+  verify "node" node --version
+  verify "pnpm" pnpm --version
+  verify "gcloud" gcloud --version
+  verify "pre-commit" pre-commit --version
+  verify "reuse" reuse --version
+  verify "lychee" lychee --version
+  verify "firebase" firebase --version
+  verify "playwright-cli" pnpm --filter @genshin/e2e exec playwright --version
+  verify "playwright-browsers" pnpm --filter @genshin/e2e exec playwright install --list
   eval "${_xtrace}"
 }
 
@@ -68,13 +68,13 @@ run_version_summary() {
   { set +x; } 2>/dev/null
   step "Environment versions"
 
-  print_version "node"       node --version
-  print_version "pnpm"       pnpm --version
-  print_version "gcloud"     gcloud --version
+  print_version "node" node --version
+  print_version "pnpm" pnpm --version
+  print_version "gcloud" gcloud --version
   print_version "pre-commit" pre-commit --version
-  print_version "reuse"      reuse --version
-  print_version "lychee"     lychee --version
-  print_version "firebase"   firebase --version
+  print_version "reuse" reuse --version
+  print_version "lychee" lychee --version
+  print_version "firebase" firebase --version
   print_version "playwright" pnpm --filter @genshin/e2e exec playwright --version
   eval "${_xtrace}"
 }

--- a/.devcontainer/postAttachCommand.sh
+++ b/.devcontainer/postAttachCommand.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
 # shellcheck source=lib.sh
 source "${SCRIPT_DIR}/lib.sh"
 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -7,6 +7,7 @@ set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+# shellcheck source-path=SCRIPTDIR
 # shellcheck source=lib.sh
 source "${SCRIPT_DIR}/lib.sh"
 
@@ -17,10 +18,10 @@ corepack install
 
 step "Installing Google Cloud SDK"
 
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/cloud.google.gpg && \
-echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
-sudo DEBIAN_FRONTEND=noninteractive apt-get update && \
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y google-cloud-sdk
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/cloud.google.gpg &&
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list &&
+  sudo DEBIAN_FRONTEND=noninteractive apt-get update &&
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y google-cloud-sdk
 
 step "Installing project dependencies"
 
@@ -40,8 +41,8 @@ step "Installing lychee link checker"
 LYCHEE_VERSION="0.24.2"
 LYCHEE_DIR=lychee-x86_64-unknown-linux-gnu
 curl -fsSL \
-  "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/${LYCHEE_DIR}.tar.gz" \
-  | sudo tar -xz -C /usr/local/bin --strip-components=1 "${LYCHEE_DIR}/lychee"
+  "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/${LYCHEE_DIR}.tar.gz" |
+  sudo tar -xz -C /usr/local/bin --strip-components=1 "${LYCHEE_DIR}/lychee"
 sudo chmod +x /usr/local/bin/lychee
 
 step "Installing Playwright Chromium and Chrome"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,8 +66,8 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        # -x follows sourced files, so helpers in .devcontainer/lib.sh are
-        # checked against their callers rather than reported as unresolved.
+        # Without -x, the .devcontainer entrypoints report lib.sh as
+        # unresolvable instead of checking against it.
         args: [-x]
 
   # Shell script formatting
@@ -75,9 +75,9 @@ repos:
     rev: v3.13.1-1
     hooks:
       - id: shfmt
-        # --write is in the hook's default args, and pre-commit replaces
-        # those wholesale rather than appending; without it shfmt prints to
-        # stdout, exits 0, and gates nothing.
+        # Keep --write. It is one of the hook's default args, and pre-commit
+        # replaces those wholesale rather than appending; without it shfmt
+        # writes to stdout and exits 0 on files it would have rewritten.
         args: [--write, -i, '2', -ci]
 
   # Vale - Prose linting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,25 @@ repos:
       - id: yamllint
         args: [--strict]
 
+  # Shell script linting
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        # -x follows sourced files, so helpers in .devcontainer/lib.sh are
+        # checked against their callers rather than reported as unresolved.
+        args: [-x]
+
+  # Shell script formatting
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        # --write is in the hook's default args, and pre-commit replaces
+        # those wholesale rather than appending; without it shfmt prints to
+        # stdout, exits 0, and gates nothing.
+        args: [--write, -i, '2', -ci]
+
   # Vale - Prose linting
   - repo: https://github.com/errata-ai/vale
     rev: v3.17.1

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,10 @@
     // TypeScript enhancements
     "yoavbls.pretty-ts-errors",
 
+    // Shell scripts
+    "timonwong.shellcheck",
+    "foxundermoon.shell-format",
+
     // Documentation
     "chrischinchilla.vale-vscode",
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,8 +37,7 @@
   },
 
   // Shell scripts
-  // Mirrors the shfmt pre-commit hook's flags so formatting on save produces
-  // what the commit gate expects.
+  // Keep in step with the shfmt pre-commit hook's flags.
   "shellformat.flag": "-i 2 -ci",
 
   // TypeScript

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,14 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.wordWrap": "on"
   },
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+
+  // Shell scripts
+  // Mirrors the shfmt pre-commit hook's flags so formatting on save produces
+  // what the commit gate expects.
+  "shellformat.flag": "-i 2 -ci",
 
   // TypeScript
   "typescript.preferences.importModuleSpecifier": "shortest",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Pre-commit enforces formatting, linting, documentation, and hygiene checks on ev
 
 ### What your pull request has to pass
 
-- Every pre-commit hook. Run `pre-commit install` once, and the same hooks run on each commit that CI runs over the whole tree—so a clean commit is a clean build. The first commit after that builds an isolated environment for each hook and can take several minutes. `pre-commit run --all-files` reproduces CI exactly.
+- Every pre-commit hook. Run `pre-commit install` once, and the same hooks run on each commit that CI runs over the whole tree—so a clean commit is a clean build. The first commit afterward builds each hook's environment and can take several minutes. `pre-commit run --all-files` reproduces CI exactly.
 - The workspace build and tests: `pnpm turbo run typecheck test build`.
 - The end-to-end suite in `tools/e2e`: `pnpm turbo run test:e2e`. It starts the Firebase emulators, the API, and the dev server itself, so stop any `pnpm dev` first—in this checkout or any other worktree—or the emulators fail to bind.
 - Feature work adds tests when it introduces testable behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Pre-commit enforces formatting, linting, documentation, and hygiene checks on ev
 
 ### What your pull request has to pass
 
-- Every pre-commit hook. Run `pre-commit install` once, and the same hooks run on each commit that CI runs over the whole tree—so a clean commit is a clean build. `pre-commit run --all-files` reproduces CI exactly.
+- Every pre-commit hook. Run `pre-commit install` once, and the same hooks run on each commit that CI runs over the whole tree—so a clean commit is a clean build. The first commit after that builds an isolated environment for each hook and can take several minutes. `pre-commit run --all-files` reproduces CI exactly.
 - The workspace build and tests: `pnpm turbo run typecheck test build`.
 - The end-to-end suite in `tools/e2e`: `pnpm turbo run test:e2e`. It starts the Firebase emulators, the API, and the dev server itself, so stop any `pnpm dev` first—in this checkout or any other worktree—or the emulators fail to bind.
 - Feature work adds tests when it introduces testable behavior.

--- a/apps/api/scripts/smoke-test-container.sh
+++ b/apps/api/scripts/smoke-test-container.sh
@@ -17,7 +17,7 @@ docker run -d --name "$CONTAINER_NAME" \
   "$IMAGE_TAG"
 
 for i in $(seq 1 "$HEALTH_TIMEOUT_SECONDS"); do
-  if curl -fsSL "http://localhost:$PORT/health" > /dev/null 2>&1; then
+  if curl -fsSL "http://localhost:$PORT/health" >/dev/null 2>&1; then
     echo "Health check passed on attempt $i"
     break
   fi

--- a/apps/web/scripts/firebase-config-to-outputs.sh
+++ b/apps/web/scripts/firebase-config-to-outputs.sh
@@ -22,4 +22,4 @@ CFG=$(terraform output -json firebase_web_app_config)
   echo "VITE_FIREBASE_STORAGE_BUCKET=$(echo "$CFG" | jq -er .storage_bucket)"
   echo "VITE_FIREBASE_MESSAGING_SENDER_ID=$(echo "$CFG" | jq -er .messaging_sender_id)"
   echo "VITE_FIREBASE_APP_ID=$(echo "$CFG" | jq -er .app_id)"
-} >> "$GITHUB_OUTPUT"
+} >>"$GITHUB_OUTPUT"

--- a/apps/web/scripts/verify-build-output.sh
+++ b/apps/web/scripts/verify-build-output.sh
@@ -9,7 +9,19 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
 # Verify build artifacts exist and have expected structure
-test -d apps/web/dist || { echo "dist directory not found" >&2; exit 1; }
-test -f apps/web/dist/index.html || { echo "index.html not found" >&2; exit 1; }
-test -d apps/web/dist/assets || { echo "assets directory not found" >&2; exit 1; }
-test -f apps/web/dist/version.json || { echo "version.json not found" >&2; exit 1; }
+test -d apps/web/dist || {
+  echo "dist directory not found" >&2
+  exit 1
+}
+test -f apps/web/dist/index.html || {
+  echo "index.html not found" >&2
+  exit 1
+}
+test -d apps/web/dist/assets || {
+  echo "assets directory not found" >&2
+  exit 1
+}
+test -f apps/web/dist/version.json || {
+  echo "version.json not found" >&2
+  exit 1
+}

--- a/apps/web/scripts/verify-build-output.sh
+++ b/apps/web/scripts/verify-build-output.sh
@@ -16,7 +16,6 @@ require() {
   }
 }
 
-# Verify build artifacts exist and have expected structure
 require -d apps/web/dist
 require -f apps/web/dist/index.html
 require -d apps/web/dist/assets

--- a/apps/web/scripts/verify-build-output.sh
+++ b/apps/web/scripts/verify-build-output.sh
@@ -8,20 +8,16 @@ set -x
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+require() {
+  local kind="$1" path="$2"
+  test "${kind}" "${path}" || {
+    echo "${path} not found" >&2
+    exit 1
+  }
+}
+
 # Verify build artifacts exist and have expected structure
-test -d apps/web/dist || {
-  echo "dist directory not found" >&2
-  exit 1
-}
-test -f apps/web/dist/index.html || {
-  echo "index.html not found" >&2
-  exit 1
-}
-test -d apps/web/dist/assets || {
-  echo "assets directory not found" >&2
-  exit 1
-}
-test -f apps/web/dist/version.json || {
-  echo "version.json not found" >&2
-  exit 1
-}
+require -d apps/web/dist
+require -f apps/web/dist/index.html
+require -d apps/web/dist/assets
+require -f apps/web/dist/version.json

--- a/apps/web/scripts/verify-deployment.sh
+++ b/apps/web/scripts/verify-deployment.sh
@@ -13,4 +13,7 @@ DOMAIN="${1:?Error: domain URL is required as first argument}"
 CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 DEPLOYED=$(curl -fsSL "$DOMAIN/version.json" | jq -r '.sha')
 
-[ "$CURRENT_SHA" = "$DEPLOYED" ] || { echo "SHA mismatch: deployed=$DEPLOYED current=$CURRENT_SHA" >&2; exit 1; }
+[ "$CURRENT_SHA" = "$DEPLOYED" ] || {
+  echo "SHA mismatch: deployed=$DEPLOYED current=$CURRENT_SHA" >&2
+  exit 1
+}

--- a/scripts/install-reuse.sh
+++ b/scripts/install-reuse.sh
@@ -13,14 +13,14 @@ set -euo pipefail
 # renovate: datasource=github-releases depName=fsfe/reuse-tool extractVersion=^v(?<version>.+)$
 REUSE_VERSION="${REUSE_VERSION:-6.2.0}"
 
-if command -v reuse > /dev/null 2>&1; then
+if command -v reuse >/dev/null 2>&1; then
   installed="$(reuse --version 2>/dev/null | awk '{print $NF}')"
   if [[ "${installed}" == "${REUSE_VERSION}" ]]; then
     echo "reuse ${REUSE_VERSION} already installed; skipping."
     exit 0
   fi
   echo "reuse ${installed} present; replacing with ${REUSE_VERSION}."
-  pipx uninstall reuse > /dev/null
+  pipx uninstall reuse >/dev/null
 fi
 
 pipx install "reuse==${REUSE_VERSION}"


### PR DESCRIPTION
## Summary

The ten tracked `.sh` files now have a linter and a formatter, closing the gap the guardrail audit in #1014 named. Both hooks vendor their own prebuilt binary, so the devcontainer image is unchanged — and pre-commit is where they become a gate at all, since sessions and CI run outside the container.

Three commits: the gate, a refactor of the shell helpers the gate churned, then a comment pass. The last two are droppable on their own if you'd rather they went separately.

Closes #217

## Gotchas

- **`--write` in the shfmt args is load-bearing.** pre-commit replaces a manifest's default args wholesale rather than appending, and `--write` is one of them. Without it shfmt prints to stdout and exits 0 — reporting `Passed` on a file it would have rewritten. I hit exactly that on the first pass. Worth knowing before overriding args on any other formatter hook here.
- **The `.sh` churn in the first commit is one-time reformatting, not logic.** `> /dev/null` closes up, `&& \` continuations move the operator to the end of the line, and one-line `|| { ...; exit 1; }` guards become blocks.
- **`source-path=SCRIPTDIR` is what makes `-x` work.** The two `.devcontainer` entrypoints already carried `source=lib.sh`, but that resolves against the working directory — the repository root under pre-commit — so shellcheck reported the helper as unresolvable instead of reading it.
- **The second commit removes Duplicated Code that shfmt made louder.** `lib.sh` repeated the xtrace save/restore incantation in all three `run_*` functions (now a `quietly` wrapper) and listed the same eight tools twice (now `for_each_tool`, taking the action to apply). `verify-build-output.sh` had four identical guard blocks that shfmt had just expanded from 4 lines to 16 (now a `require` helper). One behaviour change, in log text only: the Playwright CLI verify label drops its `-cli` suffix, and `require` reports the full path rather than a hand-written noun. Nothing but a human reads either.
- Left alone deliberately: `FAILURES` is Global Data, but bash offers no encapsulation that pays for itself. `verify-deployment.sh` shares the guard shape, but one caller doesn't earn a library shared across two scripts.
- Documenting `postCreateCommand.sh` as the devcontainer extension point is left to #219, which owns that scope. The task list on #217 claimed it too.

## Verification

- Ran both hooks against a deliberately broken script: shellcheck failed on SC2034/SC2086/SC2050, and shfmt rewrote 8-space indentation to 2. Confirms neither is decoration.
- Drove `verify-build-output.sh` through all five states, creating one artifact at a time: each of the four `require` calls fires in turn and only the complete tree exits 0.
- Exercised `run_status` on both paths (failure exits 1 with the collected labels, success exits 0), and confirmed under `set -x` that `quietly` suppresses the trace during a report and restores it afterward.
- `run_verification` still reports the same nine entries; `bash -n` parses all ten scripts.