### PR TITLE
docs: state non-affiliation with HoYoverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ See the [Manual Setup Guide](./docs/how-tos/manual-setup.md) for Node.js 20+ and
 - **Documentation**: Browse [docs/](./docs/) for how-tos, references, and explanations
 - **Planning & Roadmap**: See [GitHub Issues & Milestones](https://github.com/dungeon-studio/genshin.dungeon.studio/milestones) for what's next
 - **License**: [MIT](./LICENSE)
+
+## Not affiliated with HoYoverse
+
+Genshin Planner is an unofficial fan project. It's not affiliated with, endorsed by, or sponsored by HoYoverse. Genshin Impact and all related names, characters, and artwork are trademarks and copyright of COGNOSPHERE PTE. LTD. Game data is presented for reference and may be inaccurate or out of date.

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ See the [Manual Setup Guide](./docs/how-tos/manual-setup.md) for Node.js 20+ and
 
 ## Not affiliated with HoYoverse
 
-Genshin Planner is an unofficial fan project. It's not affiliated with, endorsed by, or sponsored by HoYoverse. Genshin Impact and all related names, characters, and artwork are trademarks and copyright of COGNOSPHERE PTE. LTD. Game data is presented for reference and may be inaccurate or out of date.
+Genshin Planner is an unofficial fan project, neither endorsed nor sponsored by HoYoverse. Genshin Impact and all related names, characters, and artwork are trademarks and copyrights of COGNOSPHERE PTE. LTD.

--- a/apps/web/src/components/chrome/footer.tsx
+++ b/apps/web/src/components/chrome/footer.tsx
@@ -99,6 +99,10 @@ export function Footer(): JSX.Element {
           Game data current as of {GAME_DATA_VERSION}
         </p>
         <p className="mt-1 text-xs text-muted-foreground/70">© 2026 Dungeon Studio</p>
+        <p className="mt-1 text-xs text-muted-foreground/70">
+          Not affiliated with or endorsed by HoYoverse. Genshin Impact is a trademark of COGNOSPHERE
+          PTE. LTD.
+        </p>
       </Container>
     </footer>
   );


### PR DESCRIPTION
## Summary

The unofficial-fan-project disclaimer now appears on every page of the web
app and in the README. Terms of Service already carried a non-affiliation
section from #914, but reaching it took a click from the footer, and the
README said nothing at all.

Closes #827

## Gotchas

- **No footer test.** Asserting the disclaimer string back would be a change
  detector; the existing footer tests cover link behavior, which is unchanged.
- **No Vale vocabulary entry.** `HoYoverse` and `COGNOSPHERE` pass spelling as
  written, so `.styles/config/vocabularies/Project/accept.txt` is untouched.
- **Terms wording left alone.** That section says "miHoYo/Cognosphere" where
  the new copy says "COGNOSPHERE PTE. LTD."; #827 didn't ask to revise legal
  copy, and #647 has a legal review pass pending.