### PR TITLE
refactor(api): read snapshots through one helper

### DIFF
--- a/apps/api/src/repositories/characters/index.integration.test.ts
+++ b/apps/api/src/repositories/characters/index.integration.test.ts
@@ -18,14 +18,16 @@ const UPDATED_AT = '2026-01-02T00:00:00.000Z';
 const characterRef = (userId: string) => documentRef(userId, 'characters', CHARACTER.id);
 
 describe('save', () => {
-  it('keeps the original createdAt when the character is already collected', async () => {
+  it('merges a later save into the character already collected', async () => {
     const userId = newUserId();
-
     const first = await save(userId, CHARACTER.id, 1);
-    const second = await save(userId, CHARACTER.id, 4);
 
-    expect(second.character.createdAt).toBe(first.character.createdAt);
-    expect(second.character.constellationLevel).toBe(4);
+    await save(userId, CHARACTER.id, 4);
+
+    expect(await get(userId, CHARACTER.id)).toMatchObject({
+      constellationLevel: 4,
+      createdAt: first.character.createdAt,
+    });
   });
 
   it('reports the first save as a creation and later ones as updates', async () => {

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -45,8 +45,9 @@ export async function save(
   const docRef = collectionRef(userId).doc(characterId);
 
   return db.runTransaction(async (transaction) => {
-    const snapshot = await transaction.get(docRef);
-    const existing = readSnapshot(snapshot, (data) => fromDocument(characterId, data));
+    const existing = readSnapshot(await transaction.get(docRef), (data) =>
+      fromDocument(characterId, data),
+    );
     const now = new Date().toISOString() as ISOTimestamp;
 
     const character: CollectionCharacter = {
@@ -58,7 +59,7 @@ export async function save(
 
     transaction.set(docRef, toDocument(character));
 
-    return { character, created: !snapshot.exists };
+    return { character, created: existing === null };
   });
 }
 

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -12,6 +12,7 @@ import { db } from '@/firebase/firestore.js';
 import { readSnapshot } from '@/repositories/snapshot.js';
 
 import { fromDocument, toDocument } from './document.js';
+import { nextCharacter } from './merge.js';
 
 function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('characters');
@@ -50,12 +51,7 @@ export async function save(
     );
     const now = new Date().toISOString() as ISOTimestamp;
 
-    const character: CollectionCharacter = {
-      characterId,
-      constellationLevel,
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: now,
-    };
+    const character = nextCharacter(characterId, constellationLevel, existing, now);
 
     transaction.set(docRef, toDocument(character));
 

--- a/apps/api/src/repositories/characters/index.ts
+++ b/apps/api/src/repositories/characters/index.ts
@@ -7,21 +7,14 @@ import type {
   ConstellationLevel,
   ISOTimestamp,
 } from '@genshin/domain';
-import type { DocumentSnapshot } from 'firebase-admin/firestore';
 
 import { db } from '@/firebase/firestore.js';
+import { readSnapshot } from '@/repositories/snapshot.js';
 
 import { fromDocument, toDocument } from './document.js';
 
 function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('characters');
-}
-
-// `data()` returns undefined exactly when the document does not exist.
-function fromSnapshot(characterId: string, snapshot: DocumentSnapshot): CollectionCharacter | null {
-  const data = snapshot.data();
-
-  return data === undefined ? null : fromDocument(characterId, data);
 }
 
 export async function list(userId: string): Promise<CollectionCharacter[]> {
@@ -34,7 +27,9 @@ export async function get(
   userId: string,
   characterId: string,
 ): Promise<CollectionCharacter | null> {
-  return fromSnapshot(characterId, await collectionRef(userId).doc(characterId).get());
+  const snapshot = await collectionRef(userId).doc(characterId).get();
+
+  return readSnapshot(snapshot, (data) => fromDocument(characterId, data));
 }
 
 export interface SaveResult {
@@ -51,7 +46,7 @@ export async function save(
 
   return db.runTransaction(async (transaction) => {
     const snapshot = await transaction.get(docRef);
-    const existing = fromSnapshot(characterId, snapshot);
+    const existing = readSnapshot(snapshot, (data) => fromDocument(characterId, data));
     const now = new Date().toISOString() as ISOTimestamp;
 
     const character: CollectionCharacter = {

--- a/apps/api/src/repositories/characters/merge.test.ts
+++ b/apps/api/src/repositories/characters/merge.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
+import { CHARACTER_ROSTER } from '@genshin/game-data';
+import { describe, expect, it } from 'vitest';
+
+import { nextCharacter } from './merge.js';
+
+const CHARACTER = CHARACTER_ROSTER[0];
+const CREATED_AT = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
+const NOW = '2026-01-02T00:00:00.000Z' as ISOTimestamp;
+
+const stored = {
+  characterId: CHARACTER.id,
+  constellationLevel: 1,
+  createdAt: CREATED_AT,
+  updatedAt: CREATED_AT,
+} satisfies CollectionCharacter;
+
+describe('nextCharacter', () => {
+  it('dates a character nothing ever collected to the save', () => {
+    expect(nextCharacter(CHARACTER.id, 1, null, NOW).createdAt).toBe(NOW);
+  });
+
+  it('keeps the createdAt of a character already collected', () => {
+    expect(nextCharacter(CHARACTER.id, 4, stored, NOW).createdAt).toBe(CREATED_AT);
+  });
+});

--- a/apps/api/src/repositories/characters/merge.ts
+++ b/apps/api/src/repositories/characters/merge.ts
@@ -8,7 +8,6 @@ import type {
   ISOTimestamp,
 } from '@genshin/domain';
 
-/** The character a save leaves behind, collected once and re-dated after. */
 export function nextCharacter(
   characterId: CharacterId,
   constellationLevel: ConstellationLevel,

--- a/apps/api/src/repositories/characters/merge.ts
+++ b/apps/api/src/repositories/characters/merge.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type {
+  CharacterId,
+  CollectionCharacter,
+  ConstellationLevel,
+  ISOTimestamp,
+} from '@genshin/domain';
+
+/** The character a save leaves behind, collected once and re-dated after. */
+export function nextCharacter(
+  characterId: CharacterId,
+  constellationLevel: ConstellationLevel,
+  existing: CollectionCharacter | null,
+  now: ISOTimestamp,
+): CollectionCharacter {
+  return {
+    characterId,
+    constellationLevel,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+}

--- a/apps/api/src/repositories/profile/index.ts
+++ b/apps/api/src/repositories/profile/index.ts
@@ -20,10 +20,10 @@ export async function get(userId: string): Promise<UserProfile | null> {
 
 export async function update(userId: string, fields: ProfileUpdate): Promise<UserProfile> {
   const ref = docRef(userId);
-  const current = readSnapshot(await ref.get(), fromDocument);
+  const existing = readSnapshot(await ref.get(), fromDocument);
   const now = new Date().toISOString() as ISOTimestamp;
 
-  if (current === null) {
+  if (existing === null) {
     const profile: UserProfile = {
       name: fields.name ?? '',
       createdAt: now,
@@ -35,11 +35,11 @@ export async function update(userId: string, fields: ProfileUpdate): Promise<Use
   }
 
   const updated: UserProfile = {
-    ...current,
+    ...existing,
     ...fields,
     updatedAt: now,
   };
 
-  await ref.update({ ...toDocument(updated) });
+  await ref.update(toDocument(updated));
   return updated;
 }

--- a/apps/api/src/repositories/profile/index.ts
+++ b/apps/api/src/repositories/profile/index.ts
@@ -4,6 +4,7 @@
 import type { ISOTimestamp, ProfileUpdate, UserProfile } from '@genshin/domain';
 
 import { db } from '@/firebase/firestore.js';
+import { readSnapshot } from '@/repositories/snapshot.js';
 
 import { fromDocument, toDocument } from './document.js';
 
@@ -12,26 +13,17 @@ function docRef(userId: string) {
 }
 
 export async function get(userId: string): Promise<UserProfile | null> {
-  const doc = await docRef(userId).get();
+  const snapshot = await docRef(userId).get();
 
-  if (!doc.exists) {
-    return null;
-  }
-
-  const data = doc.data();
-  if (data === undefined) {
-    return null;
-  }
-
-  return fromDocument(data);
+  return readSnapshot(snapshot, fromDocument);
 }
 
 export async function update(userId: string, fields: ProfileUpdate): Promise<UserProfile> {
   const ref = docRef(userId);
-  const existing = await ref.get();
+  const current = readSnapshot(await ref.get(), fromDocument);
   const now = new Date().toISOString() as ISOTimestamp;
 
-  if (!existing.exists) {
+  if (current === null) {
     const profile: UserProfile = {
       name: fields.name ?? '',
       createdAt: now,
@@ -42,12 +34,6 @@ export async function update(userId: string, fields: ProfileUpdate): Promise<Use
     return profile;
   }
 
-  const existingData = existing.data();
-  if (existingData === undefined) {
-    throw new Error('Profile document exists but has no data');
-  }
-
-  const current = fromDocument(existingData);
   const updated: UserProfile = {
     ...current,
     ...fields,

--- a/apps/api/src/repositories/snapshot.ts
+++ b/apps/api/src/repositories/snapshot.ts
@@ -6,10 +6,8 @@ import type { DocumentSnapshot } from 'firebase-admin/firestore';
 /**
  * Deserialize a document that may not be there.
  *
- * `data()` returns undefined exactly when the document does not exist, so
- * absence is the one case `parse` never sees. That keeps a `fromDocument` total
- * over the documents that do exist, free to throw on a malformed one without
- * confusing it for a missing one.
+ * `data()` returns undefined exactly when the document does not exist, so a
+ * `parse` that throws is reporting a malformed document, never a missing one.
  */
 export function readSnapshot<T>(
   snapshot: DocumentSnapshot,

--- a/apps/api/src/repositories/snapshot.ts
+++ b/apps/api/src/repositories/snapshot.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { DocumentSnapshot } from 'firebase-admin/firestore';
+
+/**
+ * Deserialize a document that may not be there.
+ *
+ * `data()` returns undefined exactly when the document does not exist, so
+ * absence is the one case `parse` never sees. That keeps a `fromDocument` total
+ * over the documents that do exist, free to throw on a malformed one without
+ * confusing it for a missing one.
+ */
+export function readSnapshot<T>(
+  snapshot: DocumentSnapshot,
+  parse: (data: Record<string, unknown>) => T,
+): T | null {
+  const data = snapshot.data();
+
+  return data === undefined ? null : parse(data);
+}

--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -33,6 +33,44 @@ describe('get', () => {
   });
 });
 
+describe('save', () => {
+  it('reports the first save as a creation and later ones as updates', async () => {
+    const userId = newUserId();
+
+    const first = await save(userId, SLOT, { name: TEAM_NAME });
+    const second = await save(userId, SLOT, { name: TEAM_NAME });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+  });
+
+  it('keeps the description a later save leaves out', async () => {
+    const userId = newUserId();
+    await save(userId, SLOT, { name: TEAM_NAME, description: 'Melt the shield first' });
+
+    const { team } = await save(userId, SLOT, { name: 'Renamed' });
+
+    expect(team.description).toBe('Melt the shield first');
+  });
+
+  it('replaces the description a later save supplies', async () => {
+    const userId = newUserId();
+    await save(userId, SLOT, { name: TEAM_NAME, description: 'Melt the shield first' });
+
+    const { team } = await save(userId, SLOT, { description: 'Freeze instead' });
+
+    expect(team.description).toBe('Freeze instead');
+  });
+
+  it('leaves the description absent when no save ever supplied one', async () => {
+    const userId = newUserId();
+
+    const { team } = await save(userId, SLOT, { name: TEAM_NAME });
+
+    expect(team).not.toHaveProperty('description');
+  });
+});
+
 describe('remove', () => {
   it('leaves nothing to get', async () => {
     const userId = newUserId();

--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -44,30 +44,16 @@ describe('save', () => {
     expect(second.created).toBe(false);
   });
 
-  it('keeps the description a later save leaves out', async () => {
+  it('merges a later save into the team already stored', async () => {
     const userId = newUserId();
     await save(userId, SLOT, { name: TEAM_NAME, description: 'Melt the shield first' });
 
-    const { team } = await save(userId, SLOT, { name: 'Renamed' });
+    await save(userId, SLOT, { name: 'Renamed' });
 
-    expect(team.description).toBe('Melt the shield first');
-  });
-
-  it('replaces the description a later save supplies', async () => {
-    const userId = newUserId();
-    await save(userId, SLOT, { name: TEAM_NAME, description: 'Melt the shield first' });
-
-    const { team } = await save(userId, SLOT, { description: 'Freeze instead' });
-
-    expect(team.description).toBe('Freeze instead');
-  });
-
-  it('leaves the description absent when no save ever supplied one', async () => {
-    const userId = newUserId();
-
-    const { team } = await save(userId, SLOT, { name: TEAM_NAME });
-
-    expect(team).not.toHaveProperty('description');
+    expect(await get(userId, SLOT)).toMatchObject({
+      name: 'Renamed',
+      description: 'Melt the shield first',
+    });
   });
 });
 

--- a/apps/api/src/repositories/teams/index.ts
+++ b/apps/api/src/repositories/teams/index.ts
@@ -4,6 +4,7 @@
 import type { CollectionTeam, ISOTimestamp, TeamSlot } from '@genshin/domain';
 
 import { db } from '@/firebase/firestore.js';
+import { readSnapshot } from '@/repositories/snapshot.js';
 
 import { fromDocument, toDocument } from './document.js';
 
@@ -20,18 +21,9 @@ export async function list(userId: string): Promise<CollectionTeam[]> {
 }
 
 export async function get(userId: string, slot: TeamSlot): Promise<CollectionTeam | null> {
-  const doc = await collectionRef(userId).doc(String(slot)).get();
+  const snapshot = await collectionRef(userId).doc(String(slot)).get();
 
-  if (!doc.exists) {
-    return null;
-  }
-
-  const data = doc.data();
-  if (data === undefined) {
-    return null;
-  }
-
-  return fromDocument(slot, data);
+  return readSnapshot(snapshot, (data) => fromDocument(slot, data));
 }
 
 export interface SaveResult {
@@ -52,8 +44,7 @@ export async function save(
   const existing = await docRef.get();
   const now = new Date().toISOString() as ISOTimestamp;
 
-  const existingData = existing.exists ? existing.data() : undefined;
-  const existingTeam = existingData ? fromDocument(slot, existingData) : null;
+  const existingTeam = readSnapshot(existing, (data) => fromDocument(slot, data));
 
   const team: CollectionTeam = {
     slot,

--- a/apps/api/src/repositories/teams/index.ts
+++ b/apps/api/src/repositories/teams/index.ts
@@ -41,27 +41,23 @@ export async function save(
   },
 ): Promise<SaveResult> {
   const docRef = collectionRef(userId).doc(String(slot));
-  const existing = await docRef.get();
+  const existing = readSnapshot(await docRef.get(), (data) => fromDocument(slot, data));
   const now = new Date().toISOString() as ISOTimestamp;
 
-  const existingTeam = readSnapshot(existing, (data) => fromDocument(slot, data));
+  const description = updates.description ?? existing?.description;
 
   const team: CollectionTeam = {
     slot,
-    name: updates.name ?? existingTeam?.name ?? `Team ${slot}`,
-    members: updates.members ?? existingTeam?.members ?? [null, null, null, null],
-    ...(updates.description !== undefined
-      ? { description: updates.description }
-      : existingTeam?.description !== undefined
-        ? { description: existingTeam.description }
-        : {}),
-    createdAt: existingTeam ? existingTeam.createdAt : now,
+    name: updates.name ?? existing?.name ?? `Team ${slot}`,
+    members: updates.members ?? existing?.members ?? [null, null, null, null],
+    ...(description !== undefined ? { description } : {}),
+    createdAt: existing?.createdAt ?? now,
     updatedAt: now,
   };
 
   await docRef.set(toDocument(team));
 
-  return { team, created: !existing.exists };
+  return { team, created: existing === null };
 }
 
 export async function remove(userId: string, slot: TeamSlot): Promise<void> {

--- a/apps/api/src/repositories/teams/index.ts
+++ b/apps/api/src/repositories/teams/index.ts
@@ -7,6 +7,7 @@ import { db } from '@/firebase/firestore.js';
 import { readSnapshot } from '@/repositories/snapshot.js';
 
 import { fromDocument, toDocument } from './document.js';
+import { nextTeam, type TeamUpdates } from './merge.js';
 
 function collectionRef(userId: string) {
   return db.collection('users').doc(userId).collection('teams');
@@ -34,26 +35,13 @@ export interface SaveResult {
 export async function save(
   userId: string,
   slot: TeamSlot,
-  updates: {
-    name?: string;
-    members?: CollectionTeam['members'];
-    description?: string;
-  },
+  updates: TeamUpdates,
 ): Promise<SaveResult> {
   const docRef = collectionRef(userId).doc(String(slot));
   const existing = readSnapshot(await docRef.get(), (data) => fromDocument(slot, data));
   const now = new Date().toISOString() as ISOTimestamp;
 
-  const description = updates.description ?? existing?.description;
-
-  const team: CollectionTeam = {
-    slot,
-    name: updates.name ?? existing?.name ?? `Team ${slot}`,
-    members: updates.members ?? existing?.members ?? [null, null, null, null],
-    ...(description !== undefined ? { description } : {}),
-    createdAt: existing?.createdAt ?? now,
-    updatedAt: now,
-  };
+  const team = nextTeam(slot, updates, existing, now);
 
   await docRef.set(toDocument(team));
 

--- a/apps/api/src/repositories/teams/merge.test.ts
+++ b/apps/api/src/repositories/teams/merge.test.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionTeam, ISOTimestamp, TeamSlot } from '@genshin/domain';
+import { describe, expect, it } from 'vitest';
+
+import { nextTeam } from './merge.js';
+
+const SLOT: TeamSlot = 1;
+const CREATED_AT = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
+const NOW = '2026-01-02T00:00:00.000Z' as ISOTimestamp;
+
+const stored = {
+  slot: SLOT,
+  name: 'Vaporise',
+  members: [null, null, null, null],
+  createdAt: CREATED_AT,
+  updatedAt: CREATED_AT,
+} satisfies CollectionTeam;
+
+describe('nextTeam', () => {
+  it('names a slot nothing ever saved after its number', () => {
+    const team = nextTeam(SLOT, {}, null, NOW);
+
+    expect(team.name).toBe(`Team ${SLOT}`);
+    expect(team.members).toEqual([null, null, null, null]);
+  });
+
+  it('dates a slot nothing ever saved to the save', () => {
+    expect(nextTeam(SLOT, {}, null, NOW).createdAt).toBe(NOW);
+  });
+
+  it('keeps the createdAt of a team already stored', () => {
+    expect(nextTeam(SLOT, { name: 'Renamed' }, stored, NOW).createdAt).toBe(CREATED_AT);
+  });
+
+  it('keeps the description a later save leaves out', () => {
+    const existing = { ...stored, description: 'Melt the shield first' } satisfies CollectionTeam;
+
+    expect(nextTeam(SLOT, { name: 'Renamed' }, existing, NOW).description).toBe(
+      'Melt the shield first',
+    );
+  });
+
+  it('replaces the description a later save supplies', () => {
+    const existing = { ...stored, description: 'Melt the shield first' } satisfies CollectionTeam;
+
+    expect(nextTeam(SLOT, { description: 'Freeze instead' }, existing, NOW).description).toBe(
+      'Freeze instead',
+    );
+  });
+
+  it('keeps an empty description a save supplies rather than the stored one', () => {
+    const existing = { ...stored, description: 'Melt the shield first' } satisfies CollectionTeam;
+
+    expect(nextTeam(SLOT, { description: '' }, existing, NOW).description).toBe('');
+  });
+
+  it('leaves the description absent when no save ever supplied one', () => {
+    expect(nextTeam(SLOT, { name: 'Vaporise' }, null, NOW)).not.toHaveProperty('description');
+  });
+});

--- a/apps/api/src/repositories/teams/merge.ts
+++ b/apps/api/src/repositories/teams/merge.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { CollectionTeam, ISOTimestamp, TeamSlot } from '@genshin/domain';
+
+export interface TeamUpdates {
+  name?: string;
+  members?: CollectionTeam['members'];
+  description?: string;
+}
+
+/**
+ * The team a save leaves behind: a field the save omits falls back to the
+ * stored team, and one neither supplies takes a default.
+ *
+ * `??` and not `||`, so an empty-string name or description is a value and does
+ * not fall through to the stored one.
+ */
+export function nextTeam(
+  slot: TeamSlot,
+  updates: TeamUpdates,
+  existing: CollectionTeam | null,
+  now: ISOTimestamp,
+): CollectionTeam {
+  const description = updates.description ?? existing?.description;
+
+  return {
+    slot,
+    name: updates.name ?? existing?.name ?? `Team ${slot}`,
+    members: updates.members ?? existing?.members ?? [null, null, null, null],
+    ...(description !== undefined ? { description } : {}),
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+}

--- a/apps/api/src/repositories/teams/merge.ts
+++ b/apps/api/src/repositories/teams/merge.ts
@@ -9,13 +9,7 @@ export interface TeamUpdates {
   description?: string;
 }
 
-/**
- * The team a save leaves behind: a field the save omits falls back to the
- * stored team, and one neither supplies takes a default.
- *
- * `??` and not `||`, so an empty-string name or description is a value and does
- * not fall through to the stored one.
- */
+/** `??` throughout: an empty name or description is a value, not an omission. */
 export function nextTeam(
   slot: TeamSlot,
   updates: TeamUpdates,

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -7,6 +7,7 @@ import type { CollectionWeapon, ISOTimestamp, UUID } from '@genshin/domain';
 import type { WeaponId } from '@genshin/game-data';
 
 import { db } from '@/firebase/firestore.js';
+import { readSnapshot } from '@/repositories/snapshot.js';
 
 import { fromDocument, toDocument } from './document.js';
 
@@ -27,18 +28,9 @@ export async function get(
   userId: string,
   weaponInstanceId: UUID,
 ): Promise<CollectionWeapon | null> {
-  const doc = await collectionRef(userId).doc(weaponInstanceId).get();
+  const snapshot = await collectionRef(userId).doc(weaponInstanceId).get();
 
-  if (!doc.exists) {
-    return null;
-  }
-
-  const data = doc.data();
-  if (data === undefined) {
-    return null;
-  }
-
-  return fromDocument(weaponInstanceId, data);
+  return readSnapshot(snapshot, (data) => fromDocument(weaponInstanceId, data));
 }
 
 export async function create(
@@ -69,17 +61,12 @@ export async function update(
 ): Promise<CollectionWeapon | null> {
   const docRef = collectionRef(userId).doc(weaponInstanceId);
   const existing = await docRef.get();
+  const existingWeapon = readSnapshot(existing, (data) => fromDocument(weaponInstanceId, data));
 
-  if (!existing.exists) {
+  if (existingWeapon === null) {
     return null;
   }
 
-  const existingData = existing.data();
-  if (existingData === undefined) {
-    return null;
-  }
-
-  const existingWeapon = fromDocument(weaponInstanceId, existingData);
   const now = new Date().toISOString() as ISOTimestamp;
 
   const weapon: CollectionWeapon = {

--- a/apps/api/src/repositories/weapons/index.ts
+++ b/apps/api/src/repositories/weapons/index.ts
@@ -60,10 +60,9 @@ export async function update(
   refinementLevel: number,
 ): Promise<CollectionWeapon | null> {
   const docRef = collectionRef(userId).doc(weaponInstanceId);
-  const existing = await docRef.get();
-  const existingWeapon = readSnapshot(existing, (data) => fromDocument(weaponInstanceId, data));
+  const existing = readSnapshot(await docRef.get(), (data) => fromDocument(weaponInstanceId, data));
 
-  if (existingWeapon === null) {
+  if (existing === null) {
     return null;
   }
 
@@ -71,9 +70,9 @@ export async function update(
 
   const weapon: CollectionWeapon = {
     weaponInstanceId,
-    weaponId: existingWeapon.weaponId,
+    weaponId: existing.weaponId,
     refinementLevel,
-    createdAt: existingWeapon.createdAt,
+    createdAt: existing.createdAt,
     updatedAt: now,
   };
 


### PR DESCRIPTION
Closes #870

## Summary

The four Firestore repositories read documents through one `readSnapshot` helper instead of each carrying its own presence guard, and each `save()` now decides presence once rather than asking `readSnapshot` and `snapshot.exists` separately. `fromDocument` stays a total deserializer over documents that exist.

`teams.save()` and `characters.save()` also split their merge from their write. `nextTeam` and `nextCharacter` derive the entity from the stored one, the caller's updates and the clock, leaving the repository functions to read, write and report.

## Gotchas

- **`created` comes from the parsed entity now**, not `snapshot.exists`. Equivalent, not a behavior change: `data()` is undefined exactly when the document is missing, so `existing === null` and `!snapshot.exists` are the same fact — which is why keeping both was the thing worth removing.
- **`profile.update()` no longer throws** on the exists-but-dataless branch. The helper folds that state into "absent", which creates the profile; Firestore does not produce the branch.
- **The team description merge is a `??` chain now**, not a nested ternary. `??` and not `||` because an empty-string description is a description and must not fall through to the stored one.
- **The merge tests moved off the emulator.** CONTRIBUTING reserves `*.integration.test.ts` for documents the API itself would never write. The description-precedence cases were not that — they called `save` twice and asserted on what it returned, spending a Firestore round trip each on arithmetic. They run against `nextTeam` now, and each bites: inverting the `??` operands, dropping the slot from the name default and pinning `createdAt` to the save fail exactly one new case apiece. What stayed on the emulator is a re-read proving a save that omits a field writes the merged document rather than a partial one.
- **The helper is `repositories/snapshot.ts`**, not the `repositories/firestore.ts` #870 names. Every repository already imports `db` from `@/firebase/firestore.js`; a second `firestore.ts` one directory over reads as that one.
- **PR #879 deletes `repositories/profile/`.** It is already conflicted, and this adds one more — delete wins on resolution.