### PR TITLE
fix(web): drop stable auth from the auth effect deps

### DIFF
--- a/apps/web/src/features/auth/auth-provider.tsx
+++ b/apps/web/src/features/auth/auth-provider.tsx
@@ -21,7 +21,7 @@ export function AuthProvider({ children }: { children: ReactNode }): JSX.Element
     });
 
     return unsubscribe;
-  }, [auth]);
+  }, []);
 
   return <AuthContext value={{ user, loading }}>{children}</AuthContext>;
 }


### PR DESCRIPTION
Closes #826

`auth` is a module-level `export const`, so naming it in the `useEffect`
dependency array claimed a reactive value that can never change identity.
`react-hooks/exhaustive-deps` flagged it; the empty array states what the effect
already did.

## Gotchas

- **The `eslint` pre-commit hook matches no files** (#888), so this warning
  surfaces only under `pnpm turbo run lint` — the commit hooks neither caught it
  nor prove it fixed.
- **The adjacent smells are deliberately untouched.** Reviewing this file
  surfaced a duplicated loading derivation (#1265) and the `user`/`loading` pair
  it rests on (#1264). Both are filed rather than folded in here.
