### PR TITLE
ci: track web bundle size with Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,13 @@ jobs:
       # lib/firebase.ts. This build only proves the app compiles and its output is
       # discarded, so any non-empty value satisfies it. Deployed bundles come from
       # the separate build step in deploy.yml, which injects the real config.
+      # apps/web's Codecov bundle report is uploaded from inside `vite build`, so
+      # the token is consumed here rather than by the upload step below. Placeholder
+      # Firebase values shift the bundle by a few bytes against a deployed build,
+      # which is constant run to run and so invisible to a size comparison.
       - name: Build
         env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           VITE_API_BASE_URL: https://api.invalid
           VITE_FIREBASE_API_KEY: ci
           VITE_FIREBASE_AUTH_DOMAIN: ci.invalid
@@ -88,6 +93,20 @@ jobs:
 
       - name: Verify Build Artifacts
         run: bash apps/web/scripts/verify-build-output.sh
+
+      # Rebuilds apps/web to inspect what the bundle plugin collected, which the
+      # uploading build above does not leave behind. Guards against it silently
+      # reporting nothing; see the script for why that is the failure to expect.
+      - name: Verify bundle stats
+        env:
+          VITE_API_BASE_URL: https://api.invalid
+          VITE_FIREBASE_API_KEY: ci
+          VITE_FIREBASE_AUTH_DOMAIN: ci.invalid
+          VITE_FIREBASE_PROJECT_ID: ci
+          VITE_FIREBASE_STORAGE_BUCKET: ci.invalid
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ci
+          VITE_FIREBASE_APP_ID: ci
+        run: pnpm --filter @genshin/web verify:bundle-stats
 
       - name: Upload coverage and test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,8 @@ jobs:
       # lib/firebase.ts. This build only proves the app compiles and its output is
       # discarded, so any non-empty value satisfies it. Deployed bundles come from
       # the separate build step in deploy.yml, which injects the real config.
-      # apps/web's Codecov bundle report is uploaded from inside `vite build`, so
-      # the token is consumed here rather than by the upload step below. Placeholder
-      # Firebase values shift the bundle by a few bytes against a deployed build,
-      # which is constant run to run and so invisible to a size comparison.
+      # apps/web's Codecov bundle report uploads from inside `vite build`, so the
+      # token is consumed here rather than by the upload step below.
       - name: Build
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -94,9 +92,9 @@ jobs:
       - name: Verify Build Artifacts
         run: bash apps/web/scripts/verify-build-output.sh
 
-      # Rebuilds apps/web to inspect what the bundle plugin collected, which the
-      # uploading build above does not leave behind. Guards against it silently
-      # reporting nothing; see the script for why that is the failure to expect.
+      # Rebuilds apps/web to inspect what the bundle plugin collected; the
+      # uploading build above leaves nothing on disk. See the script for the
+      # failure it guards.
       - name: Verify bundle stats
         env:
           VITE_API_BASE_URL: https://api.invalid

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "schemas:export": "tsx scripts/export-schemas.ts",
     "test": "vitest run",
