### PR TITLE
feat(web): serve robots.txt and sitemap.xml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           VITE_API_BASE_URL: https://api.invalid
+          VITE_SITE_ORIGIN: https://ci.invalid
           VITE_FIREBASE_API_KEY: ci
           VITE_FIREBASE_AUTH_DOMAIN: ci.invalid
           VITE_FIREBASE_PROJECT_ID: ci
@@ -98,6 +99,7 @@ jobs:
       - name: Verify bundle stats
         env:
           VITE_API_BASE_URL: https://api.invalid
+          VITE_SITE_ORIGIN: https://ci.invalid
           VITE_FIREBASE_API_KEY: ci
           VITE_FIREBASE_AUTH_DOMAIN: ci.invalid
           VITE_FIREBASE_PROJECT_ID: ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ jobs:
         run: pnpm turbo run build --filter=@genshin/web
         env:
           VITE_API_BASE_URL: https://api.develop.genshin.dungeon.studio
+          VITE_SITE_ORIGIN: https://develop.genshin.dungeon.studio
           VITE_FIREBASE_API_KEY: ${{ steps.firebase-config.outputs.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ steps.firebase-config.outputs.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ steps.firebase-config.outputs.VITE_FIREBASE_PROJECT_ID }}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,3 +16,7 @@ VITE_FIREBASE_APP_ID=
 # API base URL — the origin of the API server (no trailing slash).
 # Set per environment at build time; this default targets the local API server.
 VITE_API_BASE_URL=http://localhost:8080
+
+# Origin this build is deployed to (no trailing slash). Names itself in the
+# generated robots.txt and sitemap.xml; only the public origin invites crawlers.
+VITE_SITE_ORIGIN=http://localhost:5173

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,6 +17,7 @@ VITE_FIREBASE_APP_ID=
 # Set per environment at build time; this default targets the local API server.
 VITE_API_BASE_URL=http://localhost:8080
 
-# Origin this build is deployed to (no trailing slash). Names itself in the
-# generated robots.txt and sitemap.xml; only the public origin invites crawlers.
+# Origin this build is deployed to (no trailing slash). The generated
+# robots.txt and sitemap.xml name it, and only the public origin invites
+# crawlers.
 VITE_SITE_ORIGIN=http://localhost:5173

