### PR TITLE
test(api): cover the repository layer against Firestore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,9 @@ jobs:
         run: bash scripts/verify-dev.sh
 
   # Exercises the repository layer against a real Firestore. The workspace job
-  # above mocks it away, and the browser suite below reaches it only along the
-  # paths the UI offers — neither can plant a document the API is incapable of
-  # writing, which is what the version-union and slot-filter cases need.
+  # above mocks it away and the browser suite below reaches it only along the
+  # paths the UI offers, so neither can plant a stored document the API is
+  # incapable of writing.
   integration:
     name: Test against Firestore
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,57 @@ jobs:
           TIMEOUT_SECONDS: '120'
         run: bash scripts/verify-dev.sh
 
+  # Exercises the repository layer against a real Firestore. The workspace job
+  # above mocks it away, and the browser suite below reaches it only along the
+  # paths the UI offers — neither can plant a document the API is incapable of
+  # writing, which is what the version-union and slot-filter cases need.
+  integration:
+    name: Test against Firestore
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # renovate: datasource=java-version depName=java
+      JAVA_VERSION: '21'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - uses: ./.github/actions/setup-firebase-emulators
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      # Coverage lives in the script rather than a `--` passthrough, which would
+      # reach `firebase emulators:exec` instead of the vitest run inside it.
+      - name: Run integration tests
+        run: pnpm turbo run test:integration --filter @genshin/api
+
+      # Under the same flag as the unit suite, whose paths already cover
+      # apps/api/src/**; Codecov merges the two reports.
+      - name: Upload integration coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: apps/api/coverage-integration/lcov.info
+          flags: api
+          fail_ci_if_error: false
+
+      - name: Upload integration test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: apps/api/test-results/integration-junit.xml
+          flags: api
+          report_type: test_results
+          fail_ci_if_error: false
+
   # Drives a real browser through the assembled stack — Firebase emulators, the
   # API, and the Vite dev server. Separate from the workspace job because it is
   # the only check needing a JDK and a browser, and turbo cannot schedule either.

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ out/
 
 # Coverage reports
 coverage/
+coverage-integration/
 
 # Test results
 test-results/

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -15,6 +15,7 @@ ls:
   # declared explicitly or files would be silently skipped).
   .test.ts: kebab-case
   .test.tsx: kebab-case
+  .integration.test.ts: kebab-case
   .spec.ts: kebab-case
   .config.ts: kebab-case
   .config.js: kebab-case

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ For code conventions—comments, documentation strategy, naming, shared types, t
 - **Assert only the necessary properties**: keep each assertion as close to the property under test as possible; redundant assertions obscure what the test proves.
 - **Use `satisfies` for fixture annotations**: it validates the fixture shape at the declaration site without changing the inferred type, avoiding index-signature assignability errors.
 - **One schema assertion per route test, then field-level spot checks**: validate the response against the published JSON Schema with AJV first, then assert one specific value; don't re-test the schema field by field.
-- **Reserve the emulator suite for what no route can produce**: `*.integration.test.ts` files run against a real Firestore under `pnpm --filter @genshin/api test:integration`; a test belongs there when it has to plant a stored document the API itself would never write, not to re-cover ground the route or browser suites already reach.
+- **Reserve the emulator suite for what no route can produce**: an `*.integration.test.ts` earns its place when it has to plant a stored document the API itself would never write, not by re-covering ground the route or browser suites already reach.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ For code conventions—comments, documentation strategy, naming, shared types, t
 - **Assert only the necessary properties**: keep each assertion as close to the property under test as possible; redundant assertions obscure what the test proves.
 - **Use `satisfies` for fixture annotations**: it validates the fixture shape at the declaration site without changing the inferred type, avoiding index-signature assignability errors.
 - **One schema assertion per route test, then field-level spot checks**: validate the response against the published JSON Schema with AJV first, then assert one specific value; don't re-test the schema field by field.
+- **Reserve the emulator suite for what no route can produce**: `*.integration.test.ts` files run against a real Firestore under `pnpm --filter @genshin/api test:integration`; a test belongs there when it has to plant a stored document the API itself would never write, not to re-cover ground the route or browser suites already reach.
 
 ---
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/main.js",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:integration": "firebase emulators:exec --only firestore --project demo-dungeon-studio-genshin-dev \"vitest run --coverage --config vitest.integration.config.ts\"",
     "typecheck": "tsc --noEmit && tsc --project tsconfig.scripts.json --noEmit",
     "schemas:export": "tsx scripts/export-schemas.ts",
     "schemas:check": "tsx scripts/check-schema-compat.ts"

