### PR TITLE
fix(domain): reject calendar-invalid ISO timestamps

### DIFF
--- a/packages/domain/src/iso-timestamp.test.ts
+++ b/packages/domain/src/iso-timestamp.test.ts
@@ -50,6 +50,18 @@ describe('isISOTimestamp', () => {
     expect(isISOTimestamp('2024-13-01T00:00:00Z')).toBe(false);
   });
 
+  it('rejects a day the month does not have', () => {
+    expect(isISOTimestamp('2024-02-30T00:00:00Z')).toBe(false);
+  });
+
+  it('rejects a leap day in a non-leap year', () => {
+    expect(isISOTimestamp('2023-02-29T00:00:00Z')).toBe(false);
+  });
+
+  it('accepts a leap day in a leap year', () => {
+    expect(isISOTimestamp('2024-02-29T00:00:00Z')).toBe(true);
+  });
+
   it('rejects a random string', () => {
     expect(isISOTimestamp('not-a-timestamp')).toBe(false);
   });

--- a/packages/domain/src/iso-timestamp.ts
+++ b/packages/domain/src/iso-timestamp.ts
@@ -7,11 +7,29 @@ export type ISOTimestamp = string & { readonly [__brand]: 'ISOTimestamp' };
 
 // Structural check: ISO 8601 date-time with required time and offset.
 // Semantic check (e.g. month 13): delegated to Date.parse.
-const ISO_8601_DATE_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_8601_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 export function isISOTimestamp(value: unknown): value is ISOTimestamp {
+  if (typeof value !== 'string') return false;
+
+  const parts = ISO_8601_DATE_TIME.exec(value);
+  if (parts === null || Number.isNaN(Date.parse(value))) return false;
+
+  const year = Number(parts[1]);
+  const month = Number(parts[2]);
+  const day = Number(parts[3]);
+
+  // Date.parse rolls an impossible day forward (2024-02-30 lands in March)
+  // instead of failing, so the calendar date has to survive a UTC round-trip.
+  // setUTCFullYear rather than Date.UTC, which maps years 0-99 into the 1900s.
+  const roundTrip = new Date(0);
+  roundTrip.setUTCFullYear(year, month - 1, day);
+
   return (
-    typeof value === 'string' && ISO_8601_DATE_TIME.test(value) && !Number.isNaN(Date.parse(value))
+    roundTrip.getUTCFullYear() === year &&
+    roundTrip.getUTCMonth() === month - 1 &&
+    roundTrip.getUTCDate() === day
   );
 }
 

--- a/packages/domain/src/iso-timestamp.ts
+++ b/packages/domain/src/iso-timestamp.ts
@@ -10,9 +10,8 @@ export type ISOTimestamp = string & { readonly [__brand]: 'ISOTimestamp' };
 const ISO_8601_DATE_TIME = /^(\d{4}-\d{2}-\d{2})T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 // Date.parse bounds the day to 01-31, but a day the month does not have rolls
-// forward rather than failing — 2024-02-30 lands in March. Such a date is only
-// real if it survives a UTC round-trip unchanged. Built with setUTCFullYear
-// rather than Date.UTC, which maps years 0-99 into the 1900s.
+// forward instead of failing: 2024-02-30 becomes 1 March. Date.UTC would be
+// shorter but maps years 0-99 into the 1900s.
 function isRealCalendarDate(date: string): boolean {
   const [year, month, day] = date.split('-').map(Number);
 

--- a/packages/domain/src/iso-timestamp.ts
+++ b/packages/domain/src/iso-timestamp.ts
@@ -6,9 +6,21 @@ declare const __brand: unique symbol;
 export type ISOTimestamp = string & { readonly [__brand]: 'ISOTimestamp' };
 
 // Structural check: ISO 8601 date-time with required time and offset.
-// Semantic check (e.g. month 13): delegated to Date.parse.
-const ISO_8601_DATE_TIME =
-  /^(\d{4})-(\d{2})-(\d{2})T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+// Field ranges (month 13, hour 25, leap second): delegated to Date.parse.
+const ISO_8601_DATE_TIME = /^(\d{4}-\d{2}-\d{2})T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+// Date.parse bounds the day to 01-31, but a day the month does not have rolls
+// forward rather than failing — 2024-02-30 lands in March. Such a date is only
+// real if it survives a UTC round-trip unchanged. Built with setUTCFullYear
+// rather than Date.UTC, which maps years 0-99 into the 1900s.
+function isRealCalendarDate(date: string): boolean {
+  const [year, month, day] = date.split('-').map(Number);
+
+  const roundTrip = new Date(0);
+  roundTrip.setUTCFullYear(year, month - 1, day);
+
+  return roundTrip.toISOString().startsWith(date);
+}
 
 export function isISOTimestamp(value: unknown): value is ISOTimestamp {
   if (typeof value !== 'string') return false;
@@ -16,21 +28,7 @@ export function isISOTimestamp(value: unknown): value is ISOTimestamp {
   const parts = ISO_8601_DATE_TIME.exec(value);
   if (parts === null || Number.isNaN(Date.parse(value))) return false;
 
-  const year = Number(parts[1]);
-  const month = Number(parts[2]);
-  const day = Number(parts[3]);
-
-  // Date.parse rolls an impossible day forward (2024-02-30 lands in March)
-  // instead of failing, so the calendar date has to survive a UTC round-trip.
-  // setUTCFullYear rather than Date.UTC, which maps years 0-99 into the 1900s.
-  const roundTrip = new Date(0);
-  roundTrip.setUTCFullYear(year, month - 1, day);
-
-  return (
-    roundTrip.getUTCFullYear() === year &&
-    roundTrip.getUTCMonth() === month - 1 &&
-    roundTrip.getUTCDate() === day
-  );
+  return isRealCalendarDate(parts[1]);
 }
 
 export function nowTimestamp(): ISOTimestamp {


### PR DESCRIPTION
Closes #878

## Summary

`isISOTimestamp` accepted days that do not exist — `2024-02-30T00:00:00Z` returned `true`. `Date.parse` bounds the day to 01-31 but rolls a day the month does not have forward into the next month rather than failing, so the guard now requires the calendar date to survive a UTC round-trip. The check lives in its own `isRealCalendarDate`, leaving `isISOTimestamp` a two-step read: structure and field ranges, then calendar reality.

## Gotchas

- **Hand-rolled rather than delegated, deliberately** — Zod 4.4.3's `z.iso.datetime({ offset: true })` is an exact behavioural match and already ships in both apps, but `packages/domain` carries no runtime dependencies and Zod's placement there is the open decision in #946. Evidence recorded on that issue; this fix stays inside the existing boundary rather than settling it in passing.
- **`setUTCFullYear` on `new Date(0)`, not `Date.UTC`** — `Date.UTC` maps years 0-99 into the 1900s, so it would reject the four-digit years `0000`-`0099`. The roundabout construction is deliberate.
- **`Date.parse` is still load-bearing** — the round-trip only sees the date, so hour 25, minute/second 60, and out-of-range offsets still rest on the `Date.parse` guard. Dropping it would reopen those.
- **No stored data can trip the tighter check** — every timestamp the app writes comes from `toISOString()`, which never emits an impossible date. This closes the hole only for externally supplied or migrated values.

## Verification

- Brute-forced the refactored formulation against the original across every year/month/day combination in ten representative years — 4,620 inputs, zero divergences.
- Cross-checked the guard against Zod 4.4.3 over 18,480 inputs spanning years 0001-9999, months 00-13, days 00-32, and `Z`/offset/invalid-hour/leap-second suffixes — zero divergences.
