### PR TITLE
chore: consolidate the GitHub label taxonomy

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,19 +24,12 @@ categories:
   - title: '⬆️ Dependencies'
     labels:
       - 'dependencies'
-      - 'automated'
   - title: '🧰 Chores'
     labels:
       - 'chore'
 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
-
-# Keep triage-only pull requests out of the notes.
-exclude-labels:
-  - 'duplicate'
-  - 'invalid'
-  - 'wontfix'
 
 # Strip the conventional-commit prefix from each bullet; the category heading
 # already conveys the type, so 'feat: add X' reads as 'add X'.
@@ -57,7 +50,6 @@ version-resolver:
       - 'security'
       - 'documentation'
       - 'dependencies'
-      - 'automated'
       - 'chore'
   default: patch
 
@@ -106,7 +98,7 @@ autolabeler:
     files:
       - 'docs/**'
       - '*.md'
-  - label: 'types'
+  - label: 'domain'
     files:
       - 'packages/domain/**'
   - label: 'game-data'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -75,7 +75,7 @@ autolabeler:
   - label: 'chore'
     title:
       - '/^(chore|build)(?!\(deps)(\(.+\))?:/i'
-      - '/^(ci|style|refactor|test|perf)(\(.+\))?:/i'
+      - '/^(ci|style|refactor|test|perf|revert)(\(.+\))?:/i'
   - label: 'breaking-change'
     title:
       - '/^\w+(\(.+\))?!:/'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -93,6 +93,9 @@ jobs:
           days-before-issue-close: -1
           days-before-pr-stale: 30
           days-before-pr-close: 14
+          # The action defaults to `Stale`; without this it recreates that
+          # label rather than reusing the repository's lowercase one.
+          stale-pr-label: stale
           # Closing a Renovate pull request tells Renovate the version is
           # unwanted and it will not re-offer it. Renovate labels nothing by
           # default, so this depends on renovate.json applying the label.

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -93,8 +93,8 @@ jobs:
           days-before-issue-close: -1
           days-before-pr-stale: 30
           days-before-pr-close: 14
-          # The action defaults to `Stale`; without this it recreates that
-          # label rather than reusing the repository's lowercase one.
+          # The action defaults this input to Stale and creates that label if
+          # it is absent.
           stale-pr-label: stale
           # Closing a Renovate pull request tells Renovate the version is
           # unwanted and it will not re-offer it. Renovate labels nothing by

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "customManagers:dockerfileVersions"
   ],
   "timezone": "Europe/London",
-  "labels": ["dependencies", "automated"],
+  "labels": ["dependencies"],
   "reviewers": ["alunduil"],
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
Closes #844

Settles a canonical 24 labels, down from 36. They are already applied to the repository, so this diff is only the config that names them by string and #781 can import live state. Inventory, per-label rationale, and naming rules are in the close-out comment on #844.

## Gotchas

**Two deleted labels can come back before this merges.** `develop` still names `automated` in `renovate.json` and `types` in the autolabeler, so a Renovate pull request opening in the window recreates either with a random colour. Confirm the live set is 24 after merge; the fix is a delete and a rename, not a revert.

**Piggybacked fix: `revert:` mapped to no label.** Titles are gated to eleven conventional-commit types but only ten reached an autolabeler matcher, so a merged revert would land outside every category heading. Included because it breaks the acceptance criterion #844 set for itself. Latent — no revert has ever merged.

**`exclude-labels` was dead config.** It excluded `duplicate`, `invalid`, and `wontfix`, but Release Drafter only reads merged pull requests, which are never any of those. Removing it changes no output.