### PR TITLE
fix(api): save characters inside a Firestore transaction

### DIFF
--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -7,6 +7,7 @@ import type {
   ConstellationLevel,
   ISOTimestamp,
 } from '@genshin/domain';
+import type { DocumentSnapshot } from 'firebase-admin/firestore';
 
 import { db } from '@/firebase/firestore.js';
 
@@ -14,6 +15,14 @@ import { fromDocument, toDocument } from './document.js';
 
 function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('characters');
+}
+
+// `data()` is undefined exactly when the document is absent, so it subsumes an
+// `exists` check.
+function fromSnapshot(characterId: string, snapshot: DocumentSnapshot): CollectionCharacter | null {
+  const data = snapshot.data();
+
+  return data === undefined ? null : fromDocument(characterId, data);
 }
 
 export async function list(userId: string): Promise<CollectionCharacter[]> {
@@ -26,18 +35,7 @@ export async function get(
   userId: string,
   characterId: string,
 ): Promise<CollectionCharacter | null> {
-  const doc = await collectionRef(userId).doc(characterId).get();
-
-  if (!doc.exists) {
-    return null;
-  }
-
-  const data = doc.data();
-  if (data === undefined) {
-    return null;
-  }
-
-  return fromDocument(characterId, data);
+  return fromSnapshot(characterId, await collectionRef(userId).doc(characterId).get());
 }
 
 export interface SaveResult {
@@ -53,21 +51,20 @@ export async function save(
   const docRef = collectionRef(userId).doc(characterId);
 
   return db.runTransaction(async (transaction) => {
-    const existing = await transaction.get(docRef);
+    const snapshot = await transaction.get(docRef);
+    const existing = fromSnapshot(characterId, snapshot);
     const now = new Date().toISOString() as ISOTimestamp;
-
-    const existingData = existing.exists ? existing.data() : undefined;
 
     const character: CollectionCharacter = {
       characterId,
       constellationLevel,
-      createdAt: existingData ? fromDocument(characterId, existingData).createdAt : now,
+      createdAt: existing?.createdAt ?? now,
       updatedAt: now,
     };
 
     transaction.set(docRef, toDocument(character));
 
-    return { character, created: !existing.exists };
+    return { character, created: !snapshot.exists };
   });
 }
 

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -17,8 +17,7 @@ function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('characters');
 }
 
-// `data()` is undefined exactly when the document is absent, so it subsumes an
-// `exists` check.
+// `data()` returns undefined exactly when the document does not exist.
 function fromSnapshot(characterId: string, snapshot: DocumentSnapshot): CollectionCharacter | null {
   const data = snapshot.data();
 

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -51,21 +51,24 @@ export async function save(
   constellationLevel: ConstellationLevel,
 ): Promise<SaveResult> {
   const docRef = collectionRef(userId).doc(characterId);
-  const existing = await docRef.get();
-  const now = new Date().toISOString() as ISOTimestamp;
 
-  const existingData = existing.exists ? existing.data() : undefined;
+  return db.runTransaction(async (transaction) => {
+    const existing = await transaction.get(docRef);
+    const now = new Date().toISOString() as ISOTimestamp;
 
-  const character: CollectionCharacter = {
-    characterId,
-    constellationLevel,
-    createdAt: existingData ? fromDocument(characterId, existingData).createdAt : now,
-    updatedAt: now,
-  };
+    const existingData = existing.exists ? existing.data() : undefined;
 
-  await docRef.set(toDocument(character));
+    const character: CollectionCharacter = {
+      characterId,
+      constellationLevel,
+      createdAt: existingData ? fromDocument(characterId, existingData).createdAt : now,
+      updatedAt: now,
+    };
 
-  return { character, created: !existing.exists };
+    transaction.set(docRef, toDocument(character));
+
+    return { character, created: !existing.exists };
+  });
 }
 
 export async function remove(userId: string, characterId: string): Promise<void> {


### PR DESCRIPTION
Closes #447

`save` read the document, then wrote it back to preserve `createdAt`. Two concurrent upserts of the same character could both see it missing, so each stamped its own `createdAt` and each returned `created: true` — whichever write landed last decided what was stored. Reading and writing inside `runTransaction` makes that atomic: Firestore replays the callback when the document changes underneath it, so `createdAt` is stamped once and `created` reflects what the winning attempt saw.

## Gotchas

- **The diff touches `get`, which has nothing to do with the race.** `save` was consulting the document's existence three separate ways, which buried the only rule that matters — `createdAt` survives an update. `fromSnapshot` extracts the decode `get` already did inline, so both share it and `save`'s nested ternaries collapse to a null-coalesce.
- **`created` stays bound to `snapshot.exists` rather than the decoded value.** `data()` returns undefined exactly when the document is absent, so either would work. But existence is what that flag reports, and this PR exists because that flag was wrong — keeping it off the decode means it doesn't also depend on whether the stored document parses.
- **`teams.save` has the same shape and the same race.** Out of scope here, filed as #1236.

## Verification

No test ships with this. The behaviour only reproduces under real concurrency, and mocking `runTransaction` would assert nothing beyond the call. Against the Firestore emulator, eight concurrent saves of one character produced eight distinct `createdAt` values and eight `created: true` before the fix, and one of each after; a sequential create-then-update confirmed the refactor left `createdAt` preservation and the `created` flag intact. Both checks belong in the suite once #445 lands an emulator-backed harness.