+    "verify:bundle-stats": "tsx scripts/verify-bundle-stats.ts",
     "typecheck": "tsc -b --noEmit && tsc --project tsconfig.scripts.json --noEmit"
   },
   "dependencies": {
@@ -36,6 +37,7 @@
     "zustand": "5.0.14"
   },
   "devDependencies": {
+    "@codecov/vite-plugin": "2.0.1",
     "@eslint-react/eslint-plugin": "5.18.3",
     "@genshin/eslint-config": "workspace:*",
     "@tailwindcss/postcss": "4.3.3",

--- a/apps/web/scripts/verify-bundle-stats.ts
+++ b/apps/web/scripts/verify-bundle-stats.ts
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-// Proves the Codecov bundle plugin still reads this app's bundle. It declares a
-// peer range ending at Vite 6, and Vite 8 builds through Rolldown rather than
-// Rollup, so the hooks it reads are compatible by convention rather than by
-// contract. A break there costs nothing at build time and uploads an empty
-// report, which Codecov renders as a bundle that simply stopped changing — so
-// the failure has to be asserted here rather than waited for.
+// Proves the Codecov bundle plugin still reads this app's bundle. It declares no
+// support for the Vite major this app builds on, and the bundler underneath is
+// Rolldown rather than the Rollup its hooks assume, so collection holds by
+// convention rather than by contract. It would break silently: the build still
+// succeeds, the report uploads empty, and Codecov shows a bundle that stopped
+// changing.
 //
-// Runs its own dry-run build because the plugin writes the stats file only when
-// it is not uploading; the uploading build in CI leaves nothing to inspect.
+// Builds in the plugin's dry-run mode, the only one that writes the report to
+// disk; the uploading build in CI leaves nothing to inspect.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
@@ -29,10 +29,8 @@ interface BundleStats {
 const appDir = fileURLToPath(new URL('..', import.meta.url));
 const distDir = fileURLToPath(new URL('../dist', import.meta.url));
 
-// The plugin builds this filename from `bundleName` in vite.config.ts plus the
-// output format it appends. Discovering it rather than spelling it out keeps a
-// rename over there from surfacing here as a missing-report failure, which reads
-// like the plugin breakage this script exists to catch.
+// The plugin derives the filename from `bundleName` in vite.config.ts and the
+// output format it appends.
 const statsSuffix = '-stats.json';
 
 function statsReports(): string[] {
@@ -74,7 +72,7 @@ function collectBundleStats(): BundleStats {
   try {
     return JSON.parse(readFileSync(report, 'utf-8')) as BundleStats;
   } finally {
-    // Keeps an 80 kB report that only this script reads out of anything published.
+    // dist/ is published; the report is scaffolding for this script alone.
     rmSync(report, { force: true });
   }
 }
@@ -83,11 +81,9 @@ function sized<T extends Sized>(entries: T[], matching: (entry: T) => boolean = 
   return entries.filter((entry) => entry.size > 0 && matching(entry));
 }
 
-// A bundle this app could actually serve has at least one JavaScript asset, the
-// entry chunk holding it, and the modules that went into it. Each list empties
-// independently when the plugin loses hold of a different bundler hook, and
-// sizes go to zero separately again — the plugin can name every module while
-// measuring none of them, which costs the report its attribution.
+// Each list empties independently as the plugin loses hold of a different hook,
+// and sizes zero out separately again: it can name every module while measuring
+// none, which costs the report its attribution.
 function shortfallsIn(stats: BundleStats): string[] {
   const assets = stats.assets ?? [];
   const chunks = stats.chunks ?? [];

--- a/apps/web/scripts/verify-bundle-stats.ts
+++ b/apps/web/scripts/verify-bundle-stats.ts
@@ -12,73 +12,122 @@
 // it is not uploading; the uploading build in CI leaves nothing to inspect.
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync, rmSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+interface Sized {
+  size: number;
+}
+
 interface BundleStats {
-  bundleName?: string;
-  assets?: { name: string; size: number; gzipSize?: number }[];
+  assets?: (Sized & { name: string })[];
   chunks?: { uniqueId: string }[];
-  modules?: { name: string; size: number }[];
+  modules?: (Sized & { name: string })[];
 }
 
 const appDir = fileURLToPath(new URL('..', import.meta.url));
+const distDir = fileURLToPath(new URL('../dist', import.meta.url));
 
-// Matches `bundleName` in vite.config.ts, with the output format the plugin
-// appends to it.
-const statsPath = fileURLToPath(new URL('../dist/web-esm-stats.json', import.meta.url));
+// The plugin builds this filename from `bundleName` in vite.config.ts plus the
+// output format it appends. Discovering it rather than spelling it out keeps a
+// rename over there from surfacing here as a missing-report failure, which reads
+// like the plugin breakage this script exists to catch.
+const statsSuffix = '-stats.json';
 
-execFileSync('pnpm', ['exec', 'vite', 'build'], {
-  cwd: appDir,
-  stdio: 'inherit',
-  env: { ...process.env, CODECOV_BUNDLE_DRY_RUN: 'true' },
-});
+function statsReports(): string[] {
+  if (!existsSync(distDir)) return [];
 
-let stats: BundleStats;
-try {
-  stats = JSON.parse(readFileSync(statsPath, 'utf-8')) as BundleStats;
-} catch (error) {
-  throw new Error(
-    `The bundle plugin wrote no stats to ${statsPath}. It no longer recognises this ` +
-      `app's bundle; check its Vite support before trusting any Codecov bundle report.`,
-    { cause: error },
-  );
-} finally {
-  // Keeps an 80 kB report that only this script reads out of anything published.
-  rmSync(statsPath, { force: true });
+  return readdirSync(distDir)
+    .filter((name) => name.endsWith(statsSuffix))
+    .map((name) => join(distDir, name));
 }
 
-const assets = stats.assets ?? [];
-const chunks = stats.chunks ?? [];
-const modules = stats.modules ?? [];
+function collectBundleStats(): BundleStats {
+  // A report left by an earlier run would otherwise pass for a fresh one.
+  for (const stale of statsReports()) rmSync(stale);
 
-const failures: string[] = [];
+  execFileSync('pnpm', ['exec', 'vite', 'build'], {
+    cwd: appDir,
+    stdio: 'inherit',
+    env: { ...process.env, CODECOV_BUNDLE_DRY_RUN: 'true' },
+  });
+
+  const [report, ...surplus] = statsReports();
+
+  if (report === undefined) {
+    throw new Error(
+      `The bundle plugin wrote no ${statsSuffix} report to ${distDir}. It no longer ` +
+        `recognises this app's bundle; check its Vite support before trusting any ` +
+        `Codecov bundle report.`,
+    );
+  }
+
+  if (surplus.length > 0) {
+    throw new Error(
+      `Expected one ${statsSuffix} report in ${distDir}, found ${String(surplus.length + 1)}: ` +
+        `${[report, ...surplus].join(', ')}. Each describes a different output, so there ` +
+        `is no single report to hold the build to.`,
+    );
+  }
+
+  try {
+    return JSON.parse(readFileSync(report, 'utf-8')) as BundleStats;
+  } finally {
+    // Keeps an 80 kB report that only this script reads out of anything published.
+    rmSync(report, { force: true });
+  }
+}
+
+function sized<T extends Sized>(entries: T[], matching: (entry: T) => boolean = () => true): T[] {
+  return entries.filter((entry) => entry.size > 0 && matching(entry));
+}
 
 // A bundle this app could actually serve has at least one JavaScript asset, the
 // entry chunk holding it, and the modules that went into it. Each list empties
-// independently when the plugin loses hold of a different bundler hook.
-if (!assets.some((asset) => asset.name.endsWith('.js') && asset.size > 0)) {
-  failures.push(`no JavaScript asset with a non-zero size (found ${String(assets.length)} assets)`);
+// independently when the plugin loses hold of a different bundler hook, and
+// sizes go to zero separately again — the plugin can name every module while
+// measuring none of them, which costs the report its attribution.
+function shortfallsIn(stats: BundleStats): string[] {
+  const assets = stats.assets ?? [];
+  const chunks = stats.chunks ?? [];
+  const modules = stats.modules ?? [];
+
+  const shortfalls: string[] = [];
+
+  if (sized(assets, (asset) => asset.name.endsWith('.js')).length === 0) {
+    shortfalls.push(
+      `no JavaScript asset with a non-zero size (found ${String(assets.length)} assets)`,
+    );
+  }
+
+  if (chunks.length === 0) {
+    shortfalls.push('no chunks');
+  }
+
+  if (sized(modules).length === 0) {
+    shortfalls.push(`no module with a non-zero size (found ${String(modules.length)} modules)`);
+  }
+
+  return shortfalls;
 }
 
-if (chunks.length === 0) {
-  failures.push('no chunks');
+function summarise(stats: BundleStats): string {
+  return (
+    `${String(stats.assets?.length ?? 0)} assets, ` +
+    `${String(stats.chunks?.length ?? 0)} chunks, ` +
+    `${String(stats.modules?.length ?? 0)} modules`
+  );
 }
 
-// Sized modules are what turns a size change into an attributable one; the
-// plugin can list assets correctly while reporting every module as zero.
-if (!modules.some((module) => module.size > 0)) {
-  failures.push(`no module with a non-zero size (found ${String(modules.length)} modules)`);
-}
+const stats = collectBundleStats();
+const shortfalls = shortfallsIn(stats);
 
-if (failures.length > 0) {
+if (shortfalls.length > 0) {
   throw new Error(
-    `Codecov bundle stats are incomplete: ${failures.join('; ')}. The plugin built ` +
+    `Codecov bundle stats are incomplete: ${shortfalls.join('; ')}. The plugin built ` +
       `without error but did not describe the bundle, so uploaded reports would understate it.`,
   );
 }
 
-console.log(
-  `Codecov bundle stats OK: ${String(assets.length)} assets, ` +
-    `${String(chunks.length)} chunks, ${String(modules.length)} modules.`,
-);
+console.log(`Codecov bundle stats OK: ${summarise(stats)}.`);

--- a/apps/web/scripts/verify-bundle-stats.ts
+++ b/apps/web/scripts/verify-bundle-stats.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Proves the Codecov bundle plugin still reads this app's bundle. It declares a
+// peer range ending at Vite 6, and Vite 8 builds through Rolldown rather than
+// Rollup, so the hooks it reads are compatible by convention rather than by
+// contract. A break there costs nothing at build time and uploads an empty
+// report, which Codecov renders as a bundle that simply stopped changing — so
+// the failure has to be asserted here rather than waited for.
+//
+// Runs its own dry-run build because the plugin writes the stats file only when
+// it is not uploading; the uploading build in CI leaves nothing to inspect.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+interface BundleStats {
+  bundleName?: string;
+  assets?: { name: string; size: number; gzipSize?: number }[];
+  chunks?: { uniqueId: string }[];
+  modules?: { name: string; size: number }[];
+}
+
+const appDir = fileURLToPath(new URL('..', import.meta.url));
+
+// Matches `bundleName` in vite.config.ts, with the output format the plugin
+// appends to it.
+const statsPath = fileURLToPath(new URL('../dist/web-esm-stats.json', import.meta.url));
+
+execFileSync('pnpm', ['exec', 'vite', 'build'], {
+  cwd: appDir,
+  stdio: 'inherit',
+  env: { ...process.env, CODECOV_BUNDLE_DRY_RUN: 'true' },
+});
+
+let stats: BundleStats;
+try {
+  stats = JSON.parse(readFileSync(statsPath, 'utf-8')) as BundleStats;
+} catch (error) {
+  throw new Error(
+    `The bundle plugin wrote no stats to ${statsPath}. It no longer recognises this ` +
+      `app's bundle; check its Vite support before trusting any Codecov bundle report.`,
+    { cause: error },
+  );
+} finally {
+  // Keeps an 80 kB report that only this script reads out of anything published.
+  rmSync(statsPath, { force: true });
+}
+
+const assets = stats.assets ?? [];
+const chunks = stats.chunks ?? [];
+const modules = stats.modules ?? [];
+
+const failures: string[] = [];
+
+// A bundle this app could actually serve has at least one JavaScript asset, the
+// entry chunk holding it, and the modules that went into it. Each list empties
+// independently when the plugin loses hold of a different bundler hook.
+if (!assets.some((asset) => asset.name.endsWith('.js') && asset.size > 0)) {
+  failures.push(`no JavaScript asset with a non-zero size (found ${String(assets.length)} assets)`);
+}
+
+if (chunks.length === 0) {
+  failures.push('no chunks');
+}
+
+// Sized modules are what turns a size change into an attributable one; the
+// plugin can list assets correctly while reporting every module as zero.
+if (!modules.some((module) => module.size > 0)) {
+  failures.push(`no module with a non-zero size (found ${String(modules.length)} modules)`);
+}
+
+if (failures.length > 0) {
+  throw new Error(
+    `Codecov bundle stats are incomplete: ${failures.join('; ')}. The plugin built ` +
+      `without error but did not describe the bundle, so uploaded reports would understate it.`,
+  );
+}
+
+console.log(
+  `Codecov bundle stats OK: ${String(assets.length)} assets, ` +
+    `${String(chunks.length)} chunks, ${String(modules.length)} modules.`,
+);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -37,24 +37,18 @@ function shortSha(): string {
 const appVersion: string = packageVersion();
 const buildSha: string = shortSha();
 
-// A dry run collects the same stats but writes them beside the bundle instead of
-// uploading, which is how scripts/verify-bundle-stats.ts inspects them.
+// Writes the report beside the bundle instead of uploading it, which is how
+// scripts/verify-bundle-stats.ts inspects what the plugin collected.
 const bundleStatsDryRun: boolean = process.env.CODECOV_BUNDLE_DRY_RUN === 'true';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
-    // Bundle size tracking. The upload happens inside `vite build` rather than as
-    // a later CI step, so the token has to reach this process — turbo's strict
-    // env mode drops it unless `build.passThroughEnv` in turbo.json lists it.
-    // Keying on the token confines uploads to CI; local builds do nothing.
-    //
-    // The declared peer range stops at Vite 6 and this app builds on Vite 8,
-    // whose Rolldown bundler reports the Rollup-compatible hooks the plugin
-    // reads. It works, but nothing upstream guarantees it keeps working, and a
-    // plugin that silently collected nothing would look exactly like a bundle
-    // that never changed — hence the verify:bundle-stats gate in CI.
+    // Uploads from inside `vite build`, so the token has to reach this process:
+    // turbo's strict env mode drops it unless `build.passThroughEnv` in
+    // turbo.json lists it. Keying on the token confines uploads to CI.
+    // scripts/verify-bundle-stats.ts guards the collection this relies on.
     codecovVitePlugin({
       enableBundleAnalysis: bundleStatsDryRun || process.env.CODECOV_TOKEN !== undefined,
       bundleName: 'web',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
+import { codecovVitePlugin } from '@codecov/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
@@ -36,10 +37,31 @@ function shortSha(): string {
 const appVersion: string = packageVersion();
 const buildSha: string = shortSha();
 
+// A dry run collects the same stats but writes them beside the bundle instead of
+// uploading, which is how scripts/verify-bundle-stats.ts inspects them.
+const bundleStatsDryRun: boolean = process.env.CODECOV_BUNDLE_DRY_RUN === 'true';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
+    // Bundle size tracking. The upload happens inside `vite build` rather than as
+    // a later CI step, so the token has to reach this process — turbo's strict
+    // env mode drops it unless `build.passThroughEnv` in turbo.json lists it.
+    // Keying on the token confines uploads to CI; local builds do nothing.
+    //
+    // The declared peer range stops at Vite 6 and this app builds on Vite 8,
+    // whose Rolldown bundler reports the Rollup-compatible hooks the plugin
+    // reads. It works, but nothing upstream guarantees it keeps working, and a
+    // plugin that silently collected nothing would look exactly like a bundle
+    // that never changed — hence the verify:bundle-stats gate in CI.
+    codecovVitePlugin({
+      enableBundleAnalysis: bundleStatsDryRun || process.env.CODECOV_TOKEN !== undefined,
+      bundleName: 'web',
+      uploadToken: process.env.CODECOV_TOKEN,
+      dryRun: bundleStatsDryRun,
+      telemetry: false,
+    }),
     {
       name: 'validate-env',
       // .github/workflows/deploy.yml injects these for deployed builds. Failing

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,16 @@ comment:
   behavior: default
   require_changes: false
 
+# apps/web only; `@codecov/vite-plugin` in its vite.config.ts uploads the report
+# from inside `vite build`. A ratchet against the base commit rather than a fixed
+# size ceiling, matching how the coverage statuses above are set: what a bundle
+# should weigh is not known yet, but a jump within one pull request is reviewable
+# either way. A real status, not `informational`, though nothing requires it to
+# pass until the develop ruleset gains required checks.
+bundle_analysis:
+  warning_threshold: '5%'
+  status: true
+
 flag_management:
   default_rules:
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,12 +25,9 @@ comment:
   behavior: default
   require_changes: false
 
-# apps/web only; `@codecov/vite-plugin` in its vite.config.ts uploads the report
-# from inside `vite build`. A ratchet against the base commit rather than a fixed
-# size ceiling, matching how the coverage statuses above are set: what a bundle
-# should weigh is not known yet, but a jump within one pull request is reviewable
-# either way. A real status, not `informational`, though nothing requires it to
-# pass until the develop ruleset gains required checks.
+# apps/web only, uploaded from inside `vite build` rather than by a CI step; see
+# its vite.config.ts. Compares each commit against its base, like the coverage
+# statuses above.
 bundle_analysis:
   warning_threshold: '5%'
   status: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
         specifier: 5.0.14
         version: 5.0.14(@types/react@19.2.18)(react@19.2.8)
     devDependencies:
+      '@codecov/vite-plugin':
+        specifier: 2.0.1
+        version: 2.0.1(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.9)(yaml@2.9.0))
       '@eslint-react/eslint-plugin':
         specifier: 5.18.3
         version: 5.18.3(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
@@ -472,6 +475,24 @@ importers:
 
 packages:
 
+  '@actions/core@3.0.1':
+    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
+
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
+
+  '@actions/github@9.1.1':
+    resolution: {integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==}
+
+  '@actions/http-client@3.0.2':
+    resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
+
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
+
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
@@ -577,6 +598,16 @@ packages:
 
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
+  '@codecov/bundler-plugin-core@2.0.1':
+    resolution: {integrity: sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@codecov/vite-plugin@2.0.1':
+    resolution: {integrity: sha512-w7nGA9SSc0WECzn05yRrw3uN8293I620Kd9x97I0kyyxUjtWxCMmlgmAbS364gJZYvljd0A6iQyAigVV2dOX9A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      vite: 4.x || 5.x || 6.x
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1525,6 +1556,54 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.13':
+    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -3033,6 +3112,9 @@ packages:
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
+
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -4715,6 +4797,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -6441,6 +6526,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   turbo@2.10.8:
     resolution: {integrity: sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg==}
     hasBin: true
@@ -6536,6 +6625,9 @@ packages:
     resolution: {integrity: sha512-db38BYsx+oZEx0bc+PeGmIwG+YiYH5Xluhxf9EBnL39U4+DAXJtXQHLJ+zzTH36lx/N54/WKQQYnh0kQWJ74yg==}
     engines: {node: '>=22.0.0'}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -6543,6 +6635,10 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -6726,6 +6822,9 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   websocket-driver@0.7.5:
     resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
@@ -6912,6 +7011,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -6934,6 +7036,37 @@ packages:
         optional: true
 
 snapshots:
+
+  '@actions/core@3.0.1':
+    dependencies:
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.1
+
+  '@actions/exec@3.0.0':
+    dependencies:
+      '@actions/io': 3.0.2
+
+  '@actions/github@9.1.1':
+    dependencies:
+      '@actions/http-client': 3.0.2
+      '@octokit/core': 7.0.7
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
+      '@octokit/request': 10.0.13
+      '@octokit/request-error': 7.1.1
+      undici: 6.28.0
+
+  '@actions/http-client@3.0.2':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.28.0
+
+  '@actions/http-client@4.0.1':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.28.0
+
+  '@actions/io@3.0.2': {}
 
   '@adobe/css-tools@4.5.0': {}
 
@@ -7082,6 +7215,21 @@ snapshots:
     dependencies:
       hashery: 1.5.1
       keyv: 5.6.0
+
+  '@codecov/bundler-plugin-core@2.0.1':
+    dependencies:
+      '@actions/core': 3.0.1
+      '@actions/github': 9.1.1
+      chalk: 4.1.2
+      semver: 7.8.5
+      unplugin: 1.16.1
+      zod: 3.25.76
+
+  '@codecov/vite-plugin@2.0.1(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.9)(yaml@2.9.0))':
+    dependencies:
+      '@codecov/bundler-plugin-core': 2.0.1
+      unplugin: 1.16.1
+      vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.9)(yaml@2.9.0)
 
   '@colors/colors@1.5.0':
     optional: true
@@ -8112,6 +8260,64 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.13
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.13
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.13':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.10
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
 
   '@open-draft/deferred-promise@2.2.0': {}
 
@@ -9322,6 +9528,8 @@ snapshots:
       safe-buffer: 5.1.2
 
   basic-ftp@5.3.1: {}
+
+  before-after-hook@4.0.0: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -11519,6 +11727,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-with-bigint@3.5.10: {}
+
   json5@2.2.3: {}
 
   jsoncompat@0.4.2: {}
@@ -13349,6 +13559,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel@0.0.6: {}
+
   turbo@2.10.8:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.8
@@ -13482,9 +13694,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  universal-user-agent@7.0.3: {}
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.18.0
+      webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -13643,6 +13862,8 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   websocket-driver@0.7.5:
     dependencies:
@@ -13855,6 +14076,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
         "index.html",
         "tsconfig*.json"
       ],
-      "outputs": ["dist/**", ".next/**", "build/**"]
+      "outputs": ["dist/**", ".next/**", "build/**"],
+      "passThroughEnv": ["CODECOV_TOKEN"]
     },
     "dev": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Closes #450

Wires `@codecov/vite-plugin` into `apps/web` so pull requests carry a bundle size comparison against their base commit — the last piece of the Codecov integration from #131. Thresholds ratchet against the base, like the coverage statuses already in `codecov.yml`.

## Gotchas

- **Turbo silently strips `CODECOV_TOKEN`.** The plugin uploads from inside `vite build`, not a separate CI step, and turbo's strict env mode passes only declared variables plus the `VITE_*` prefix it infers for this app — so the token needs `passThroughEnv` in `turbo.json`, or the upload quietly degrades to tokenless.
- **The plugin declares no support for our Vite.** Its peer range stops at 6; we build on 8, through Rolldown. It works today, but upstream has left [Vite 7 support](https://github.com/codecov/codecov-javascript-bundler-plugins/issues/264) open since June 2025. It would fail silently — empty report, successful build, a bundle that merely looks like it stopped changing — so `verify-bundle-stats.ts` fails when the report doesn't describe a servable bundle.
- **A turbo cache hit uploads nothing**, because vite never runs while the replayed logs look identical. Reports land only on commits that rebuild the app, which is self-consistent: the last report on `develop` stays the accurate baseline.

No comparison appears on this PR itself — `develop` has no bundle report to compare against until this merges.