--- a/apps/api/src/repositories/characters/index.integration.test.ts
+++ b/apps/api/src/repositories/characters/index.integration.test.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { randomUUID } from 'node:crypto';
+
+import { CHARACTERS } from '@genshin/game-data';
+import { describe, expect, it } from 'vitest';
+
+import { db } from '@/firebase/firestore.js';
+
+import { get, remove, save } from './index.js';
+
+// Any character satisfies these; taking the first keeps a roster change from
+// stranding the suite on one that no longer exists.
+const CHARACTER = CHARACTERS[0];
+
+// A fresh user per test, so no test observes another's documents and the
+// emulator never needs clearing between them.
+const newUserId = () => randomUUID();
+
+function documentRef(userId: string, characterId: string) {
+  return db.collection('users').doc(userId).collection('characters').doc(characterId);
+}
+
+describe('save', () => {
+  it('keeps the original createdAt when the character is already collected', async () => {
+    const userId = newUserId();
+
+    const first = await save(userId, CHARACTER.id, 1);
+    const second = await save(userId, CHARACTER.id, 4);
+
+    expect(second.character.createdAt).toBe(first.character.createdAt);
+    expect(second.character.constellationLevel).toBe(4);
+  });
+
+  it('reports the first save as a creation and later ones as updates', async () => {
+    const userId = newUserId();
+
+    const first = await save(userId, CHARACTER.id, 1);
+    const second = await save(userId, CHARACTER.id, 2);
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+  });
+});
+
+describe('remove', () => {
+  it('leaves nothing to get', async () => {
+    const userId = newUserId();
+    await save(userId, CHARACTER.id, 1);
+
+    await remove(userId, CHARACTER.id);
+
+    expect(await get(userId, CHARACTER.id)).toBeNull();
+  });
+});
+
+describe('get', () => {
+  it('is null for a character the user never collected', async () => {
+    expect(await get(newUserId(), CHARACTER.id)).toBeNull();
+  });
+});
+
+// Nothing the API can do writes an unstamped document — `toDocument` always
+// stamps the current version — so these documents can only be planted, and this
+// is the only place the stored side of the version union gets exercised.
+describe('a document stored before schemaVersion existed', () => {
+  const unstamped = {
+    constellationLevel: 5,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+  };
+
+  it('still reads', async () => {
+    const userId = newUserId();
+    await documentRef(userId, CHARACTER.id).set(unstamped);
+
+    const character = await get(userId, CHARACTER.id);
+
+    expect(character).toEqual({
+      characterId: CHARACTER.id,
+      constellationLevel: unstamped.constellationLevel,
+      createdAt: unstamped.createdAt,
+      updatedAt: unstamped.updatedAt,
+    });
+  });
+
+  it('is stamped once written back', async () => {
+    const userId = newUserId();
+    await documentRef(userId, CHARACTER.id).set(unstamped);
+
+    await save(userId, CHARACTER.id, 6);
+
+    const stored = (await documentRef(userId, CHARACTER.id).get()).data();
+    expect(stored).toMatchObject({ schemaVersion: 1, createdAt: unstamped.createdAt });
+  });
+});

--- a/apps/api/src/repositories/characters/index.integration.test.ts
+++ b/apps/api/src/repositories/characters/index.integration.test.ts
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { randomUUID } from 'node:crypto';
-
 import { CHARACTERS } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
-import { db } from '@/firebase/firestore.js';
+import { documentRef, newUserId } from '@/test/firestore.js';
 
 import { get, remove, save } from './index.js';
 
@@ -14,13 +12,10 @@ import { get, remove, save } from './index.js';
 // stranding the suite on one that no longer exists.
 const CHARACTER = CHARACTERS[0];
 
