### PR TITLE
chore(vale): reorganize the vocabulary accept list

### DIFF
--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -26,7 +26,6 @@ Pyro
 # Tools, libraries, and services the repo depends on
 AJV
 Babel
-Claude
 Cloud Run
 Cloud Storage
 Codecov
@@ -40,7 +39,6 @@ Dockerfile
 ESLint
 Firebase
 Firestore
-gcloud
 GCP
 GitHub Actions
 hadolint
@@ -50,9 +48,7 @@ jq
 jsoncompat
 knip
 Lucide
-markdownlint
 Memcache
-npm
 OXC
 pipx
 pnpm
@@ -62,7 +58,6 @@ Renovate
 Stylelint
 SWC
 syncpack
-Tailwind CSS
 Trivy
 Turborepo
 TypeScript
@@ -81,7 +76,6 @@ CI/CD
 CLI
 DSGEP
 ESM
-ETag
 HMR
 HTTP
 IAM
@@ -93,7 +87,6 @@ JSONC
 MCP
 OAuth
 OpenAPI
-PascalCase
 REST
 REUSE
 RFC
@@ -130,7 +123,6 @@ SRECon
 [Mm]iddleware
 [Mm]onorepo
 [Nn]amespace
-[Oo]ptionalslop
 [Pp]arseable
 [Rr]epo
 [Rr]ollouts

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -1,26 +1,19 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-# Terms Vale accepts in Markdown prose.
+# Each entry tells Vale.Spelling to accept the word and Vale.Terms to
+# report every other capitalization of it. Entries are regular expressions
+# matched against whole words.
 #
-# Every entry does two jobs: Vale.Spelling stops flagging the term, and
-# Vale.Terms reports any other capitalization of it. Entries are regular
-# expressions matched against whole words, so two forms are in use:
-#
-#   Genshin      a name with one correct spelling; other casings are errors
-#   [Cc]onfig    an ordinary word the dictionary lacks; capitalization is
-#                the writer's call, so both forms pass
-#
-# A term earns a line when Vale flags it in this repo's prose, or when it
-# names a tool, service, or standard the repo depends on. Sections sort
-# alphabetically, ignoring case and the bracket.
+# Add a term when Vale flags it in this repo's prose, or when it names a
+# tool, service, or standard the repo depends on.
 
 # Project and site names
 Genshin
 Genshin Impact
 genshin.dungeon.studio
 
-# Genshin Impact game terms: elements and weapon types
+# Game terms: elements and weapon types
 Anemo
 Cryo
 Dendro
@@ -30,7 +23,7 @@ Hydro
 Polearm
 Pyro
 
-# Tools, libraries, and services the repo runs or depends on
+# Tools, libraries, and services the repo depends on
 AJV
 Babel
 Claude
@@ -120,7 +113,7 @@ O'Reilly
 Ostrow
 SRECon
 
-# Ordinary words the dictionary lacks; either capitalization passes
+# Ordinary words the dictionary lacks, in either capitalization
 [Aa]sync
 [Aa]uditable
 [Bb]ackfilled

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -1,182 +1,150 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-# Accepted terminology for this project
-# Vale will not flag these terms as spelling errors
-# Format: one term per line, case-sensitive
+# Terms Vale accepts in Markdown prose.
+#
+# Every entry does two jobs: Vale.Spelling stops flagging the term, and
+# Vale.Terms reports any other capitalization of it. Entries are regular
+# expressions matched against whole words, so two forms are in use:
+#
+#   Genshin      a name with one correct spelling; other casings are errors
+#   [Cc]onfig    an ordinary word the dictionary lacks; capitalization is
+#                the writer's call, so both forms pass
+#
+# A term earns a line when Vale flags it in this repo's prose, or when it
+# names a tool, service, or standard the repo depends on. Sections sort
+# alphabetically, ignoring case and the bracket.
 
-# Project names and brands
+# Project and site names
 Genshin
 Genshin Impact
 genshin.dungeon.studio
