### PR TITLE
ci: stop inheriting secrets into terraform apply

### DIFF
--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -44,8 +44,9 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-      # Each environment maps to an explicit secret to avoid dynamic secret
-      # indexing, which fixes CodeQL actions/excessive-secrets-exposure.
+      # `environment:` above resolves these environment-scoped secrets directly,
+      # so callers pass none. Reference each environment explicitly: dynamic
+      # `secrets[...]` indexing exposes every secret to this step.
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -44,9 +44,8 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-      # `environment:` above resolves these environment-scoped secrets directly,
-      # so callers pass none. Reference each environment explicitly: dynamic
-      # `secrets[...]` indexing exposes every secret to this step.
+      # Environment-scoped secrets resolve from this job's `environment:`, so
+      # callers pass none.
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,7 +26,6 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
-    secrets: inherit
 
   dev:
     name: Dev
@@ -38,7 +37,6 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: dev
-    secrets: inherit
 
   staging:
     name: Staging
@@ -50,4 +48,3 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: staging
-    secrets: inherit

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,11 +15,3 @@ rules:
     # request cannot write into the scope a develop or main run restores from.
     ignore:
       - ci.yml
-
-  secrets-inherit:
-    # terraform-apply.yml uses secret inheritance into its reusable workflow
-    # because the GCP_RW_* credentials are environment-scoped (core/dev/staging).
-    # Only the reusable declares `environment:`, so the caller cannot resolve
-    # those credentials to pass them explicitly.
-    ignore:
-      - terraform-apply.yml


### PR DESCRIPTION
## Summary

GitHub resolves environment secrets from the called job's own `environment:`,
not from what the caller passes, so `secrets: inherit` on the three apply jobs
was inert. Dropping it changes no behaviour and stops each run carrying
credentials for environments it never enters.

Refs #330; the remaining secret-name standardization is #1233.

## Gotchas

- The `.github/zizmor.yml` ignore is deleted, not moved — it suppressed a finding
  that had no cause. zizmor passes without it.
- Nothing pre-merge exercises Workload Identity auth; the first `develop` push
  touching `infrastructure/terraform/environments/**` is the real proof.

## Verification

- Confirmed over the REST environments API that `core`, `dev`, and `staging` each
  hold every secret the reusable workflow reads as an environment secret.