-// A fresh user per test, so no test observes another's documents and the
-// emulator never needs clearing between them.
-const newUserId = () => randomUUID();
+const CREATED_AT = '2026-01-01T00:00:00.000Z';
+const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 
-function documentRef(userId: string, characterId: string) {
-  return db.collection('users').doc(userId).collection('characters').doc(characterId);
-}
+const characterRef = (userId: string) => documentRef(userId, 'characters', CHARACTER.id);
 
 describe('save', () => {
   it('keeps the original createdAt when the character is already collected', async () => {
@@ -61,37 +56,31 @@ describe('get', () => {
   });
 });
 
-// Nothing the API can do writes an unstamped document — `toDocument` always
-// stamps the current version — so these documents can only be planted, and this
-// is the only place the stored side of the version union gets exercised.
 describe('a document stored before schemaVersion existed', () => {
   const unstamped = {
     constellationLevel: 5,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-02T00:00:00.000Z',
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
   };
 
   it('still reads', async () => {
     const userId = newUserId();
-    await documentRef(userId, CHARACTER.id).set(unstamped);
+    await characterRef(userId).set(unstamped);
 
     const character = await get(userId, CHARACTER.id);
 
-    expect(character).toEqual({
-      characterId: CHARACTER.id,
-      constellationLevel: unstamped.constellationLevel,
-      createdAt: unstamped.createdAt,
-      updatedAt: unstamped.updatedAt,
-    });
+    expect(character).toEqual({ characterId: CHARACTER.id, ...unstamped });
   });
 
   it('is stamped once written back', async () => {
     const userId = newUserId();
-    await documentRef(userId, CHARACTER.id).set(unstamped);
+    await characterRef(userId).set(unstamped);
 
     await save(userId, CHARACTER.id, 6);
 
-    const stored = (await documentRef(userId, CHARACTER.id).get()).data();
-    expect(stored).toMatchObject({ schemaVersion: 1, createdAt: unstamped.createdAt });
+    expect((await characterRef(userId).get()).data()).toMatchObject({
+      schemaVersion: 1,
+      createdAt: CREATED_AT,
+    });
   });
 });

--- a/apps/api/src/repositories/firestore-error.test.ts
+++ b/apps/api/src/repositories/firestore-error.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { GoogleError, Status } from 'google-gax';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { firestoreErrorToHttpException } from './firestore-error.js';
+
+// The emulator cannot be made to exhaust a quota or go unavailable on demand,
+// so the transient codes arrive here as constructed errors rather than through
+// the integration suite.
+function googleError(code?: Status): GoogleError {
+  const err = new GoogleError('firestore said no');
+  err.code = code;
+  return err;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+describe('firestoreErrorToHttpException', () => {
+  it('lets a client retry an exhausted quota', () => {
+    expect(firestoreErrorToHttpException(googleError(Status.RESOURCE_EXHAUSTED)).status).toBe(429);
+  });
+
+  it('lets a client retry an unavailable backend', () => {
+    expect(firestoreErrorToHttpException(googleError(Status.UNAVAILABLE)).status).toBe(503);
+  });
+
+  it.each([
+    ['a permanent failure', Status.PERMISSION_DENIED],
+    ['an error carrying no code', undefined],
+  ])('reports %s as an internal error', (_label, code) => {
+    expect(firestoreErrorToHttpException(googleError(code)).status).toBe(500);
+  });
+
+  it('says nothing about the underlying failure in the response', () => {
+    expect(
+      firestoreErrorToHttpException(googleError(Status.PERMISSION_DENIED)).message,
+    ).not.toMatch(/firestore said no/);
+  });
+});

--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { randomUUID } from 'node:crypto';
+
+import type { TeamSlot } from '@genshin/domain';
+import { CHARACTERS } from '@genshin/game-data';
+import { describe, expect, it } from 'vitest';
+
+import { db } from '@/firebase/firestore.js';
+
+import { get, list, remove, save } from './index.js';
+
+const SLOT = 1 as TeamSlot;
+const CHARACTER = CHARACTERS[0];
+
+// A fresh user per test, so no test observes another's documents and the
+// emulator never needs clearing between them.
+const newUserId = () => randomUUID();
+
+function collectionRef(userId: string) {
+  return db.collection('users').doc(userId).collection('teams');
+}
+
+describe('get', () => {
+  it('returns the team saved in that slot', async () => {
+    const userId = newUserId();
+    await save(userId, SLOT, { name: 'Vaporise' });
+
+    const team = await get(userId, SLOT);
+
+    expect(team?.name).toBe('Vaporise');
+  });
+
+  it('is null for a slot the user never saved', async () => {
+    expect(await get(newUserId(), SLOT)).toBeNull();
+  });
+});
+
+describe('remove', () => {
+  it('leaves nothing to get', async () => {
+    const userId = newUserId();
+    await save(userId, SLOT, { name: 'Vaporise' });
+
+    await remove(userId, SLOT);
+
+    expect(await get(userId, SLOT)).toBeNull();
+  });
+});
+
+describe('list', () => {
+  // The routes reject any slot outside 1-4 before the repository sees it, so a
+  // document named anything else can only be planted. Reading one back as a
+  // team would hand `fromDocument` a slot the domain rejects.
+  it('skips documents whose id is not a slot', async () => {
+    const userId = newUserId();
+    await save(userId, SLOT, { name: 'Vaporise' });
+    await collectionRef(userId)
+      .doc('9')
+      .set({
+        schemaVersion: 1,
+        name: 'Out of range',
+        members: [null, null, null, null],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+    const teams = await list(userId);
+
+    expect(teams.map((team) => team.slot)).toEqual([SLOT]);
+  });
+});
+
+// Nothing the API can do writes an unstamped document — `toDocument` always
+// stamps the current version — so this document can only be planted, and this
+// is the only place the stored side of the version union gets exercised.
+describe('a document stored before schemaVersion existed', () => {
+  it('still reads', async () => {
+    const userId = newUserId();
+    await collectionRef(userId)
+      .doc(String(SLOT))
+      .set({
+        name: 'Vaporise',
+        members: [{ characterId: CHARACTER.id }, null, null, null],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      });
+
+    const team = await get(userId, SLOT);
+
+    expect(team).toEqual({
+      slot: SLOT,
+      name: 'Vaporise',
+      members: [{ characterId: CHARACTER.id }, null, null, null],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    });
+  });
+});

--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -1,35 +1,31 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { randomUUID } from 'node:crypto';
-
 import type { TeamSlot } from '@genshin/domain';
 import { CHARACTERS } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
-import { db } from '@/firebase/firestore.js';
+import { documentRef, newUserId } from '@/test/firestore.js';
 
 import { get, list, remove, save } from './index.js';
 
-const SLOT = 1 as TeamSlot;
+const SLOT: TeamSlot = 1;
 const CHARACTER = CHARACTERS[0];
+const TEAM_NAME = 'Vaporise';
 
-// A fresh user per test, so no test observes another's documents and the
-// emulator never needs clearing between them.
-const newUserId = () => randomUUID();
+const CREATED_AT = '2026-01-01T00:00:00.000Z';
+const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 
-function collectionRef(userId: string) {
-  return db.collection('users').doc(userId).collection('teams');
-}
+const teamRef = (userId: string, documentId: string) => documentRef(userId, 'teams', documentId);
 
 describe('get', () => {
   it('returns the team saved in that slot', async () => {
     const userId = newUserId();
-    await save(userId, SLOT, { name: 'Vaporise' });
+    await save(userId, SLOT, { name: TEAM_NAME });
 
     const team = await get(userId, SLOT);
 
-    expect(team?.name).toBe('Vaporise');
+    expect(team?.name).toBe(TEAM_NAME);
   });
 
   it('is null for a slot the user never saved', async () => {
@@ -40,7 +36,7 @@ describe('get', () => {
 describe('remove', () => {
   it('leaves nothing to get', async () => {
     const userId = newUserId();
-    await save(userId, SLOT, { name: 'Vaporise' });
+    await save(userId, SLOT, { name: TEAM_NAME });
 
     await remove(userId, SLOT);
 
@@ -49,21 +45,19 @@ describe('remove', () => {
 });
 
 describe('list', () => {
-  // The routes reject any slot outside 1-4 before the repository sees it, so a
-  // document named anything else can only be planted. Reading one back as a
-  // team would hand `fromDocument` a slot the domain rejects.
+  // The routes reject any slot outside 1-4 before the repository sees it.
+  // Reading such a document back as a team would hand `fromDocument` a slot the
+  // domain rejects.
   it('skips documents whose id is not a slot', async () => {
     const userId = newUserId();
-    await save(userId, SLOT, { name: 'Vaporise' });
-    await collectionRef(userId)
-      .doc('9')
-      .set({
-        schemaVersion: 1,
-        name: 'Out of range',
-        members: [null, null, null, null],
-        createdAt: '2026-01-01T00:00:00.000Z',
-        updatedAt: '2026-01-01T00:00:00.000Z',
-      });
+    await save(userId, SLOT, { name: TEAM_NAME });
+    await teamRef(userId, '9').set({
+      schemaVersion: 1,
+      name: 'Out of range',
+      members: [null, null, null, null],
+      createdAt: CREATED_AT,
+      updatedAt: UPDATED_AT,
+    });
 
     const teams = await list(userId);
 
@@ -71,29 +65,19 @@ describe('list', () => {
   });
 });
 
-// Nothing the API can do writes an unstamped document — `toDocument` always
-// stamps the current version — so this document can only be planted, and this
-// is the only place the stored side of the version union gets exercised.
 describe('a document stored before schemaVersion existed', () => {
   it('still reads', async () => {
     const userId = newUserId();
-    await collectionRef(userId)
-      .doc(String(SLOT))
-      .set({
-        name: 'Vaporise',
-        members: [{ characterId: CHARACTER.id }, null, null, null],
-        createdAt: '2026-01-01T00:00:00.000Z',
-        updatedAt: '2026-01-02T00:00:00.000Z',
-      });
+    const unstamped = {
+      name: TEAM_NAME,
+      members: [{ characterId: CHARACTER.id }, null, null, null],
+      createdAt: CREATED_AT,
+      updatedAt: UPDATED_AT,
+    };
+    await teamRef(userId, String(SLOT)).set(unstamped);
 
     const team = await get(userId, SLOT);
 
-    expect(team).toEqual({
-      slot: SLOT,
-      name: 'Vaporise',
-      members: [{ characterId: CHARACTER.id }, null, null, null],
-      createdAt: '2026-01-01T00:00:00.000Z',
-      updatedAt: '2026-01-02T00:00:00.000Z',
-    });
+    expect(team).toEqual({ slot: SLOT, ...unstamped });
   });
 });

--- a/apps/api/src/repositories/weapons/index.integration.test.ts
+++ b/apps/api/src/repositories/weapons/index.integration.test.ts
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { randomUUID } from 'node:crypto';
+
+import type { UUID } from '@genshin/domain';
+import { WEAPONS } from '@genshin/game-data';
+import { describe, expect, it } from 'vitest';
+
+import { db } from '@/firebase/firestore.js';
+
+import { create, get, list, remove, update } from './index.js';
+
+// Two distinct weapons, so a filtered list has something to leave out. Taken
+// from game data, so a roster change cannot strand the suite.
+const [WEAPON, OTHER_WEAPON] = WEAPONS;
+
+const REFINEMENT_LEVEL = 1;
+
+// A fresh user per test, so no test observes another's documents and the
+// emulator never needs clearing between them.
+const newUserId = () => randomUUID();
+
+// `create` mints instance ids itself; these stand in where a test needs one the
+// collection does not hold. The brand carries no runtime check, so the routes
+// assert it the same way.
+const newInstanceId = () => randomUUID() as UUID;
+
+function documentRef(userId: string, weaponInstanceId: string) {
+  return db.collection('users').doc(userId).collection('weapons').doc(weaponInstanceId);
+}
+
+describe('list', () => {
+  it('returns only the instances of the weapon it is filtered to', async () => {
+    const userId = newUserId();
+    const wanted = await create(userId, WEAPON.id, REFINEMENT_LEVEL);
+    await create(userId, WEAPON.id, REFINEMENT_LEVEL);
+    await create(userId, OTHER_WEAPON.id, REFINEMENT_LEVEL);
+
+    const instances = await list(userId, WEAPON.id);
+
+    expect(instances).toHaveLength(2);
+    expect(instances.map((instance) => instance.weaponId)).toEqual([WEAPON.id, WEAPON.id]);
+    expect(instances.map((instance) => instance.weaponInstanceId)).toContain(
+      wanted.weaponInstanceId,
+    );
+  });
+});
+
+describe('update', () => {
+  it('changes the refinement level without disturbing the rest of the instance', async () => {
+    const userId = newUserId();
+    const created = await create(userId, WEAPON.id, REFINEMENT_LEVEL);
+
+    const updated = await update(userId, created.weaponInstanceId as UUID, 5);
+
+    expect(updated).toMatchObject({
+      weaponInstanceId: created.weaponInstanceId,
+      weaponId: created.weaponId,
+      createdAt: created.createdAt,
+      refinementLevel: 5,
+    });
+  });
+
+  it('is null for an instance the user does not have', async () => {
+    expect(await update(newUserId(), newInstanceId(), 5)).toBeNull();
+  });
+});
+
+describe('remove', () => {
+  it('takes out the named instance and leaves the rest of the weapon alone', async () => {
+    const userId = newUserId();
+    const doomed = await create(userId, WEAPON.id, REFINEMENT_LEVEL);
+    const survivor = await create(userId, WEAPON.id, REFINEMENT_LEVEL);
+
+    await remove(userId, doomed.weaponInstanceId as UUID);
+
+    expect(await get(userId, doomed.weaponInstanceId as UUID)).toBeNull();
+    expect(await get(userId, survivor.weaponInstanceId as UUID)).not.toBeNull();
+  });
+});
+
+// Nothing the API can do writes an unstamped document — `toDocument` always
+// stamps the current version — so this document can only be planted, and this
+// is the only place the stored side of the version union gets exercised.
+describe('a document stored before schemaVersion existed', () => {
+  it('still reads', async () => {
+    const userId = newUserId();
+    const weaponInstanceId = randomUUID();
+    const unstamped = {
+      weaponId: WEAPON.id,
+      refinementLevel: 3,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    };
+    await documentRef(userId, weaponInstanceId).set(unstamped);
+
+    const weapon = await get(userId, weaponInstanceId as UUID);
+
+    expect(weapon).toEqual({ weaponInstanceId, ...unstamped });
+  });
+});

--- a/apps/api/src/repositories/weapons/index.integration.test.ts
+++ b/apps/api/src/repositories/weapons/index.integration.test.ts
@@ -3,11 +3,11 @@
 
 import { randomUUID } from 'node:crypto';
 
-import type { UUID } from '@genshin/domain';
+import type { CollectionWeapon, UUID } from '@genshin/domain';
 import { WEAPONS } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
-import { db } from '@/firebase/firestore.js';
+import { documentRef, newUserId } from '@/test/firestore.js';
 
 import { create, get, list, remove, update } from './index.js';
 
@@ -16,19 +16,18 @@ import { create, get, list, remove, update } from './index.js';
 const [WEAPON, OTHER_WEAPON] = WEAPONS;
 
 const REFINEMENT_LEVEL = 1;
+const RAISED_REFINEMENT_LEVEL = 5;
 
-// A fresh user per test, so no test observes another's documents and the
-// emulator never needs clearing between them.
-const newUserId = () => randomUUID();
+const CREATED_AT = '2026-01-01T00:00:00.000Z';
+const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 
-// `create` mints instance ids itself; these stand in where a test needs one the
-// collection does not hold. The brand carries no runtime check, so the routes
-// assert it the same way.
+// The instance id is a branded string the collection carries as a plain one, so
+// every hand-off back into the repository restates the brand the routes assert.
+const idOf = (weapon: CollectionWeapon) => weapon.weaponInstanceId as UUID;
 const newInstanceId = () => randomUUID() as UUID;
 
-function documentRef(userId: string, weaponInstanceId: string) {
-  return db.collection('users').doc(userId).collection('weapons').doc(weaponInstanceId);
-}
+const weaponRef = (userId: string, weaponInstanceId: string) =>
+  documentRef(userId, 'weapons', weaponInstanceId);
 
 describe('list', () => {
   it('returns only the instances of the weapon it is filtered to', async () => {
@@ -52,18 +51,18 @@ describe('update', () => {
     const userId = newUserId();
     const created = await create(userId, WEAPON.id, REFINEMENT_LEVEL);
 
-    const updated = await update(userId, created.weaponInstanceId as UUID, 5);
+    const updated = await update(userId, idOf(created), RAISED_REFINEMENT_LEVEL);
 
     expect(updated).toMatchObject({
       weaponInstanceId: created.weaponInstanceId,
       weaponId: created.weaponId,
       createdAt: created.createdAt,
-      refinementLevel: 5,
+      refinementLevel: RAISED_REFINEMENT_LEVEL,
     });
   });
 
   it('is null for an instance the user does not have', async () => {
-    expect(await update(newUserId(), newInstanceId(), 5)).toBeNull();
+    expect(await update(newUserId(), newInstanceId(), RAISED_REFINEMENT_LEVEL)).toBeNull();
   });
 });
 
@@ -73,16 +72,13 @@ describe('remove', () => {
     const doomed = await create(userId, WEAPON.id, REFINEMENT_LEVEL);
     const survivor = await create(userId, WEAPON.id, REFINEMENT_LEVEL);
 
-    await remove(userId, doomed.weaponInstanceId as UUID);
+    await remove(userId, idOf(doomed));
 
-    expect(await get(userId, doomed.weaponInstanceId as UUID)).toBeNull();
-    expect(await get(userId, survivor.weaponInstanceId as UUID)).not.toBeNull();
+    expect(await get(userId, idOf(doomed))).toBeNull();
+    expect(await get(userId, idOf(survivor))).not.toBeNull();
   });
 });
 
-// Nothing the API can do writes an unstamped document — `toDocument` always
-// stamps the current version — so this document can only be planted, and this
-// is the only place the stored side of the version union gets exercised.
 describe('a document stored before schemaVersion existed', () => {
   it('still reads', async () => {
     const userId = newUserId();
@@ -90,10 +86,10 @@ describe('a document stored before schemaVersion existed', () => {
     const unstamped = {
       weaponId: WEAPON.id,
       refinementLevel: 3,
-      createdAt: '2026-01-01T00:00:00.000Z',
-      updatedAt: '2026-01-02T00:00:00.000Z',
+      createdAt: CREATED_AT,
+      updatedAt: UPDATED_AT,
     };
-    await documentRef(userId, weaponInstanceId).set(unstamped);
+    await weaponRef(userId, weaponInstanceId).set(unstamped);
 
     const weapon = await get(userId, weaponInstanceId as UUID);
 

--- a/apps/api/src/repositories/weapons/index.integration.test.ts
+++ b/apps/api/src/repositories/weapons/index.integration.test.ts
@@ -21,8 +21,8 @@ const RAISED_REFINEMENT_LEVEL = 5;
 const CREATED_AT = '2026-01-01T00:00:00.000Z';
 const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 
-// The instance id is a branded string the collection carries as a plain one, so
-// every hand-off back into the repository restates the brand the routes assert.
+// The collection type widens the branded instance id to a plain string, so
+// every hand-off back into the repository restates the brand, as the routes do.
 const idOf = (weapon: CollectionWeapon) => weapon.weaponInstanceId as UUID;
 const newInstanceId = () => randomUUID() as UUID;
 

--- a/apps/api/src/test/firestore.ts
+++ b/apps/api/src/test/firestore.ts
@@ -13,19 +13,17 @@ type UserSubcollection = 'characters' | 'teams' | 'weapons';
 /**
  * A user id no other test uses.
  *
- * Every integration test owns one, so no test observes another's documents and
- * the emulator never needs clearing between them.
+ * Isolation rests on this rather than on clearing the emulator between tests,
+ * which is what lets the suites run in parallel.
  */
 export const newUserId = (): string => randomUUID();
 
 /**
- * A document at the path the repositories read and write.
+ * A document at the path the repositories read and write, for planting stored
+ * shapes no route can produce.
  *
- * Spelled out here rather than imported from the repository under test: a test
- * that derived the path from the code it exercises could not notice the path
- * changing. Tests reach for this to plant documents the API itself would never
- * write — a stored shape predating `schemaVersion`, or an id no route would
- * accept — since those are the cases nothing else can set up.
+ * The path is restated rather than imported from the repository under test: a
+ * fixture deriving it from the code it exercises could not notice it changing.
  */
 export function documentRef(
   userId: string,

--- a/apps/api/src/test/firestore.ts
+++ b/apps/api/src/test/firestore.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { randomUUID } from 'node:crypto';
+
+import type { DocumentReference } from 'firebase-admin/firestore';
+
+import { db } from '@/firebase/firestore.js';
+
+/** The per-user subcollections the repositories own. */
+type UserSubcollection = 'characters' | 'teams' | 'weapons';
+
+/**
+ * A user id no other test uses.
+ *
+ * Every integration test owns one, so no test observes another's documents and
+ * the emulator never needs clearing between them.
+ */
+export const newUserId = (): string => randomUUID();
+
+/**
+ * A document at the path the repositories read and write.
+ *
+ * Spelled out here rather than imported from the repository under test: a test
+ * that derived the path from the code it exercises could not notice the path
+ * changing. Tests reach for this to plant documents the API itself would never
+ * write — a stored shape predating `schemaVersion`, or an id no route would
+ * accept — since those are the cases nothing else can set up.
+ */
+export function documentRef(
+  userId: string,
+  collection: UserSubcollection,
+  documentId: string,
+): DocumentReference {
+  return db.collection('users').doc(userId).collection(collection).doc(documentId);
+}

--- a/apps/api/src/test/integration-setup.ts
+++ b/apps/api/src/test/integration-setup.ts
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-// `firebase emulators:exec` exports this; without it firebase-admin resolves
-// credentials and talks to whatever project the ambient environment names. The
-// suite writes and deletes documents, so it refuses to run rather than find out
-// which project that is.
+// `firebase emulators:exec` exports this. Without it firebase-admin resolves
+// credentials and writes to whatever project the ambient environment names, so
+// the suite refuses to run rather than find out which one that is.
 if (!process.env.FIRESTORE_EMULATOR_HOST) {
   throw new Error(
     'FIRESTORE_EMULATOR_HOST is unset. Run this suite through `pnpm --filter @genshin/api test:integration`.',

--- a/apps/api/src/test/integration-setup.ts
+++ b/apps/api/src/test/integration-setup.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// `firebase emulators:exec` exports this; without it firebase-admin resolves
+// credentials and talks to whatever project the ambient environment names. The
+// suite writes and deletes documents, so it refuses to run rather than find out
+// which project that is.
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  throw new Error(
+    'FIRESTORE_EMULATOR_HOST is unset. Run this suite through `pnpm --filter @genshin/api test:integration`.',
+  );
+}

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -3,7 +3,7 @@
 
 import { fileURLToPath } from 'node:url';
 
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
@@ -13,6 +13,9 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    // Spread the defaults: assigning `exclude` replaces them, which would drop
+    // node_modules and dist from the ignore list.
+    exclude: [...configDefaults.exclude, '**/*.integration.test.ts'],
     setupFiles: ['./src/test/setup.ts'],
     reporters: ['default', 'junit'],
     outputFile: {

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+// The suite that talks to a real Firestore, so it needs an emulator and cannot
+// join the default run. Named off the `vitest.config.ts` pattern the root
+// config globs as projects, which keeps `pnpm test` from picking it up.
+//
+// Its artifacts sit beside the unit suite's rather than replacing them: both
+// runs upload under the `api` flag, and Codecov merges the two reports.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    globals: true,
+    include: ['src/**/*.integration.test.ts'],
+    setupFiles: ['./src/test/integration-setup.ts'],
+    // Every test owns a freshly generated user id, so the documents one test
+    // writes are invisible to the rest and the emulator never needs clearing.
+    // Sharing one Firestore connection across files is what makes that cheap.
+    fileParallelism: false,
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/integration-junit.xml',
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage-integration',
+    },
+  },
+});

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -5,12 +5,12 @@ import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vitest/config';
 
-// The suite that talks to a real Firestore, so it needs an emulator and cannot
-// join the default run. Named off the `vitest.config.ts` pattern the root
-// config globs as projects, which keeps `pnpm test` from picking it up.
+// Needs a running emulator, so it cannot join the default run: the root config
+// globs `vitest.config.ts` as its projects, and this filename falls outside
+// that glob.
 //
-// Its artifacts sit beside the unit suite's rather than replacing them: both
-// runs upload under the `api` flag, and Codecov merges the two reports.
+// Artifact paths sit beside the unit suite's rather than replacing them. Both
+// upload under the `api` flag, and Codecov merges the two reports.
 export default defineConfig({
   resolve: {
     alias: {
@@ -21,10 +21,6 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.integration.test.ts'],
     setupFiles: ['./src/test/integration-setup.ts'],
-    // Every test owns a freshly generated user id, so the documents one test
-    // writes are invisible to the rest and the emulator never needs clearing.
-    // Sharing one Firestore connection across files is what makes that cheap.
-    fileParallelism: false,
     reporters: ['default', 'junit'],
     outputFile: {
       junit: './test-results/integration-junit.xml',

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 ---
-# Repository index.ts files are thin Firestore I/O adapters, exercised only
-# through route tests that mock them (`vi.mock('@/repositories/.../index.js')`),
-# so they carry no direct unit coverage by design. document.ts (the
-# fromDocument/toDocument logic) stays covered. teams.save merge logic is
-# tracked for real tests separately.
+# The other repositories are covered by the emulator-backed suite; this one is
+# inert and awaiting deletion in #879, so it gets no tests written for it.
 ignore:
-  - 'apps/api/src/repositories/*/index.ts'
+  - 'apps/api/src/repositories/profile/index.ts'
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 ---
-# The other repositories are covered by the emulator-backed suite; this one is
-# inert and awaiting deletion in #879, so it gets no tests written for it.
+# Inert and awaiting deletion in #879, so no tests are written for it.
 ignore:
   - 'apps/api/src/repositories/profile/index.ts'
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -20,9 +20,8 @@
       // verify-deployment.ts is invoked from deploy.yml, so knip can't see it.
       // The schemas:* scripts are auto-detected from their package.json entries.
       "entry": ["scripts/verify-deployment.ts"],
-      // The emulator-backed suite runs under a config knip's vitest plugin does
-      // not recognise by name; listing it here is what reaches its setup file
-      // and specs.
+      // knip's vitest plugin recognises only the conventional config name;
+      // listing the integration config reaches its setup file and specs.
       "vitest": {
         "config": ["vitest.config.ts", "vitest.integration.config.ts"]
       }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -19,7 +19,13 @@
     "apps/api": {
       // verify-deployment.ts is invoked from deploy.yml, so knip can't see it.
       // The schemas:* scripts are auto-detected from their package.json entries.
-      "entry": ["scripts/verify-deployment.ts"]
+      "entry": ["scripts/verify-deployment.ts"],
+      // The emulator-backed suite runs under a config knip's vitest plugin does
+      // not recognise by name; listing it here is what reaches its setup file
+      // and specs.
+      "vitest": {
+        "config": ["vitest.config.ts", "vitest.integration.config.ts"]
+      }
     },
     "apps/web": {
       // env.d.ts holds Vite ambient client types referenced via tsconfig, not imports.

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -31,11 +31,11 @@ export const VITEST_FILES = ['**/*.test.{ts,tsx}', '**/test/**/*.{ts,tsx}'];
 
 /**
  * TypeScript files no reachable `tsconfig.json` claims, so type-aware rules
- * skip them: nothing claims `vitest.config.ts`, and only
+ * skip them: nothing claims a `vitest.*config.ts`, and only
  * `tsconfig.scripts.json` claims `scripts/`, which the project service never
  * reaches because nothing references it.
  */
-const FILES_OUTSIDE_ANY_PROJECT = ['vitest.config.ts', 'scripts/**/*.ts'];
+const FILES_OUTSIDE_ANY_PROJECT = ['vitest.*config.ts', 'scripts/**/*.ts'];
 
 /** Paths allowed to import `devDependencies`. */
 const DEV_DEPENDENCY_FILES = [

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,10 @@
       "inputs": ["src/**", "package.json", "vite.config.*", "vitest.config.*", "tsconfig*.json"],
       "env": ["FAST_CHECK_SEED"]
     },
+    "test:integration": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "test:e2e": {
       "dependsOn": ["^build", "@genshin/api#build"],
       "cache": false


### PR DESCRIPTION
## Summary

The Firestore-touching half of the API is now tested. Every
`repositories/*/index.ts` sat at 0% coverage — route tests mock the module
wholesale, and the browser suite reaches the layer only along the paths the UI
offers and reports no coverage for it. The new emulator-backed suite covers what
was left: save-on-existing, remove, the filtered weapon list, team get, and two
invariants nothing else can reach at all, because they need a stored document
the API is incapable of writing — the v0 side of each version union, and the
team list's slot-id filter.

Closes #445

## Gotchas

- `codecov.yml` stops ignoring `repositories/*/index.ts`, so those files now
  count toward the project status. `profile/index.ts` keeps an exemption: it is
  inert and awaiting deletion in #879.
- `Test against Firestore` is a new job and is not in the branch ruleset, so it
  reports without gating until it's added there.
- `FILES_OUTSIDE_ANY_PROJECT` in the shared eslint config widened from
  `vitest.config.ts` to `vitest.*config.ts`, which every workspace inherits.
- `Characters.list` stays uncovered on purpose — it has no logic the browser
  suite doesn't already prove, and re-covering it was the overlap worth skipping.
- `src/test/firestore.ts` restates the `users/{id}/{collection}` path rather than
  importing it from the repositories. That is deliberate: a fixture deriving the
  path from the code under test could not notice the path changing.

## Verification

- Mutation-checked the three subtlest assertions: dropped the team slot-id
  filter, the character `createdAt` preservation, and the weapon list's
  `weaponId` filter. Each mutation failed exactly the intended test and nothing
  else.
- Re-ran the same three mutations after the fixture refactor in 588aa3e and got
  an identical failure set, confirming it cost the suite no detection power.