-Tailwind CSS
 
-# Languages and frameworks
-TypeScript
-JavaScript
-React Compiler
-zustand
+# Genshin Impact game terms: elements and weapon types
+Anemo
+Cryo
+Dendro
+Electro
+Geo
+Hydro
+Polearm
+Pyro
 
-# Build tools and package managers
-Turborepo
-Vite
-Bun
-pnpm
-npm
-corepack
-Dockerfile
-
-# Code quality tools
-Codecov
-knip
-jq
-pipx
-ESLint
-Prettier
-Stylelint
-Vitest
-hadolint
-markdownlint
-yamllint
-syncpack
-Colocate
-middleware
-tooltip
-
-# Configuration and tooling terms
-config
-configs
-formatters
-toolchain
-
-# Backend and database
-Firebase
-Firestore
-Verzod
-
-# Schema tooling
-backfilled
-deserializer
-jsoncompat
-Memcache
-optionalslop
-Ostrow
-Parseable
-rollouts
-serializer
-SRECon
-superset
-Zod
-Hono
-
-# Environment and deployment
-gcloud
-
-# Other tools and libraries
-Babel
-Lucide
-OXC
-SWC
-
-# API and architecture
-API
-APIs
+# Tools, libraries, and services the repo runs or depends on
 AJV
-cacheable
-CLI
-CI/CD
-dereferenceable
-dereferencing
-ETag
-HMR
-MCP
-monorepo
-namespace
-OpenAPI
-repo
-repos
-roadmaps
-semver
-typechecking
-unversioned
-Unprocessable
-validators
-
-# Cloud infrastructure
-GCP
+Babel
+Claude
 Cloud Run
 Cloud Storage
-auditable
-keyless
-
-# AI services
-Claude
-Anthropic
-Copilot
-claustre
-Claustre
-
-# Git concepts
-worktree
-worktrees
-
-# DevOps and automation
-GitHub Actions
+Codecov
 CodeQL
+Copilot
+corepack
 Dependabot
-Renovate
-Trivy
-SARIF
-misconfiguration
-misconfigurations
-
-# Web assets
-favicon
-polearm
-Polearm
-
-# Development workflow
-dev
-async
-allowlist
-allowlists
-hardcoded
-memoization
-playstyles
-ddbeck's
 DevContainers
 Diátaxis
-UTC
+Dockerfile
+ESLint
+Firebase
+Firestore
+gcloud
+GCP
+GitHub Actions
+hadolint
+Hono
+JavaScript
+jq
+jsoncompat
+knip
+Lucide
+markdownlint
+Memcache
+npm
+OXC
+pipx
+pnpm
+Prettier
+React Compiler
+Renovate
+Stylelint
+SWC
+syncpack
+Tailwind CSS
+Trivy
+Turborepo
+TypeScript
+Verzod
+Vite
+Vitest
+yamllint
+Zod
+zustand
+
+# Standards, formats, and acronyms
+API
+APIs
 camelCase
+CI/CD
+CLI
+DSGEP
+ESM
+ETag
+HMR
+HTTP
+IAM
+IETF
+INI
+ISBN
+ISO
+JSONC
+MCP
+OAuth
+OpenAPI
 PascalCase
 REST
-HTTP
-URI
-URIs
-ESM
-ISO
-SPDX
 REUSE
 RFC
-IETF
-ISBN
-OAuth
-Masse
-Hardt
-Dalal
-O'Reilly
-DSGEP
-IAM
+SARIF
+semver
 SPA
-JSONC
-INI
+SPDX
+URI
+URIs
+UTC
 