--- a/apps/web/.stylelintrc.json
+++ b/apps/web/.stylelintrc.json
@@ -4,7 +4,7 @@
     "at-rule-no-unknown": [
       true,
       {
-        "ignoreAtRules": ["tailwind", "apply", "layer", "config"]
+        "ignoreAtRules": ["tailwind", "apply", "layer", "config", "source"]
       }
     ],
     "value-keyword-case": [

--- a/apps/web/scripts/site-files-plugin.ts
+++ b/apps/web/scripts/site-files-plugin.ts
@@ -9,12 +9,10 @@ import type { Plugin } from 'vite';
 import { isPublicOrigin, siteFiles } from './site-files';
 
 /**
- * Emits the crawler-facing root files, and marks every origin but the public
- * one `noindex`.
+ * Emits the site files and marks non-public origins `noindex`.
  *
- * The origin arrives as `VITE_SITE_ORIGIN`, which Vite resolves from `.env`
- * files as well as the environment, so it is only readable once the config
- * has been resolved.
+ * `VITE_SITE_ORIGIN` comes from `.env` files as well as the environment, so
+ * the origin is only readable once Vite has resolved the config.
  */
 export function siteFilesPlugin(): Plugin {
   let origin: string | undefined;
@@ -37,9 +35,9 @@ export function siteFilesPlugin(): Plugin {
       }
     },
 
-    // robots.txt keeps compliant crawlers off non-public origins entirely;
-    // this catches the ones that fetch anyway, for which a Disallow they
-    // ignored is no barrier to listing the page.
+    // robots.txt already turns compliant crawlers away. This catches the ones
+    // that fetch anyway, for which an ignored Disallow is no barrier to
+    // listing the page.
     transformIndexHtml(html) {
       if (origin === undefined || isPublicOrigin(origin)) return html;
 

--- a/apps/web/scripts/site-files-plugin.ts
+++ b/apps/web/scripts/site-files-plugin.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Plugin } from 'vite';
+
+import { isPublicOrigin, siteFiles } from './site-files';
+
+/**
+ * Emits the crawler-facing root files, and marks every origin but the public
+ * one `noindex`.
+ *
+ * The origin arrives as `VITE_SITE_ORIGIN`, which Vite resolves from `.env`
+ * files as well as the environment, so it is only readable once the config
+ * has been resolved.
+ */
+export function siteFilesPlugin(): Plugin {
+  let origin: string | undefined;
+  let outDir: string;
+
+  return {
+    name: 'generate-site-files',
+
+    configResolved(config) {
+      const env = config.env as Record<string, string | undefined>;
+      origin = env.VITE_SITE_ORIGIN;
+      outDir = path.resolve(config.root, config.build.outDir);
+    },
+
+    closeBundle() {
+      if (origin === undefined) return;
+
+      for (const file of siteFiles(origin)) {
+        fs.writeFileSync(path.join(outDir, file.name), file.contents);
+      }
+    },
+
+    // robots.txt keeps compliant crawlers off non-public origins entirely;
+    // this catches the ones that fetch anyway, for which a Disallow they
+    // ignored is no barrier to listing the page.
+    transformIndexHtml(html) {
+      if (origin === undefined || isPublicOrigin(origin)) return html;
+
+      return {
+        html,
+        tags: [
+          {
+            tag: 'meta',
+            attrs: { name: 'robots', content: 'noindex, nofollow' },
+            injectTo: 'head',
+          },
+        ],
+      };
+    },
+  };
+}

--- a/apps/web/scripts/site-files.test.ts
+++ b/apps/web/scripts/site-files.test.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { PUBLIC_ROUTES, robotsTxt, sitemapXml } from './site-files';
+
+const PUBLIC_ORIGIN = 'https://genshin.dungeon.studio';
+const PREVIEW_ORIGIN = 'https://develop.genshin.dungeon.studio';
+
+function agentRules(robots: string): Record<string, string> {
+  return Object.fromEntries(
+    robots
+      .split('\n\n')
+      .map((group) => group.split('\n').filter((line) => !line.startsWith('#')))
+      .filter((lines) => lines[0]?.startsWith('User-agent: '))
+      .map((lines) => [lines[0].replace('User-agent: ', ''), lines[1]]),
+  );
+}
+
+describe('robotsTxt', () => {
+  it('opens the public origin to crawlers', () => {
+    const rules = agentRules(robotsTxt(PUBLIC_ORIGIN));
+
+    expect(rules['*']).toBe('Allow: /');
+    expect(rules['GPTBot']).toBe('Allow: /');
+    expect(rules['ClaudeBot']).toBe('Allow: /');
+  });
+
+  it('closes every other origin, so preview deployments stay unindexed', () => {
+    const rules = agentRules(robotsTxt(PREVIEW_ORIGIN));
+
+    expect(rules['*']).toBe('Disallow: /');
+    expect(rules['GPTBot']).toBe('Disallow: /');
+    expect(rules['ClaudeBot']).toBe('Disallow: /');
+  });
+
+  it('points at the sitemap on its own origin', () => {
+    expect(robotsTxt(PREVIEW_ORIGIN)).toContain(`Sitemap: ${PREVIEW_ORIGIN}/sitemap.xml`);
+  });
+});
+
+describe('sitemapXml', () => {
+  it('lists every public route against the origin it is served from', () => {
+    const sitemap = sitemapXml(PREVIEW_ORIGIN);
+
+    for (const route of PUBLIC_ROUTES) {
+      expect(sitemap).toContain(`<loc>${PREVIEW_ORIGIN}${route}</loc>`);
+    }
+  });
+});
+
+describe('PUBLIC_ROUTES', () => {
+  // The router is the source of truth; this list is a hand-kept copy of it,
+  // so a route added there without a sitemap entry fails here.
+  it('covers every route the router declares', () => {
+    const app = readFileSync('src/app.tsx', 'utf8');
+    const declared = [...app.matchAll(/<Route path="([^"]+)"/g)]
+      .map(([, path]) => path)
+      .filter((path) => path !== '*');
+
+    expect(declared).not.toHaveLength(0);
+    expect([...PUBLIC_ROUTES].sort()).toEqual(declared.sort());
+  });
+});

--- a/apps/web/scripts/site-files.test.ts
+++ b/apps/web/scripts/site-files.test.ts
@@ -68,8 +68,7 @@ describe('sitemapXml', () => {
 });
 
 describe('PUBLIC_ROUTES', () => {
-  // The router is the source of truth; this list is a hand-kept copy of it,
-  // so a route added there without a sitemap entry fails here.
+  // The router is the source of truth; this list is a hand-kept copy of it.
   it('covers every route the router declares', () => {
     const app = readFileSync('src/app.tsx', 'utf8');
     const declared = [...app.matchAll(/<Route path="([^"]+)"/g)]

--- a/apps/web/scripts/site-files.test.ts
+++ b/apps/web/scripts/site-files.test.ts
@@ -5,10 +5,25 @@ import { readFileSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
 
-import { PUBLIC_ROUTES, robotsTxt, sitemapXml } from './site-files';
+import { PUBLIC_ROUTES, siteFiles } from './site-files';
 
 const PUBLIC_ORIGIN = 'https://genshin.dungeon.studio';
 const PREVIEW_ORIGIN = 'https://develop.genshin.dungeon.studio';
+
+function contentsOf(origin: string, name: string): string {
+  const file = siteFiles(origin).find((candidate) => candidate.name === name);
+  if (file === undefined) throw new Error(`${name} is not among the generated site files`);
+
+  return file.contents;
+}
+
+function robotsTxt(origin: string): string {
+  return contentsOf(origin, 'robots.txt');
+}
+
+function sitemapXml(origin: string): string {
+  return contentsOf(origin, 'sitemap.xml');
+}
 
 function agentRules(robots: string): Record<string, string> {
   return Object.fromEntries(

--- a/apps/web/scripts/site-files.ts
+++ b/apps/web/scripts/site-files.ts
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Builders for the crawler-facing files served from the site root.
+ * The crawler-facing files served from the site root.
  *
- * Both files name absolute URLs, so they cannot be checked in as static
- * assets: every deployed origin needs its own copy. `vite.config.ts` writes
- * them into `dist/` at the end of a build.
+ * They name absolute URLs, so they cannot be checked in as static assets:
+ * every deployed origin needs its own copy. `site-files-plugin.ts` writes
+ * them into the build output.
  */
+
+export interface SiteFile {
+  /** Path relative to the site root. */
+  readonly name: string;
+  readonly contents: string;
+}
 
 /**
  * The one origin whose content is meant to be indexed. Every other deployment
@@ -51,7 +57,7 @@ const AI_USER_AGENTS: readonly string[] = [
   'CCBot',
 ];
 
-export function robotsTxt(origin: string): string {
+function robotsTxt(origin: string): string {
   const rule = isPublicOrigin(origin) ? 'Allow: /' : 'Disallow: /';
   const groups = ['*', ...AI_USER_AGENTS].map((agent) => `User-agent: ${agent}\n${rule}`);
 
@@ -65,7 +71,7 @@ export function robotsTxt(origin: string): string {
   ].join('\n');
 }
 
-export function sitemapXml(origin: string): string {
+function sitemapXml(origin: string): string {
   const urls = PUBLIC_ROUTES.map((route) => `  <url>\n    <loc>${origin}${route}</loc>\n  </url>`);
 
   return [
@@ -75,4 +81,12 @@ export function sitemapXml(origin: string): string {
     '</urlset>',
     '',
   ].join('\n');
+}
+
+/** Everything the build has to drop at the root of `origin`. */
+export function siteFiles(origin: string): readonly SiteFile[] {
+  return [
+    { name: 'robots.txt', contents: robotsTxt(origin) },
+    { name: 'sitemap.xml', contents: sitemapXml(origin) },
+  ];
 }

--- a/apps/web/scripts/site-files.ts
+++ b/apps/web/scripts/site-files.ts
@@ -5,8 +5,7 @@
  * The crawler-facing files served from the site root.
  *
  * They name absolute URLs, so they cannot be checked in as static assets:
- * every deployed origin needs its own copy. `site-files-plugin.ts` writes
- * them into the build output.
+ * every deployed origin needs its own copy.
  */
 
 export interface SiteFile {
@@ -17,8 +16,7 @@ export interface SiteFile {
 
 /**
  * The one origin whose content is meant to be indexed. Every other deployment
- * serves the same routes from a different host, so they tell crawlers to stay
- * out rather than compete with it.
+ * serves the same routes from a different host, so it tells crawlers to stay out.
  */
 const PUBLIC_ORIGIN = 'https://genshin.dungeon.studio';
 
@@ -36,9 +34,9 @@ export const PUBLIC_ROUTES: readonly string[] = [
 ];
 
 /**
- * Agents that read the site for a model rather than for a search index. A
- * bare `*` group already binds them; naming each one states the position
- * explicitly, which is what their operators document as the opt-out signal.
+ * Agents that read the site for a model rather than a search index. The `*`
+ * group already binds them; their operators document a named group as the
+ * opt-out, so each is stated outright.
  */
 const AI_USER_AGENTS: readonly string[] = [
   'GPTBot',
@@ -83,7 +81,6 @@ function sitemapXml(origin: string): string {
   ].join('\n');
 }
 
-/** Everything the build has to drop at the root of `origin`. */
 export function siteFiles(origin: string): readonly SiteFile[] {
   return [
     { name: 'robots.txt', contents: robotsTxt(origin) },

--- a/apps/web/scripts/site-files.ts
+++ b/apps/web/scripts/site-files.ts
@@ -16,6 +16,10 @@
  */
 const PUBLIC_ORIGIN = 'https://genshin.dungeon.studio';
 
+export function isPublicOrigin(origin: string): boolean {
+  return origin === PUBLIC_ORIGIN;
+}
+
 /** Routes `src/app.tsx` renders, minus the catch-all. */
 export const PUBLIC_ROUTES: readonly string[] = [
   '/',
@@ -48,7 +52,7 @@ const AI_USER_AGENTS: readonly string[] = [
 ];
 
 export function robotsTxt(origin: string): string {
-  const rule = origin === PUBLIC_ORIGIN ? 'Allow: /' : 'Disallow: /';
+  const rule = isPublicOrigin(origin) ? 'Allow: /' : 'Disallow: /';
   const groups = ['*', ...AI_USER_AGENTS].map((agent) => `User-agent: ${agent}\n${rule}`);
 
   return [

--- a/apps/web/scripts/site-files.ts
+++ b/apps/web/scripts/site-files.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/**
+ * Builders for the crawler-facing files served from the site root.
+ *
+ * Both files name absolute URLs, so they cannot be checked in as static
+ * assets: every deployed origin needs its own copy. `vite.config.ts` writes
+ * them into `dist/` at the end of a build.
+ */
+
+/**
+ * The one origin whose content is meant to be indexed. Every other deployment
+ * serves the same routes from a different host, so they tell crawlers to stay
+ * out rather than compete with it.
+ */
+const PUBLIC_ORIGIN = 'https://genshin.dungeon.studio';
+
+/** Routes `src/app.tsx` renders, minus the catch-all. */
+export const PUBLIC_ROUTES: readonly string[] = [
+  '/',
+  '/characters',
+  '/weapons',
+  '/privacy',
+  '/terms',
+];
+
+/**
+ * Agents that read the site for a model rather than for a search index. A
+ * bare `*` group already binds them; naming each one states the position
+ * explicitly, which is what their operators document as the opt-out signal.
+ */
+const AI_USER_AGENTS: readonly string[] = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'ClaudeBot',
+  'Claude-User',
+  'anthropic-ai',
+  'PerplexityBot',
+  'Perplexity-User',
+  'Google-Extended',
+  'Applebot-Extended',
+  'meta-externalagent',
+  'Amazonbot',
+  'Bytespider',
+  'CCBot',
+];
+
+export function robotsTxt(origin: string): string {
+  const rule = origin === PUBLIC_ORIGIN ? 'Allow: /' : 'Disallow: /';
+  const groups = ['*', ...AI_USER_AGENTS].map((agent) => `User-agent: ${agent}\n${rule}`);
+
+  return [
+    '# Generated at build time; edit apps/web/scripts/site-files.ts.',
+    '',
+    groups.join('\n\n'),
+    '',
+    `Sitemap: ${origin}/sitemap.xml`,
+    '',
+  ].join('\n');
+}
+
+export function sitemapXml(origin: string): string {
+  const urls = PUBLIC_ROUTES.map((route) => `  <url>\n    <loc>${origin}${route}</loc>\n  </url>`);
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls,
+    '</urlset>',
+    '',
+  ].join('\n');
+}

--- a/apps/web/scripts/verify-build-output.sh
+++ b/apps/web/scripts/verify-build-output.sh
@@ -20,3 +20,5 @@ require -d apps/web/dist
 require -f apps/web/dist/index.html
 require -d apps/web/dist/assets
 require -f apps/web/dist/version.json
+require -f apps/web/dist/robots.txt
+require -f apps/web/dist/sitemap.xml

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6,9 +6,8 @@
 
 @config '../tailwind.config.js';
 
-/* Automatic source detection reaches the whole workspace, so an ordinary
-   identifier in a build script — `contents`, `grid` — ships as a utility
-   nobody wrote. Nothing here renders. */
+/* Automatic source detection reaches the whole workspace, so identifiers in
+   build scripts ship as utilities nobody wrote. Nothing here renders. */
 @source not '../scripts';
 
 :root {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6,6 +6,11 @@
 
 @config '../tailwind.config.js';
 
+/* Automatic source detection reaches the whole workspace, so an ordinary
+   identifier in a build script — `contents`, `grid` — ships as a utility
+   nobody wrote. Nothing here renders. */
+@source not '../scripts';
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,7 +9,7 @@ import { codecovVitePlugin } from '@codecov/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-import { robotsTxt, sitemapXml } from './scripts/site-files';
+import { isPublicOrigin, robotsTxt, sitemapXml } from './scripts/site-files';
 
 const requiredEnvVars: readonly string[] = [
   'VITE_FIREBASE_API_KEY',
@@ -91,6 +91,23 @@ export default defineConfig({
         const distPath = path.resolve(__dirname, 'dist');
         fs.writeFileSync(path.join(distPath, 'robots.txt'), robotsTxt(siteOrigin));
         fs.writeFileSync(path.join(distPath, 'sitemap.xml'), sitemapXml(siteOrigin));
+      },
+      // robots.txt keeps compliant crawlers off non-public origins entirely;
+      // this catches the ones that fetch anyway, for which a Disallow they
+      // ignored is no barrier to listing the page.
+      transformIndexHtml(html) {
+        if (siteOrigin === undefined || isPublicOrigin(siteOrigin)) return html;
+
+        return {
+          html,
+          tags: [
+            {
+              tag: 'meta',
+              attrs: { name: 'robots', content: 'noindex, nofollow' },
+              injectTo: 'head' as const,
+            },
+          ],
+        };
       },
     },
     {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,7 +9,7 @@ import { codecovVitePlugin } from '@codecov/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-import { isPublicOrigin, robotsTxt, sitemapXml } from './scripts/site-files';
+import { siteFilesPlugin } from './scripts/site-files-plugin';
 
 const requiredEnvVars: readonly string[] = [
   'VITE_FIREBASE_API_KEY',
@@ -44,10 +44,6 @@ const buildSha: string = shortSha();
 // scripts/verify-bundle-stats.ts inspects what the plugin collected.
 const bundleStatsDryRun: boolean = process.env.CODECOV_BUNDLE_DRY_RUN === 'true';
 
-// Resolved from `.env` files as well as the environment, so it is only
-// readable once Vite has merged both.
-let siteOrigin: string | undefined;
-
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -77,39 +73,7 @@ export default defineConfig({
         }
       },
     },
-    {
-      name: 'generate-site-files',
-      // Generated rather than kept in public/ because both files carry
-      // absolute URLs, which differ per deployed origin.
-      configResolved(config) {
-        const env = config.env as Record<string, string | undefined>;
-        siteOrigin = env.VITE_SITE_ORIGIN;
-      },
-      closeBundle() {
-        if (siteOrigin === undefined) return;
-
-        const distPath = path.resolve(__dirname, 'dist');
-        fs.writeFileSync(path.join(distPath, 'robots.txt'), robotsTxt(siteOrigin));
-        fs.writeFileSync(path.join(distPath, 'sitemap.xml'), sitemapXml(siteOrigin));
-      },
-      // robots.txt keeps compliant crawlers off non-public origins entirely;
-      // this catches the ones that fetch anyway, for which a Disallow they
-      // ignored is no barrier to listing the page.
-      transformIndexHtml(html) {
-        if (siteOrigin === undefined || isPublicOrigin(siteOrigin)) return html;
-
-        return {
-          html,
-          tags: [
-            {
-              tag: 'meta',
-              attrs: { name: 'robots', content: 'noindex, nofollow' },
-              injectTo: 'head' as const,
-            },
-          ],
-        };
-      },
-    },
+    siteFilesPlugin(),
     {
       name: 'generate-version',
       closeBundle() {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,6 +9,8 @@ import { codecovVitePlugin } from '@codecov/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+import { robotsTxt, sitemapXml } from './scripts/site-files';
+
 const requiredEnvVars: readonly string[] = [
   'VITE_FIREBASE_API_KEY',
   'VITE_FIREBASE_AUTH_DOMAIN',
@@ -17,6 +19,7 @@ const requiredEnvVars: readonly string[] = [
   'VITE_FIREBASE_MESSAGING_SENDER_ID',
   'VITE_FIREBASE_APP_ID',
   'VITE_API_BASE_URL',
+  'VITE_SITE_ORIGIN',
 ];
 
 function packageVersion(): string {
@@ -40,6 +43,10 @@ const buildSha: string = shortSha();
 // Writes the report beside the bundle instead of uploading it, which is how
 // scripts/verify-bundle-stats.ts inspects what the plugin collected.
 const bundleStatsDryRun: boolean = process.env.CODECOV_BUNDLE_DRY_RUN === 'true';
+
+// Resolved from `.env` files as well as the environment, so it is only
+// readable once Vite has merged both.
+let siteOrigin: string | undefined;
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -68,6 +75,22 @@ export default defineConfig({
         if (missing.length > 0) {
           throw new Error(`Missing required environment variables:\n  ${missing.join('\n  ')}`);
         }
+      },
+    },
+    {
+      name: 'generate-site-files',
+      // Generated rather than kept in public/ because both files carry
+      // absolute URLs, which differ per deployed origin.
+      configResolved(config) {
+        const env = config.env as Record<string, string | undefined>;
+        siteOrigin = env.VITE_SITE_ORIGIN;
+      },
+      closeBundle() {
+        if (siteOrigin === undefined) return;
+
+        const distPath = path.resolve(__dirname, 'dist');
+        fs.writeFileSync(path.join(distPath, 'robots.txt'), robotsTxt(siteOrigin));
+        fs.writeFileSync(path.join(distPath, 'sitemap.xml'), sitemapXml(siteOrigin));
       },
     },
     {

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
       "inputs": [
         "src/**",
         "public/**",
+        "scripts/**",
         "package.json",
         "vite.config.*",
         "index.html",
@@ -26,7 +27,14 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "package.json", "vite.config.*", "vitest.config.*", "tsconfig*.json"],
+      "inputs": [
+        "src/**",
+        "scripts/**",
+        "package.json",
+        "vite.config.*",
+        "vitest.config.*",
+        "tsconfig*.json"
+      ],
       "env": ["FAST_CHECK_SEED"]
     },
     "test:integration": {
@@ -47,6 +55,7 @@
       "inputs": [
         "src/**/*.{ts,tsx}",
         "specs/**/*.ts",
+        "scripts/**/*.ts",
         "package.json",
         "vite.config.*",
         "playwright.config.*",


### PR DESCRIPTION
## Summary

`/robots.txt` and `/sitemap.xml` answer with real files instead of the SPA's
`index.html`. Only `https://genshin.dungeon.studio` invites crawlers; every other
origin serves `Disallow: /` plus a `noindex` meta tag. That origin does not
resolve yet, so what deploys today is the closed variant.

Closes #710
Closes #711

## Gotchas

- **Generated, not checked in.** Both files name absolute URLs, so a static
  `public/` copy would be wrong on every origin but one.
  `scripts/site-files-plugin.ts` writes them from the new required
  `VITE_SITE_ORIGIN`, and one constant sets the posture for the files and the
  meta tag together.
- **The two controls partly undermine each other.** A crawler that honours
  `Disallow` never fetches the page to read the `noindex`. `Disallow` is the
  primary control; the tag catches bots that fetch anyway. Measuring which do:
  #1256.
- **One commit is unrelated to robots.txt.** Tailwind v4 scans the workspace and
  the `content` globs narrow nothing, so build-script identifiers ship as utility
  classes — `.static` already did. `@source not '../scripts'` scopes the scan,
  leaving the stylesheet 24 bytes smaller and otherwise byte-identical.

## Verification

- Served the build through the Firebase Hosting emulator: `/robots.txt` → 200
  `text/plain`, `/sitemap.xml` → 200 `application/xml`, `/characters` → 200
  `text/html`. Static files beat the SPA rewrite and the content types match both
  issues' criteria.