### PR TITLE
refactor: share the strict TypeScript baseline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,6 +47,7 @@ per-repository instruction file either tool loads.
 ## Build and CI rules
 
 - Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't automatically build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
+- Every workspace `tsconfig.json` extends `@genshin/tsconfig` and keeps only what genuinely differs: the path-relative options TypeScript resolves against the declaring file (`outDir`, `rootDir`, `paths`, `include`, `exclude`) and the platform axis (`module`, `moduleResolution`, `lib`, `types`, `jsx`). Strictness flags belong in the shared config, so a workspace never re-declares them.
 - The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. The build config extends `tsconfig.json`, so compiler options stay in sync automatically; only the exclude patterns differ.
 - When `tsconfig.json` uses project references, type-check with `tsc -b --noEmit`. Plain `tsc --noEmit` won't follow references.
 - A new project-wide check belongs in `.pre-commit-config.yaml`, which `ci.yml` runs over the whole tree. The `runCmd` chain in `devcontainer.yml` exercises the built image's toolchain instead, so it takes a command only when nothing else in the chain runs that tool.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,7 +47,7 @@ per-repository instruction file either tool loads.
 ## Build and CI rules
 
 - Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test` in CI, Docker, and deploy workflows. Never use raw `pnpm --filter <pkg> <task>` for these because pnpm doesn't automatically build workspace dependencies first; turbo handles dependency ordering via `^build` in `turbo.json`.
-- Every workspace `tsconfig.json` extends `@genshin/tsconfig` and keeps only what genuinely differs: the path-relative options TypeScript resolves against the declaring file (`outDir`, `rootDir`, `paths`, `include`, `exclude`) and the platform axis (`module`, `moduleResolution`, `lib`, `types`, `jsx`). Strictness flags belong in the shared config, so a workspace never re-declares them.
+- Every workspace `tsconfig.json` extends `@genshin/tsconfig` and never re-declares a strictness flag; those belong in the shared config. Keep local only the options TypeScript resolves relative to the declaring file (`outDir`, `rootDir`, `paths`, `include`) and the platform axis (`module`, `moduleResolution`, `lib`, `types`, `jsx`).
 - The API uses `tsconfig.json` (includes tests) for typechecking and `tsconfig.build.json` (excludes tests) for emit. The build config extends `tsconfig.json`, so compiler options stay in sync automatically; only the exclude patterns differ.
 - When `tsconfig.json` uses project references, type-check with `tsc -b --noEmit`. Plain `tsc --noEmit` won't follow references.
 - A new project-wide check belongs in `.pre-commit-config.yaml`, which `ci.yml` runs over the whole tree. The `runCmd` chain in `devcontainer.yml` exercises the built image's toolchain instead, so it takes a command only when nothing else in the chain runs that tool.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,6 +27,7 @@ COPY apps/api/package.json ./apps/api/
 COPY packages/collection-json/package.json ./packages/collection-json/
 COPY packages/domain/package.json ./packages/domain/
 COPY packages/game-data/package.json ./packages/game-data/
+COPY packages/tsconfig/package.json ./packages/tsconfig/
 COPY packages/validation/package.json ./packages/validation/
 
 RUN pnpm install --frozen-lockfile

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@types/negotiator": "0.6.5",
     "@types/node": "25.9.5",
     "@typescript/native": "npm:typescript@7.0.2",

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -7,9 +7,7 @@
     "rootDir": "./src",
     "types": ["node"],
     "resolveJsonModule": true,
-    // Path aliases eliminate relative imports and clarify module organization.
-    // Single @/* pattern handles all imports (e.g., @/middleware/auth → ./src/middleware/auth).
-    // tsc-alias rewrites these in compiled JS during build for runtime compatibility.
+    // tsc-alias rewrites these in the emitted JavaScript so Node can resolve them.
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,18 +1,12 @@
 {
+  "extends": "@genshin/tsconfig/base.json",
   "compilerOptions": {
-    "target": "ES2022",
     "module": "nodenext",
-    "lib": ["ES2022"],
     "moduleResolution": "nodenext",
     "outDir": "./dist",
     "rootDir": "./src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "types": ["node"],
-    "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "verbatimModuleSyntax": true,
     // Path aliases eliminate relative imports and clarify module organization.
     // Single @/* pattern handles all imports (e.g., @/middleware/auth → ./src/middleware/auth).
     // tsc-alias rewrites these in compiled JS during build for runtime compatibility.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@codecov/vite-plugin": "2.0.1",
     "@eslint-react/eslint-plugin": "5.18.3",
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@tailwindcss/postcss": "4.3.3",
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.2",

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -1,14 +1,9 @@
 {
-  "extends": "@genshin/tsconfig/base.json",
+  "extends": "@genshin/tsconfig/no-emit.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
-    "useDefineForClassFields": true,
-    "allowImportingTsExtensions": true,
-    "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
       "@/*": ["./src/*"]

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -1,31 +1,18 @@
 {
+  "extends": "@genshin/tsconfig/base.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2022",
-    "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
-    "skipLibCheck": true,
-
-    /* Bundler mode */
     "moduleResolution": "bundler",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
+    "types": ["vite/client"],
+    "useDefineForClassFields": true,
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,14 +1,10 @@
 {
-  "extends": "@genshin/tsconfig/base.json",
+  "extends": "@genshin/tsconfig/no-emit.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",
     "lib": ["ES2023"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "allowImportingTsExtensions": true,
-    "noEmit": true
+    "types": ["node"]
   },
   "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,26 +1,14 @@
 {
+  "extends": "@genshin/tsconfig/base.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
-    "types": ["node"],
-    "skipLibCheck": true,
-
-    /* Bundler mode */
     "moduleResolution": "bundler",
+    "types": ["node"],
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noEmit": true
   },
   "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -63,9 +63,11 @@ closest template.
   `@vitest/coverage-v8` dev dependencies and a `vitest.config.ts`.
 
 - [ ] `tsconfig.json`: extends `@genshin/tsconfig/library.json` and adds only
-      `outDir`, `rootDir`, `include`, and `exclude`. TypeScript resolves those
-      four relative to the file declaring them, so the shared config can't carry
+      `outDir`, `rootDir`, and `include`. TypeScript resolves those three
+      relative to the file declaring them, so the shared config can't carry
       them. A package reaching for Node APIs also adds `"types": ["node"]`.
+      Skip `exclude`: with `include` naming `src`, the compiler already leaves
+      `node_modules` and the output directory out.
 - [ ] `tsconfig.build.json`: extends `./tsconfig.json` and adds
       `"exclude": ["src/**/*.test.ts"]`. The `build` script points here so test
       files stay out of `dist`.

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -65,9 +65,7 @@ closest template.
 - [ ] `tsconfig.json`: extends `@genshin/tsconfig/library.json` and adds only
       `outDir`, `rootDir`, and `include`. TypeScript resolves those three
       relative to the file declaring them, so the shared config can't carry
-      them. A package reaching for Node APIs also adds `"types": ["node"]`.
-      Skip `exclude`: with `include` naming `src`, the compiler already leaves
-      `node_modules` and the output directory out.
+      them. A package that uses Node APIs also adds `"types": ["node"]`.
 - [ ] `tsconfig.build.json`: extends `./tsconfig.json` and adds
       `"exclude": ["src/**/*.test.ts"]`. The `build` script points here so test
       files stay out of `dist`.

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -46,6 +46,7 @@ closest template.
     },
     "devDependencies": {
       "@genshin/eslint-config": "workspace:*",
+      "@genshin/tsconfig": "workspace:*",
       "@typescript/native": "npm:typescript@7.0.2",
       "eslint": "10.4.0",
       "typescript": "npm:@typescript/typescript6@6.0.2"
@@ -61,8 +62,10 @@ closest template.
   Add `test` only once tests exist, along with the `vitest` and
   `@vitest/coverage-v8` dev dependencies and a `vitest.config.ts`.
 
-- [ ] `tsconfig.json`: compiler options plus `include: ["src/**/*"]` (no shared
-      base to extend).
+- [ ] `tsconfig.json`: extends `@genshin/tsconfig/library.json` and adds only
+      `outDir`, `rootDir`, `include`, and `exclude`. TypeScript resolves those
+      four relative to the file declaring them, so the shared config can't carry
+      them. A package reaching for Node APIs also adds `"types": ["node"]`.
 - [ ] `tsconfig.build.json`: extends `./tsconfig.json` and adds
       `"exclude": ["src/**/*.test.ts"]`. The `build` script points here so test
       files stay out of `dist`.

--- a/packages/collection-json/package.json
+++ b/packages/collection-json/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.1",

--- a/packages/collection-json/tsconfig.json
+++ b/packages/collection-json/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"]
 }

--- a/packages/collection-json/tsconfig.json
+++ b/packages/collection-json/tsconfig.json
@@ -1,20 +1,8 @@
 {
+  "extends": "@genshin/tsconfig/library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022"],
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.1",

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"]
 }

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,20 +1,8 @@
 {
+  "extends": "@genshin/tsconfig/library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022"],
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/game-data/package.json
+++ b/packages/game-data/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@types/node": "25.9.5",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "4.1.10",

--- a/packages/game-data/tsconfig.json
+++ b/packages/game-data/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"]
 }

--- a/packages/game-data/tsconfig.json
+++ b/packages/game-data/tsconfig.json
@@ -1,20 +1,8 @@
 {
+  "extends": "@genshin/tsconfig/library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022"],
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -8,7 +8,6 @@
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
 
     "strict": true,

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,0 +1,20 @@
+{
+  // Path-relative options (outDir, rootDir, paths, include, exclude) resolve
+  // against the file that declares them, so they stay in each workspace.
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  }
+}

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,6 +1,6 @@
 {
-  // Path-relative options (outDir, rootDir, paths, include, exclude) resolve
-  // against the file that declares them, so they stay in each workspace.
+  // TypeScript resolves outDir, rootDir, paths, and include relative to the
+  // file declaring them, so each workspace keeps its own.
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],

--- a/packages/tsconfig/library.json
+++ b/packages/tsconfig/library.json
@@ -1,6 +1,4 @@
 {
-  // Workspace libraries: ESM consumed through a bundler-style resolver, with
-  // declarations emitted so dependents typecheck against `dist`.
   "extends": "./base.json",
   "compilerOptions": {
     "module": "ES2022",

--- a/packages/tsconfig/library.json
+++ b/packages/tsconfig/library.json
@@ -1,0 +1,11 @@
+{
+  // Workspace libraries: ESM consumed through a bundler-style resolver, with
+  // declarations emitted so dependents typecheck against `dist`.
+  "extends": "./base.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/tsconfig/no-emit.json
+++ b/packages/tsconfig/no-emit.json
@@ -1,6 +1,5 @@
 {
-  // Type-checked only: a bundler or test runner performs the transform, so tsc
-  // never writes output and TypeScript extensions stay in import specifiers.
+  // Another tool transforms these sources, so tsc only checks them.
   "extends": "./base.json",
   "compilerOptions": {
     "module": "ESNext",

--- a/packages/tsconfig/no-emit.json
+++ b/packages/tsconfig/no-emit.json
@@ -1,0 +1,11 @@
+{
+  // Type-checked only: a bundler or test runner performs the transform, so tsc
+  // never writes output and TypeScript extensions stay in import specifiers.
+  "extends": "./base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -6,10 +6,12 @@
   "type": "module",
   "exports": {
     "./base.json": "./base.json",
-    "./library.json": "./library.json"
+    "./library.json": "./library.json",
+    "./no-emit.json": "./no-emit.json"
   },
   "files": [
     "base.json",
-    "library.json"
+    "library.json",
+    "no-emit.json"
   ]
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@genshin/tsconfig",
+  "version": "0.0.0",
+  "description": "Shared TypeScript compiler baseline for the monorepo",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./base.json": "./base.json",
+    "./library.json": "./library.json"
+  },
+  "files": [
+    "base.json",
+    "library.json"
+  ]
+}

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.1",

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"]
 }

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -1,20 +1,8 @@
 {
+  "extends": "@genshin/tsconfig/library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022"],
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@types/negotiator':
         specifier: 0.6.5
         version: 0.6.5
@@ -205,6 +208,9 @@ importers:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@tailwindcss/postcss':
         specifier: 4.3.3
         version: 4.3.3
@@ -298,6 +304,9 @@ importers:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@typescript/native':
         specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
@@ -329,6 +338,9 @@ importers:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@typescript/native':
         specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
@@ -374,6 +386,9 @@ importers:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: 25.9.5
         version: 25.9.5
@@ -393,11 +408,16 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  packages/tsconfig: {}
+
   packages/validation:
     devDependencies:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@typescript/native':
         specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
@@ -426,6 +446,9 @@ importers:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@types/node':
         specifier: 25.9.5
         version: 25.9.5
@@ -454,6 +477,9 @@ importers:
       '@genshin/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@genshin/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@types/node':
         specifier: 25.9.5
         version: 25.9.5

--- a/tools/e2e/package.json
+++ b/tools/e2e/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@types/node": "25.9.5",
     "@typescript/native": "npm:typescript@7.0.2",
     "eslint": "10.8.1",

--- a/tools/e2e/tsconfig.json
+++ b/tools/e2e/tsconfig.json
@@ -1,22 +1,12 @@
 {
+  "extends": "@genshin/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2023",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["node"],
-    "skipLibCheck": true,
-
     "moduleResolution": "bundler",
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["specs/**/*.ts", "playwright.config.ts"]
 }

--- a/tools/e2e/tsconfig.json
+++ b/tools/e2e/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "@genshin/tsconfig/base.json",
+  "extends": "@genshin/tsconfig/no-emit.json",
   "compilerOptions": {
     "target": "ES2023",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "noEmit": true
+    "types": ["node"]
   },
   "include": ["specs/**/*.ts", "playwright.config.ts"]
 }

--- a/tools/game-data-codegen/package.json
+++ b/tools/game-data-codegen/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",
+    "@genshin/tsconfig": "workspace:*",
     "@types/node": "25.9.5",
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "4.1.10",

--- a/tools/game-data-codegen/tsconfig.json
+++ b/tools/game-data-codegen/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "types": ["node"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"]
 }

--- a/tools/game-data-codegen/tsconfig.json
+++ b/tools/game-data-codegen/tsconfig.json
@@ -1,21 +1,9 @@
 {
+  "extends": "@genshin/tsconfig/library.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022"],
-    "types": ["node"],
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Closes #871

`@genshin/tsconfig` carries the strict baseline in `base.json`, with `library.json` (declaration emit, five consumers) and `no-emit.json` (three consumers) layered on it. Each workspace tsconfig extends one of the three and keeps only its path-relative options and platform axis. `tools/e2e` postdates the issue and is included.

## Gotchas

**The baseline is the union of what workspaces declared, not the intersection.** An intersection would have stayed too thin to stop workspaces re-declaring strictness flags, so `apps/api` and the libraries each pick up flags they were missing, `erasableSyntaxOnly` and `noUnusedLocals` among them. Nothing errored under the wider set.

**Emit is byte-identical except two `export {} from` shells** in `packages/domain/dist/index.js`, which `verbatimModuleSyntax` preserves for `export { type X } from`. Both targets already exist in `dist` with no top-level side effects, and `apps/api` emits the same shells today, so the source keeps the repo's inline `{ type X }` style.

**Three deleted settings only restated a compiler default** — `forceConsistentCasingInFileNames`, `useDefineForClassFields`, and the libraries' `exclude` — each checked against `tsc --all` on the 7.0.2 compiler. `esModuleInterop` also defaults to `true` now but stays pinned, because that default moved in the current major and the flag changes CommonJS interop emit.

**The five identical `tsconfig.build.json` files can't be shared, and it fails silently.** Hoisting their `exclude` resolves `src/**/*.test.ts` against `packages/tsconfig/`, where it matches nothing: the entry vanishes from the resolved config and domain's 11 test files rejoin the build, green the whole way.

**`apps/api`'s Dockerfile needs the manifest copy** because the builder stage runs `tsc` before `COPY packages`.
