### PR TITLE
test(api): cover the team save merge

### DIFF
--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -23,7 +23,7 @@ const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 
 const teamRef = (userId: string, documentId: string) => documentRef(userId, 'teams', documentId);
 
-/** A user whose slot already holds a team, alongside that team as first saved. */
+/** A user whose slot already holds a team, and that team as first saved. */
 async function userWithTeam(updates: Parameters<typeof save>[2]) {
   const userId = newUserId();
   const { team } = await save(userId, SLOT, updates);
@@ -79,8 +79,8 @@ describe('save', () => {
     expect(stored).toMatchObject({ name: TEAM_NAME, members: NO_MEMBERS });
   });
 
-  // An omitted description keeps the stored one, so blanking it is the only way
-  // to take a description back.
+  // An omitted description keeps the stored one, so a blank string is the only
+  // way to remove one.
   it('takes an empty description as the new description', async () => {
     const { userId } = await userWithTeam({ name: TEAM_NAME, description: DESCRIPTION });
 

--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -23,8 +23,16 @@ const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 
 const teamRef = (userId: string, documentId: string) => documentRef(userId, 'teams', documentId);
 
+/** A user whose slot already holds a team, alongside that team as first saved. */
+async function userWithTeam(updates: Parameters<typeof save>[2]) {
+  const userId = newUserId();
+  const { team } = await save(userId, SLOT, updates);
+
+  return { userId, team };
+}
+
 describe('save', () => {
-  it('names a slot the user never saved after that slot and leaves its positions open', async () => {
+  it('defaults the name and leaves every position open for an unsaved slot', async () => {
     const userId = newUserId();
 
     const { team } = await save(userId, SLOT, {});
@@ -43,8 +51,7 @@ describe('save', () => {
   });
 
   it('leaves the fields an update omits as they were', async () => {
-    const userId = newUserId();
-    const { team: original } = await save(userId, SLOT, {
+    const { userId, team: original } = await userWithTeam({
       name: TEAM_NAME,
       members: MEMBERS,
       description: DESCRIPTION,
@@ -52,7 +59,9 @@ describe('save', () => {
 
     await save(userId, SLOT, { name: RENAMED });
 
-    expect(await get(userId, SLOT)).toMatchObject({
+    const stored = await get(userId, SLOT);
+
+    expect(stored).toMatchObject({
       name: RENAMED,
       members: MEMBERS,
       description: DESCRIPTION,
@@ -61,30 +70,31 @@ describe('save', () => {
   });
 
   it('empties every position an update clears', async () => {
-    const userId = newUserId();
-    await save(userId, SLOT, { name: TEAM_NAME, members: MEMBERS });
+    const { userId } = await userWithTeam({ name: TEAM_NAME, members: MEMBERS });
 
     await save(userId, SLOT, { members: NO_MEMBERS });
 
-    expect(await get(userId, SLOT)).toMatchObject({ name: TEAM_NAME, members: NO_MEMBERS });
+    const stored = await get(userId, SLOT);
+
+    expect(stored).toMatchObject({ name: TEAM_NAME, members: NO_MEMBERS });
   });
 
   // An omitted description keeps the stored one, so blanking it is the only way
   // to take a description back.
   it('takes an empty description as the new description', async () => {
-    const userId = newUserId();
-    await save(userId, SLOT, { name: TEAM_NAME, description: DESCRIPTION });
+    const { userId } = await userWithTeam({ name: TEAM_NAME, description: DESCRIPTION });
 
     await save(userId, SLOT, { description: '' });
 
-    expect((await get(userId, SLOT))?.description).toBe('');
+    const stored = await get(userId, SLOT);
+
+    expect(stored?.description).toBe('');
   });
 });
 
 describe('get', () => {
   it('returns the team saved in that slot', async () => {
-    const userId = newUserId();
-    await save(userId, SLOT, { name: TEAM_NAME });
+    const { userId } = await userWithTeam({ name: TEAM_NAME });
 
     const team = await get(userId, SLOT);
 
@@ -98,8 +108,7 @@ describe('get', () => {
 
 describe('remove', () => {
   it('leaves nothing to get', async () => {
-    const userId = newUserId();
-    await save(userId, SLOT, { name: TEAM_NAME });
+    const { userId } = await userWithTeam({ name: TEAM_NAME });
 
     await remove(userId, SLOT);
 
@@ -112,8 +121,7 @@ describe('list', () => {
   // Reading such a document back as a team would hand `fromDocument` a slot the
   // domain rejects.
   it('skips documents whose id is not a slot', async () => {
-    const userId = newUserId();
-    await save(userId, SLOT, { name: TEAM_NAME });
+    const { userId } = await userWithTeam({ name: TEAM_NAME });
     await teamRef(userId, '9').set({
       schemaVersion: 1,
       name: 'Out of range',

--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { TeamSlot } from '@genshin/domain';
+import type { CollectionTeamMembers, TeamSlot } from '@genshin/domain';
 import { CHARACTER_ROSTER } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
@@ -12,11 +12,74 @@ import { get, list, remove, save } from './index.js';
 const SLOT: TeamSlot = 1;
 const CHARACTER = CHARACTER_ROSTER[0];
 const TEAM_NAME = 'Vaporise';
+const RENAMED = 'Melt';
+const DESCRIPTION = 'Opens with the hydro application';
+
+const MEMBERS = [{ characterId: CHARACTER.id }, null, null, null] satisfies CollectionTeamMembers;
+const NO_MEMBERS = [null, null, null, null] satisfies CollectionTeamMembers;
 
 const CREATED_AT = '2026-01-01T00:00:00.000Z';
 const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 
 const teamRef = (userId: string, documentId: string) => documentRef(userId, 'teams', documentId);
+
+describe('save', () => {
+  it('names a slot the user never saved after that slot and leaves its positions open', async () => {
+    const userId = newUserId();
+
+    const { team } = await save(userId, SLOT, {});
+
+    expect(team).toMatchObject({ name: `Team ${SLOT}`, members: NO_MEMBERS });
+  });
+
+  it('reports the first save as a creation and later ones as updates', async () => {
+    const userId = newUserId();
+
+    const first = await save(userId, SLOT, { name: TEAM_NAME });
+    const second = await save(userId, SLOT, { name: RENAMED });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+  });
+
+  it('leaves the fields an update omits as they were', async () => {
+    const userId = newUserId();
+    const { team: original } = await save(userId, SLOT, {
+      name: TEAM_NAME,
+      members: MEMBERS,
+      description: DESCRIPTION,
+    });
+
+    await save(userId, SLOT, { name: RENAMED });
+
+    expect(await get(userId, SLOT)).toMatchObject({
+      name: RENAMED,
+      members: MEMBERS,
+      description: DESCRIPTION,
+      createdAt: original.createdAt,
+    });
+  });
+
+  it('empties every position an update clears', async () => {
+    const userId = newUserId();
+    await save(userId, SLOT, { name: TEAM_NAME, members: MEMBERS });
+
+    await save(userId, SLOT, { members: NO_MEMBERS });
+
+    expect(await get(userId, SLOT)).toMatchObject({ name: TEAM_NAME, members: NO_MEMBERS });
+  });
+
+  // An omitted description keeps the stored one, so blanking it is the only way
+  // to take a description back.
+  it('takes an empty description as the new description', async () => {
+    const userId = newUserId();
+    await save(userId, SLOT, { name: TEAM_NAME, description: DESCRIPTION });
+
+    await save(userId, SLOT, { description: '' });
+
+    expect((await get(userId, SLOT))?.description).toBe('');
+  });
+});
 
 describe('get', () => {
   it('returns the team saved in that slot', async () => {


### PR DESCRIPTION
Closes #874

`teams.save()` decides each field between the update, the stored team, and a default. The suite called it only to plant fixtures, so nothing asserted which won. Tests now pin the defaults for an unsaved slot, the fields an update omits, the positions it clears, and the description a blank string removes.

## Gotchas

- **Two acceptance criteria were already met.** #1239 narrowed `codecov.yml`'s ignore to `profile/index.ts` alone, and its suite covers the `characters.save()` and `weapons.update()` merge paths the issue also named. Only `teams.save()` was left.
- **Emulator tests, not the mocked unit tests the issue prescribed.** #1239 established the emulator suite as where the repository layer is exercised; the mocked-SDK style the issue assumed no longer exists here.
- **Blanking is the only way to drop a description.** An omitted `description` keeps the stored one, so `description: ''` is the removal. That is existing behavior, documented by a test rather than changed.
- **The refactor reaches three tests this PR didn't otherwise touch.** Extracting the `userWithTeam` arrange step left the `get`, `remove`, and `list` tests duplicating it, so they adopt the helper too. Behavior is unchanged there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EdynWpbwvTtVbt38jRzPr