### PR TITLE
chore: exempt java from the release-age bake

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,11 @@
       "minimumReleaseAge": null
     },
     {
+      "description": "Exempt the java-version datasource from the minimum release-age bake, so its renovate/stability-days check can resolve under internalChecksFilter:strict; the Adoptium release_versions endpoint it reads carries no release timestamps",
+      "matchDatasources": ["java-version"],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Move the Terraform CLI in one pull request across the bootstrap and dev required_version constraints and the TERRAFORM_VERSION pins in four workflows",
       "matchDepNames": ["hashicorp/terraform"],
       "groupName": "terraform cli"

--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Exempt the java-version datasource from the minimum release-age bake, so its renovate/stability-days check can resolve under internalChecksFilter:strict; the Adoptium release_versions endpoint it reads carries no release timestamps",
+      "description": "The release_versions endpoint Renovate reads carries no release timestamps, so a release-age bake here would never resolve its renovate/stability-days check under internalChecksFilter:strict",
       "matchDatasources": ["java-version"],
       "minimumReleaseAge": null
     },


### PR DESCRIPTION
Renovate's `java-version` datasource reads the Adoptium `release_versions` endpoint, which returns only version fields and no dates, and the datasource never sets `releaseTimestamp`. The repo-wide `minimumReleaseAge` of three days therefore has nothing to measure against and can never be satisfied for it. Under `internalChecksFilter:strict` that leaves `renovate/stability-days` pinned at pending rather than resolving either way, which is what has held both open java pull requests since 5 August: #1111 and #1128, each with every check green and a merge state of `BLOCKED`.

This adds a `matchDatasources` exemption alongside the `matchUpdateTypes` one that already sits above it for the same failure mode.

## Gotchas

**This drops the release-age bake for JDK bumps entirely.** The datasource cannot support a bake at all, so the real choice is no bake or java never updating, and this JDK exists only to run the Firestore emulator in CI.

**The existing exemption looked like it should already cover this.** It keys on `matchUpdateTypes`, so it catches update types that inherently carry no timestamp — pins, digests, lockfile maintenance. A plain `patch` update from a datasource that happens to publish no timestamps falls straight through it.

**The develop ruleset has no bypass actors,** so neither java PR could have been force-merged past the pending status in the meantime.

**#1111 needs a rebase after this lands, not just an unblock.** It was cut against a `ci.yml` with two `JAVA_VERSION` blocks; `develop` now has three, the `integration` job's having arrived in #1239 afterwards. Its hunks still apply cleanly, so merging as-is would leave that job pinned at `'21'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSbuGAQM6g32Kknz8eZkiq
