### PR TITLE
fix: repair pnpm lockfile after renovate merge skew

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8890,7 +8890,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:


### PR DESCRIPTION
Every CI and Deploy job on `develop` has been failing at `pnpm install --frozen-lockfile` since 8ee39eb. The `@testing-library/jest-dom@7.0.1` snapshot referenced a vitest peer-suffix key ending in `tsx@4.23.11`, which no longer exists anywhere in the lockfile — one stale reference against 25 correct `4.23.12` ones.

#1298 (tsx 4.23.12) rewrote every peer-suffix key. #1297 (jest-dom 7.0.1) was resolved against the pre-bump base and added a new `optionalDependencies: vitest:` line still carrying `tsx@4.23.11`. Both branched from the same base `055d968` and merged sixteen seconds apart, so git merged two clean-looking diffs into an internally inconsistent lockfile.

## Gotchas

**`--lockfile-only` does not fix this.** pnpm reports "Lockfile is up to date, resolution step is skipped" and exits without touching the file — the importer specs all match, only a snapshot cross-reference is dangling. `pnpm install --no-frozen-lockfile` is what repairs it, and it's what pnpm's own error message prescribes.

**Nothing here is a version change.** The diff is one line, swapping `tsx@4.23.11` for `tsx@4.23.12` inside a resolution key. No package resolves differently than #1298 already intended.

**This PR does not stop it recurring.** The recurrence guard is #1302, blocked by #1190. Worth noting for anyone reaching for the obvious fix: `rebaseWhen: "behind-base-branch"` would *not* have caught this. The two merges were sixteen seconds apart, shorter than any Renovate run, and with no required status checks nothing gated the second merge. Only a required check under a strict up-to-date policy closes it.