-# Game elements (Genshin Impact)
-Pyro
-Hydro
-Anemo
-Electro
-Dendro
-Cryo
-Geo
-DPS
+# Authors and works cited in docs
+Dalal
+Hardt
+Masse
+O'Reilly
+Ostrow
+SRECon
+
+# Ordinary words the dictionary lacks; either capitalization passes
+[Aa]sync
+[Aa]uditable
+[Bb]ackfilled
+[Cc]acheable
+[Cc]olocate
+[Cc]onfig
+[Cc]onfigs
+[Dd]eserializer
+[Dd]ev
+[Ff]avicon
+[Ff]ormatters
+[Hh]ardcoded
+[Kk]eyless
+[Mm]iddleware
+[Mm]onorepo
+[Nn]amespace
+[Oo]ptionalslop
+[Pp]arseable
+[Rr]epo
+[Rr]ollouts
+[Ss]erializer
+[Ss]uperset
+[Tt]oolchain
+[Tt]ypechecking
+[Uu]nprocessable
+[Uu]nversioned
+[Vv]alidators

--- a/.styles/config/vocabularies/Project/accept.txt
+++ b/.styles/config/vocabularies/Project/accept.txt
@@ -123,6 +123,7 @@ SRECon
 [Mm]iddleware
 [Mm]onorepo
 [Nn]amespace
+[Oo]ptionalslop
 [Pp]arseable
 [Rr]epo
 [Rr]ollouts

--- a/docs/reference/schema-versioning.md
+++ b/docs/reference/schema-versioning.md
@@ -169,5 +169,5 @@ stamp. Lifecycle:
 
 Robbie Ostrow (OpenAI), [Escaping Version Skew: Formalizing compatibility in a
 world of partial rollouts](https://www.usenix.org/conference/srecon26americas/presentation/ostrow),
-SRECon Americas 2026. Source for the two-role model, the optional-field
+SRECon Americas 2026. Source for the two-role model, the optionalslop
 anti-pattern, the subsumption checker approach, and the `jsoncompat` tool.

--- a/docs/reference/schema-versioning.md
+++ b/docs/reference/schema-versioning.md
@@ -169,5 +169,5 @@ stamp. Lifecycle:
 
 Robbie Ostrow (OpenAI), [Escaping Version Skew: Formalizing compatibility in a
 world of partial rollouts](https://www.usenix.org/conference/srecon26americas/presentation/ostrow),
-SRECon Americas 2026. Source for the two-role model, the optionalslop
+SRECon Americas 2026. Source for the two-role model, the optional-field
 anti-pattern, the subsumption checker approach, and the `jsoncompat` tool.


### PR DESCRIPTION
Closes #274.

Every `accept.txt` entry does two jobs and the list was curated for one: `Vale.Spelling` accepts the term, and `Vale.Terms` reports every *other* capitalization of it. That second job had collected false positives. `Vale.Terms` doesn't exempt sentence-initial position, so every lowercase common noun (`config`, `dev`, `repo`) was waiting for the first doc to open a sentence with it, and `Colocate` already demanded a capital C on an ordinary verb. Ordinary words now take `[Cc]onfig` form, which accepts either capitalization; names whose casing is a real convention keep enforcing it.

Terms that earn nothing are gone, proven by deleting them and confirming Vale's output doesn't move — including words that appear only inside code spans, which Vale never reads. 142 terms to 115, in five documented sections instead of seventeen ad-hoc ones. Vale emits a byte-identical 535 alerts at every commit here, so no current doc changes behaviour; only the latent cases do.

## Gotchas

Dropping the duplicate lowercase `polearm` means `Polearm` is now enforced in prose. Today's two lowercase uses sit inside `<!-- vale off -->` blocks, so nothing breaks yet.

`optionalslop` stays — it's Ostrow's own term, quoted in the `schema-versioning.md` bibliography beside three other contributions of his. I couldn't verify its rendering anywhere public: USENIX 403s and the `jsoncompat` README doesn't use it. If the talk writes it as two words, the doc and the entry both need the same fix.

Six tools live at HEAD but not yet documented (`knip`, `hadolint`, `yamllint`, `CodeQL`, `SARIF`, `Cloud Run`) stay deliberately, and are the only inert entries left.