### PR TITLE
chore: drop the retired Claustre ignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,15 +100,10 @@ vite.config.ts.timestamp-*
 service-account*.json
 
 # ===================================
-# Claude Code / Claustre
+# Claude Code
 # ===================================
 
-# Claustre session identifier (generated per worktree session)
-.claustre_session_id
-
-# Claude Code local settings and hooks (claustre-injected, session-specific)
 .claude/settings.local.json
-.claude/hooks/
 
 # ===================================
 # Temporary Files


### PR DESCRIPTION
Closes #829

Claustre stopped orchestrating sessions here, so `.gitignore` no longer ignores
the artefacts it used to inject. `CLAUDE.md` and the Vale vocabulary were already
reconciled by #897 and #1224 — `.gitignore` was the last mention in the repo.

## Gotchas

- **`.claude/hooks/` stops being ignored.** Claustre injected session hooks there
  and nothing writes it now, so keeping the ignore would silently hide project
  hooks a contributor adds on purpose. `.claude/settings.local.json` stays
  ignored on its own merit: Claude Code writes it per-checkout when permissions
  are approved locally, so it is machine state whoever put it there.