### PR TITLE
ci: restore secret inheritance for terraform apply

### DIFF
--- a/.github/workflows/terraform-apply-reusable.yml
+++ b/.github/workflows/terraform-apply-reusable.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-      # Environment-scoped secrets resolve from this job's `environment:`, so
-      # callers pass none.
+      # Each environment maps to an explicit secret to avoid dynamic secret
+      # indexing, which fixes CodeQL actions/excessive-secrets-exposure.
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_RW_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,6 +26,7 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
+    secrets: inherit
 
   dev:
     name: Dev
@@ -37,6 +38,7 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: dev
+    secrets: inherit
 
   staging:
     name: Staging
@@ -48,3 +50,4 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: staging
+    secrets: inherit

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,6 +26,12 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
+    # Load-bearing on all three jobs. The GCP_RW_* credentials resolve from
+    # the reusable workflow's own `environment:`, but only for a called
+    # workflow that receives a secrets mapping --- hand it none and its
+    # `secrets` context is empty, the environment's own included. `inherit`
+    # is the only available form: the caller has no access to environment
+    # secrets, so it cannot name them.
     secrets: inherit
 
   dev:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -26,12 +26,9 @@ jobs:
     uses: ./.github/workflows/terraform-apply-reusable.yml
     with:
       environment: core
-    # Load-bearing on all three jobs. The GCP_RW_* credentials resolve from
-    # the reusable workflow's own `environment:`, but only for a called
-    # workflow that receives a secrets mapping --- hand it none and its
-    # `secrets` context is empty, the environment's own included. `inherit`
-    # is the only available form: the caller has no access to environment
-    # secrets, so it cannot name them.
+    # A called workflow resolves its `environment:` secrets only if the caller
+    # passes a secrets mapping; with none, `secrets` is empty and the GCP_RW_*
+    # credentials never reach the auth step.
     secrets: inherit
 
   dev:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,3 +15,11 @@ rules:
     # request cannot write into the scope a develop or main run restores from.
     ignore:
       - ci.yml
+
+  secrets-inherit:
+    # terraform-apply.yml uses secret inheritance into its reusable workflow
+    # because the GCP_RW_* credentials are environment-scoped (core/dev/staging).
+    # Only the reusable declares `environment:`, so the caller cannot resolve
+    # those credentials to pass them explicitly.
+    ignore:
+      - terraform-apply.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -17,9 +17,10 @@ rules:
       - ci.yml
 
   secrets-inherit:
-    # terraform-apply.yml uses secret inheritance into its reusable workflow
-    # because the GCP_RW_* credentials are environment-scoped (core/dev/staging).
-    # Only the reusable declares `environment:`, so the caller cannot resolve
-    # those credentials to pass them explicitly.
+    # terraform-apply.yml must inherit. Its reusable workflow reads
+    # environment-scoped GCP_RW_* credentials, and a called workflow handed no
+    # secrets mapping resolves none of them, its own `environment:`
+    # notwithstanding. Naming them explicitly is not an option either: only the
+    # reusable declares `environment:`, so the caller cannot reach them.
     ignore:
       - terraform-apply.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -17,10 +17,7 @@ rules:
       - ci.yml
 
   secrets-inherit:
-    # terraform-apply.yml must inherit. Its reusable workflow reads
-    # environment-scoped GCP_RW_* credentials, and a called workflow handed no
-    # secrets mapping resolves none of them, its own `environment:`
-    # notwithstanding. Naming them explicitly is not an option either: only the
-    # reusable declares `environment:`, so the caller cannot reach them.
+    # Environment secrets cannot be passed by name: only the reusable declares
+    # `environment:`, so the caller has no handle on them and must inherit.
     ignore:
       - terraform-apply.yml


### PR DESCRIPTION
## Summary

Reverts c080369 (#1234). Without `secrets: inherit` the reusable workflow got an
empty `secrets` context, so `google-github-actions/auth` had no
`workload_identity_provider` and `Core / Apply` failed on the next develop push
([run 31329165181](https://github.com/dungeon-studio/genshin.dungeon.studio/actions/runs/31329165181)).
Nothing under `infrastructure/` had changed since the last successful apply, so no
drift accumulated.

## Gotchas

- GitHub's docs back #1234's premise, and its audit was correct --- `core`, `dev`,
  and `staging` each hold the secrets. The runner just doesn't behave that way.
- `inherit` never supplied the `GCP_RW_*` values either: only `GCP_RO_*` exists at
  repository level and the callers declare no `environment:`. Passing *something* is
  what triggers the environment lookup, so confirming the secrets exist proves
  nothing about whether the inherit is redundant.
- Nothing pre-merge exercises Workload Identity auth. The develop push after this
  merges is the only proof.

Refs #330.