### PR TITLE
feat(api): count legacy documents migrated on read

### DIFF
--- a/apps/api/src/repositories/characters/document.ts
+++ b/apps/api/src/repositories/characters/document.ts
@@ -4,7 +4,7 @@
 import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
 import { assertCollectionCharacter } from '@genshin/domain';
 
-import { observeMigration } from '@/repositories/schema-version.js';
+import { parseDocument } from '@/repositories/schema-version.js';
 
 import { entity, CURRENT_VERSION, type V1Character, type V0Character } from './schemas/index.js';
 
@@ -14,12 +14,7 @@ export function fromDocument(
   characterId: string,
   raw: Record<string, unknown>,
 ): CollectionCharacter {
-  const result = entity.safeParse(raw);
-  if (result.type !== 'ok') {
-    throw new TypeError(`Invalid character document: ${result.error.type}`);
-  }
-  observeMigration('characters', raw, CURRENT_VERSION);
-  const data = result.value;
+  const data = parseDocument('characters', entity, raw, CURRENT_VERSION);
   const character = {
     characterId,
     constellationLevel: data.constellationLevel,

--- a/apps/api/src/repositories/characters/document.ts
+++ b/apps/api/src/repositories/characters/document.ts
@@ -4,6 +4,8 @@
 import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
 import { assertCollectionCharacter } from '@genshin/domain';
 
+import { observeMigration } from '@/repositories/schema-version.js';
+
 import { entity, CURRENT_VERSION, type V1Character, type V0Character } from './schemas/index.js';
 
 export { CURRENT_VERSION, type V1Character, type V0Character };
@@ -16,6 +18,7 @@ export function fromDocument(
   if (result.type !== 'ok') {
     throw new TypeError(`Invalid character document: ${result.error.type}`);
   }
+  observeMigration('characters', raw, CURRENT_VERSION);
   const data = result.value;
   const character = {
     characterId,

--- a/apps/api/src/repositories/characters/schemas/index.ts
+++ b/apps/api/src/repositories/characters/schemas/index.ts
@@ -3,6 +3,8 @@
 
 import { createVersionedEntity, type InferredEntity } from 'verzod';
 
+import { documentVersion } from '@/repositories/schema-version.js';
+
 import { v0 } from './v0.js';
 import { v1 } from './v1.js';
 
@@ -13,11 +15,7 @@ export const CURRENT_VERSION = 1 as const;
 export const entity = createVersionedEntity({
   latestVersion: CURRENT_VERSION,
   versionMap: { 0: v0, 1: v1 },
-  getVersion(data: unknown) {
-    if (typeof data !== 'object' || data === null) return null;
-    const ver = (data as Record<string, unknown>).schemaVersion;
-    return typeof ver === 'number' ? ver : 0;
-  },
+  getVersion: documentVersion,
 });
 
 export type V1Character = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/profile/document.ts
+++ b/apps/api/src/repositories/profile/document.ts
@@ -4,6 +4,8 @@
 import type { ISOTimestamp, UserProfile } from '@genshin/domain';
 import { assertUserProfile } from '@genshin/domain';
 
+import { observeMigration } from '@/repositories/schema-version.js';
+
 import { entity, CURRENT_VERSION, type V1Profile, type V0Profile } from './schemas/index.js';
 
 export { CURRENT_VERSION, type V1Profile, type V0Profile };
@@ -13,6 +15,7 @@ export function fromDocument(raw: Record<string, unknown>): UserProfile {
   if (result.type !== 'ok') {
     throw new TypeError(`Invalid profile document: ${result.error.type}`);
   }
+  observeMigration('profile', raw, CURRENT_VERSION);
   const data = result.value;
   const profile = {
     name: data.name,

--- a/apps/api/src/repositories/profile/document.ts
+++ b/apps/api/src/repositories/profile/document.ts
@@ -4,19 +4,14 @@
 import type { ISOTimestamp, UserProfile } from '@genshin/domain';
 import { assertUserProfile } from '@genshin/domain';
 
-import { observeMigration } from '@/repositories/schema-version.js';
+import { parseDocument } from '@/repositories/schema-version.js';
 
 import { entity, CURRENT_VERSION, type V1Profile, type V0Profile } from './schemas/index.js';
 
 export { CURRENT_VERSION, type V1Profile, type V0Profile };
 
 export function fromDocument(raw: Record<string, unknown>): UserProfile {
-  const result = entity.safeParse(raw);
-  if (result.type !== 'ok') {
-    throw new TypeError(`Invalid profile document: ${result.error.type}`);
-  }
-  observeMigration('profile', raw, CURRENT_VERSION);
-  const data = result.value;
+  const data = parseDocument('profile', entity, raw, CURRENT_VERSION);
   const profile = {
     name: data.name,
     createdAt: data.createdAt as ISOTimestamp,

--- a/apps/api/src/repositories/profile/schemas/index.ts
+++ b/apps/api/src/repositories/profile/schemas/index.ts
@@ -3,6 +3,8 @@
 
 import { createVersionedEntity, type InferredEntity } from 'verzod';
 
+import { documentVersion } from '@/repositories/schema-version.js';
+
 import { v0 } from './v0.js';
 import { v1 } from './v1.js';
 
@@ -13,11 +15,7 @@ export const CURRENT_VERSION = 1 as const;
 export const entity = createVersionedEntity({
   latestVersion: CURRENT_VERSION,
   versionMap: { 0: v0, 1: v1 },
-  getVersion(data: unknown) {
-    if (typeof data !== 'object' || data === null) return null;
-    const ver = (data as Record<string, unknown>).schemaVersion;
-    return typeof ver === 'number' ? ver : 0;
-  },
+  getVersion: documentVersion,
 });
 
 export type V1Profile = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/schema-version.test.ts
+++ b/apps/api/src/repositories/schema-version.test.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { UUID } from '@genshin/domain';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as LoggerModule from '@/logger.js';
+
+const lines: string[] = [];
+
+// The repositories reach for the process-wide logger at import, so the
+// destination has to be in place before they are pulled in.
+vi.mock('@/logger.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof LoggerModule>();
+  return {
+    ...actual,
+    logger: actual.createLogger({
+      level: 'info',
+      destination: { write: (line: string) => lines.push(line) },
+    }),
+  };
+});
+
+const characters = await import('./characters/document.js');
+const profile = await import('./profile/document.js');
+const teams = await import('./teams/document.js');
+const weapons = await import('./weapons/document.js');
+
+const TIMESTAMP = '2024-01-15T12:00:00.000Z';
+const WEAPON_INSTANCE_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+
+/**
+ * Each repository at its initial version, alongside the read that parses it.
+ * A document reaches the current version by gaining `schemaVersion`; the fields
+ * are the ones every version so far has had in common.
+ */
+const REPOSITORIES = [
+  {
+    repository: 'characters',
+    currentVersion: characters.CURRENT_VERSION,
+    fields: { constellationLevel: 0, createdAt: TIMESTAMP, updatedAt: TIMESTAMP },
+    read: (document: Record<string, unknown>) => characters.fromDocument('columbina', document),
+  },
+  {
+    repository: 'profile',
+    currentVersion: profile.CURRENT_VERSION,
+    fields: { name: 'Traveler', createdAt: TIMESTAMP, updatedAt: TIMESTAMP },
+    read: (document: Record<string, unknown>) => profile.fromDocument(document),
+  },
+  {
+    repository: 'teams',
+    currentVersion: teams.CURRENT_VERSION,
+    fields: {
+      name: 'My Team',
+      members: [null, null, null, null],
+      createdAt: TIMESTAMP,
+      updatedAt: TIMESTAMP,
+    },
+    read: (document: Record<string, unknown>) => teams.fromDocument(1, document),
+  },
+  {
+    repository: 'weapons',
+    currentVersion: weapons.CURRENT_VERSION,
+    fields: {
+      weaponId: 'mistsplitter-reforged',
+      refinementLevel: 1,
+      createdAt: TIMESTAMP,
+      updatedAt: TIMESTAMP,
+    },
+    read: (document: Record<string, unknown>) => weapons.fromDocument(WEAPON_INSTANCE_ID, document),
+  },
+];
+
+function emitted(): unknown[] {
+  return lines.map((line) => JSON.parse(line) as unknown);
+}
+
+beforeEach(() => {
+  lines.length = 0;
+});
+
+describe('reading a document written before the current schema version', () => {
+  it.each(REPOSITORIES)(
+    'counts the migration in $repository',
+    ({ currentVersion, fields, read, repository }) => {
+      read(fields);
+
+      expect(emitted()).toEqual([
+        expect.objectContaining({ repository, fromVersion: 0, toVersion: currentVersion }),
+      ]);
+    },
+  );
+
+  it('says nothing about what the document held', () => {
+    teams.fromDocument(1, {
+      name: 'Childe Sundering Snowfall',
+      members: [{ characterId: 'columbina' }, null, null, null],
+      createdAt: TIMESTAMP,
+      updatedAt: TIMESTAMP,
+    });
+
+    expect(lines.join('')).not.toMatch(/Childe|columbina/);
+  });
+});
+
+describe('reading a document already at the current schema version', () => {
+  it.each(REPOSITORIES)('stays quiet for $repository', ({ currentVersion, fields, read }) => {
+    read({ ...fields, schemaVersion: currentVersion });
+
+    expect(lines).toEqual([]);
+  });
+});

--- a/apps/api/src/repositories/schema-version.test.ts
+++ b/apps/api/src/repositories/schema-version.test.ts
@@ -29,11 +29,7 @@ const weapons = await import('./weapons/document.js');
 const TIMESTAMP = '2024-01-15T12:00:00.000Z';
 const WEAPON_INSTANCE_ID = '11111111-1111-1111-1111-111111111111' as UUID;
 
-/**
- * Each repository at its initial version, alongside the read that parses it.
- * A document reaches the current version by gaining `schemaVersion`; the fields
- * are the ones every version so far has had in common.
- */
+/** Each repository's document at its initial version, with the read that parses it. */
 const REPOSITORIES = [
   {
     repository: 'characters',

--- a/apps/api/src/repositories/schema-version.ts
+++ b/apps/api/src/repositories/schema-version.ts
@@ -1,17 +1,24 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
+import type { ParseResult } from 'verzod';
+
 import { logger } from '@/logger.js';
 
 type Repository = 'characters' | 'profile' | 'teams' | 'weapons';
 
+/** The part of a versioned entity a repository reads a stored document through. */
+interface VersionedDocument<T> {
+  safeParse(data: unknown): ParseResult<T>;
+}
+
 /**
  * The version a raw document is in. Documents written before versioning carry
  * no `schemaVersion`, so its absence means 0; a non-numeric one belongs to no
- * version this entity can route.
+ * version an entity can route.
  *
- * Every repository routes with this and {@link observeMigration} reads it back,
- * so the version a document is parsed as and the version reported as migrated
+ * Every repository routes with this and {@link parseDocument} reads it back, so
+ * the version a document is parsed as and the version reported as migrated
  * cannot drift apart.
  */
 export function documentVersion(data: unknown): number | null {
@@ -21,21 +28,31 @@ export function documentVersion(data: unknown): number | null {
 }
 
 /**
- * Report that a read migrated a document forward, so the remaining population
- * of a legacy version can be watched until it drains and that version's parse
- * branch can be deleted.
+ * Parse a stored document, migrating it to `toVersion`, and record a migration
+ * that had to happen — so the population still on a legacy version can be
+ * watched until it drains and that version's parse branch can be deleted.
  *
  * Only version numbers are logged; the document itself is the user's.
  *
- * Call after a successful parse — verzod's result carries no source version.
+ * @throws TypeError when the document matches no version this entity knows.
  */
-export function observeMigration(
+export function parseDocument<T>(
   repository: Repository,
+  entity: VersionedDocument<T>,
   raw: Record<string, unknown>,
   toVersion: number,
-): void {
-  const fromVersion = documentVersion(raw);
-  if (fromVersion === null || fromVersion >= toVersion) return;
+): T {
+  const result = entity.safeParse(raw);
+  if (result.type !== 'ok') {
+    throw new TypeError(`Invalid ${repository} document: ${result.error.type}`);
+  }
 
-  logger.info({ repository, fromVersion, toVersion }, 'migrated document on read');
+  // verzod routed on `documentVersion`, so a document without one is already
+  // out through the throw above. The result itself carries no source version.
+  const fromVersion = documentVersion(raw);
+  if (fromVersion !== null && fromVersion < toVersion) {
+    logger.info({ repository, fromVersion, toVersion }, 'migrated document on read');
+  }
+
+  return result.value;
 }

--- a/apps/api/src/repositories/schema-version.ts
+++ b/apps/api/src/repositories/schema-version.ts
@@ -7,7 +7,7 @@ import { logger } from '@/logger.js';
 
 type Repository = 'characters' | 'profile' | 'teams' | 'weapons';
 
-/** The part of a versioned entity a repository reads a stored document through. */
+/** verzod's own entity type cannot be named without `any` in its generics. */
 interface VersionedDocument<T> {
   safeParse(data: unknown): ParseResult<T>;
 }
@@ -17,9 +17,8 @@ interface VersionedDocument<T> {
  * no `schemaVersion`, so its absence means 0; a non-numeric one belongs to no
  * version an entity can route.
  *
- * Every repository routes with this and {@link parseDocument} reads it back, so
- * the version a document is parsed as and the version reported as migrated
- * cannot drift apart.
+ * Routing and {@link parseDocument} both take a version from here, so the
+ * version a document parses as and the version reported as migrated agree.
  */
 export function documentVersion(data: unknown): number | null {
   if (typeof data !== 'object' || data === null) return null;
@@ -28,13 +27,13 @@ export function documentVersion(data: unknown): number | null {
 }
 
 /**
- * Parse a stored document, migrating it to `toVersion`, and record a migration
- * that had to happen — so the population still on a legacy version can be
- * watched until it drains and that version's parse branch can be deleted.
+ * Parse a stored document, migrating it to `toVersion`.
  *
- * Only version numbers are logged; the document itself is the user's.
+ * A migration logs its version pair, so the documents left on a legacy version
+ * can be watched until none remain and that version's parse branch can go. The
+ * line carries no document content; that belongs to the user.
  *
- * @throws TypeError when the document matches no version this entity knows.
+ * @throws TypeError when no known version's schema accepts the document.
  */
 export function parseDocument<T>(
   repository: Repository,
@@ -47,8 +46,8 @@ export function parseDocument<T>(
     throw new TypeError(`Invalid ${repository} document: ${result.error.type}`);
   }
 
-  // verzod routed on `documentVersion`, so a document without one is already
-  // out through the throw above. The result itself carries no source version.
+  // The parse result reports no source version, so it is taken again here.
+  // A document carrying none failed the routing above and never reaches this.
   const fromVersion = documentVersion(raw);
   if (fromVersion !== null && fromVersion < toVersion) {
     logger.info({ repository, fromVersion, toVersion }, 'migrated document on read');

--- a/apps/api/src/repositories/schema-version.ts
+++ b/apps/api/src/repositories/schema-version.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { logger } from '@/logger.js';
+
+type Repository = 'characters' | 'profile' | 'teams' | 'weapons';
+
+/**
+ * The version a raw document is in. Documents written before versioning carry
+ * no `schemaVersion`, so its absence means 0; a non-numeric one belongs to no
+ * version this entity can route.
+ *
+ * Every repository routes with this and {@link observeMigration} reads it back,
+ * so the version a document is parsed as and the version reported as migrated
+ * cannot drift apart.
+ */
+export function documentVersion(data: unknown): number | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const version = (data as Record<string, unknown>).schemaVersion;
+  return typeof version === 'number' ? version : 0;
+}
+
+/**
+ * Report that a read migrated a document forward, so the remaining population
+ * of a legacy version can be watched until it drains and that version's parse
+ * branch can be deleted.
+ *
+ * Only version numbers are logged; the document itself is the user's.
+ *
+ * Call after a successful parse — verzod's result carries no source version.
+ */
+export function observeMigration(
+  repository: Repository,
+  raw: Record<string, unknown>,
+  toVersion: number,
+): void {
+  const fromVersion = documentVersion(raw);
+  if (fromVersion === null || fromVersion >= toVersion) return;
+
+  logger.info({ repository, fromVersion, toVersion }, 'migrated document on read');
+}

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -10,7 +10,7 @@ import type {
 } from '@genshin/domain';
 import { assertCollectionTeam } from '@genshin/domain';
 
-import { observeMigration } from '@/repositories/schema-version.js';
+import { parseDocument } from '@/repositories/schema-version.js';
 
 import {
   entity,
@@ -39,12 +39,7 @@ function memberToDocument(m: CollectionTeamMember): V1Member {
 }
 
 export function fromDocument(slot: TeamSlot, raw: Record<string, unknown>): CollectionTeam {
-  const result = entity.safeParse(raw);
-  if (result.type !== 'ok') {
-    throw new TypeError(`Invalid team document: ${result.error.type}`);
-  }
-  observeMigration('teams', raw, CURRENT_VERSION);
-  const data = result.value;
+  const data = parseDocument('teams', entity, raw, CURRENT_VERSION);
   const mapped = data.members.map((m) => (m === null ? null : memberFromDocument(m)));
   const team = {
     slot,

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -10,6 +10,8 @@ import type {
 } from '@genshin/domain';
 import { assertCollectionTeam } from '@genshin/domain';
 
+import { observeMigration } from '@/repositories/schema-version.js';
+
 import {
   entity,
   CURRENT_VERSION,
@@ -41,6 +43,7 @@ export function fromDocument(slot: TeamSlot, raw: Record<string, unknown>): Coll
   if (result.type !== 'ok') {
     throw new TypeError(`Invalid team document: ${result.error.type}`);
   }
+  observeMigration('teams', raw, CURRENT_VERSION);
   const data = result.value;
   const mapped = data.members.map((m) => (m === null ? null : memberFromDocument(m)));
   const team = {

--- a/apps/api/src/repositories/teams/schemas/index.ts
+++ b/apps/api/src/repositories/teams/schemas/index.ts
@@ -3,6 +3,8 @@
 
 import { createVersionedEntity, type InferredEntity } from 'verzod';
 
+import { documentVersion } from '@/repositories/schema-version.js';
+
 import { v0 } from './v0.js';
 import { v1 } from './v1.js';
 
@@ -14,11 +16,7 @@ export const CURRENT_VERSION = 1 as const;
 export const entity = createVersionedEntity({
   latestVersion: CURRENT_VERSION,
   versionMap: { 0: v0, 1: v1 },
-  getVersion(data: unknown) {
-    if (typeof data !== 'object' || data === null) return null;
-    const ver = (data as Record<string, unknown>).schemaVersion;
-    return typeof ver === 'number' ? ver : 0;
-  },
+  getVersion: documentVersion,
 });
 
 export type V1Team = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/weapons/document.ts
+++ b/apps/api/src/repositories/weapons/document.ts
@@ -4,6 +4,8 @@
 import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/domain';
 import { assertCollectionWeapon } from '@genshin/domain';
 
+import { observeMigration } from '@/repositories/schema-version.js';
+
 import { entity, CURRENT_VERSION, type V1Weapon, type V0Weapon } from './schemas/index.js';
 
 export { CURRENT_VERSION, type V1Weapon, type V0Weapon };
@@ -16,6 +18,7 @@ export function fromDocument(
   if (result.type !== 'ok') {
     throw new TypeError(`Invalid weapon document: ${result.error.type}`);
   }
+  observeMigration('weapons', raw, CURRENT_VERSION);
   const data = result.value;
   const weapon = {
     weaponInstanceId,

--- a/apps/api/src/repositories/weapons/document.ts
+++ b/apps/api/src/repositories/weapons/document.ts
@@ -4,7 +4,7 @@
 import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/domain';
 import { assertCollectionWeapon } from '@genshin/domain';
 
-import { observeMigration } from '@/repositories/schema-version.js';
+import { parseDocument } from '@/repositories/schema-version.js';
 
 import { entity, CURRENT_VERSION, type V1Weapon, type V0Weapon } from './schemas/index.js';
 
@@ -14,12 +14,7 @@ export function fromDocument(
   weaponInstanceId: UUID,
   raw: Record<string, unknown>,
 ): CollectionWeapon {
-  const result = entity.safeParse(raw);
-  if (result.type !== 'ok') {
-    throw new TypeError(`Invalid weapon document: ${result.error.type}`);
-  }
-  observeMigration('weapons', raw, CURRENT_VERSION);
-  const data = result.value;
+  const data = parseDocument('weapons', entity, raw, CURRENT_VERSION);
   const weapon = {
     weaponInstanceId,
     weaponId: data.weaponId,

--- a/apps/api/src/repositories/weapons/schemas/index.ts
+++ b/apps/api/src/repositories/weapons/schemas/index.ts
@@ -3,6 +3,8 @@
 
 import { createVersionedEntity, type InferredEntity } from 'verzod';
 
+import { documentVersion } from '@/repositories/schema-version.js';
+
 import { v0 } from './v0.js';
 import { v1 } from './v1.js';
 
@@ -13,11 +15,7 @@ export const CURRENT_VERSION = 1 as const;
 export const entity = createVersionedEntity({
   latestVersion: CURRENT_VERSION,
   versionMap: { 0: v0, 1: v1 },
-  getVersion(data: unknown) {
-    if (typeof data !== 'object' || data === null) return null;
-    const ver = (data as Record<string, unknown>).schemaVersion;
-    return typeof ver === 'number' ? ver : 0;
-  },
+  getVersion: documentVersion,
 });
 
 export type V1Weapon = InferredEntity<typeof entity>;


### PR DESCRIPTION
## Summary

A read that migrates a Firestore document forward now records it, so the
population still on an old schema version can be watched until it drains and
that version's parse branch can be deleted. Each line carries the repository
and the version pair, nothing from the document.

That count landed in four places because reading a stored document *was* four
copies of the same parse, so the second commit moves those statements into one
function that parses, counts, and returns — leaving each repository only the
mapping into its own domain type.

Closes #736

## Gotchas

- **`getVersion` moved out of all four entities into `repositories/schema-version.ts`.**
  verzod's parse result reports no source version, so the count has to re-derive
  it; sharing the rule with `createVersionedEntity` is what stops the counted
  version and the routed version from drifting apart.
- **A parse failure now reads `Invalid characters document`, plural.** The
  message derives from the repository name instead of a hand-written noun per
  call site. Nothing asserts it and it never leaves the process — the response
  is a 500 either way.
- **The line comes from the process-wide logger, not the request-scoped child.**
  `fromDocument` has no Hono context, so a migration line carries no method or
  path; correlate with the `request completed` line by time.
- **PR #879 deletes the profile repository.** Whichever of the two lands second
  has to drop or keep that call site.

## Verification

- Deleted the `characters` call site and confirmed the new test fails, then
  restored it — the four per-repository cases bite on a repository that bypasses
  the shared read, not only on the helper in isolation.