### PR TITLE
refactor!: replace ArtifactPlan.sets tuple with named set IDs

### DIFF
--- a/apps/api/schema-snapshots/teams/v2.json
+++ b/apps/api/schema-snapshots/teams/v2.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 2
+    },
+    "name": {
+      "type": "string"
+    },
+    "members": {
+      "maxItems": 4,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "characterId": {
+                "type": "string"
+              },
+              "weaponInstanceId": {
+                "type": "string"
+              },
+              "artifactPlan": {
+                "type": "object",
+                "properties": {
+                  "sands": {
+                    "type": "string"
+                  },
+                  "goblet": {
+                    "type": "string"
+                  },
+                  "circlet": {
+                    "type": "string"
+                  },
+                  "primarySetId": {
+                    "type": "string"
+                  },
+                  "secondarySetId": {
+                    "type": "string"
+                  },
+                  "priorityMinorAffixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "secondaryMinorAffixes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "characterId"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "description": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "name",
+    "members",
+    "createdAt",
+    "updatedAt"
+  ],
+  "additionalProperties": false
+}

--- a/apps/api/scripts/schema-registry.ts
+++ b/apps/api/scripts/schema-registry.ts
@@ -9,6 +9,7 @@ import { V1CharacterSchema } from '../src/repositories/characters/schemas/v1.js'
 import { CURRENT_VERSION as teamsCurrent } from '../src/repositories/teams/schemas/index.js';
 import { V0TeamSchema } from '../src/repositories/teams/schemas/v0.js';
 import { V1TeamSchema } from '../src/repositories/teams/schemas/v1.js';
+import { V2TeamSchema } from '../src/repositories/teams/schemas/v2.js';
 import { CURRENT_VERSION as weaponsCurrent } from '../src/repositories/weapons/schemas/index.js';
 import { V0WeaponSchema } from '../src/repositories/weapons/schemas/v0.js';
 import { V1WeaponSchema } from '../src/repositories/weapons/schemas/v1.js';
@@ -26,7 +27,7 @@ export const SCHEMA_REGISTRY: Record<string, RepositorySchemas> = {
     versions: [V0CharacterSchema, V1CharacterSchema],
     currentVersion: charactersCurrent,
   },
-  teams: { versions: [V0TeamSchema, V1TeamSchema], currentVersion: teamsCurrent },
+  teams: { versions: [V0TeamSchema, V1TeamSchema, V2TeamSchema], currentVersion: teamsCurrent },
   weapons: { versions: [V0WeaponSchema, V1WeaponSchema], currentVersion: weaponsCurrent },
 };
 

--- a/apps/api/src/profiles/alps/team/item-v1.ts
+++ b/apps/api/src/profiles/alps/team/item-v1.ts
@@ -78,10 +78,17 @@ export const teamItemV1 = {
                   },
                 },
                 {
-                  id: 'sets',
+                  id: 'primarySetId',
                   type: 'semantic',
                   doc: {
-                    value: '1-2 artifact set IDs from game data',
+                    value: 'Artifact set ID for a 4-piece bonus, or the first half of a 2+2 split',
+                  },
+                },
+                {
+                  id: 'secondarySetId',
+                  type: 'semantic',
+                  doc: {
+                    value: 'Artifact set ID for the second 2-piece of a 2+2 split',
                   },
                 },
                 {

--- a/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
+++ b/apps/api/src/profiles/json-schema/teams/put-request-v1.ts
@@ -70,12 +70,15 @@ export const teamPutRequestV1 = {
             minLength: 1,
             description: 'Desired main stat for Circlet of Logos',
           },
-          sets: {
-            type: 'array',
-            items: { type: 'string', minLength: 1 },
-            minItems: 1,
-            maxItems: 2,
-            description: '1-2 artifact set IDs from game data',
+          primarySetId: {
+            type: 'string',
+            minLength: 1,
+            description: 'Artifact set ID for a 4-piece bonus, or the first half of a 2+2 split',
+          },
+          secondarySetId: {
+            type: 'string',
+            minLength: 1,
+            description: 'Artifact set ID for the second 2-piece of a 2+2 split',
           },
           priorityMinorAffixes: {
             type: 'array',

--- a/apps/api/src/repositories/teams/document.test.ts
+++ b/apps/api/src/repositories/teams/document.test.ts
@@ -109,6 +109,64 @@ describe('fromDocument', () => {
     expect(team.members[0]?.artifactPlan?.priorityMinorAffixes).toEqual(['crit-rate']);
   });
 
+  it('migrates a two-set v1 artifact plan onto the named set fields', () => {
+    const team = fromDocument(
+      1,
+      makeV1Document({
+        members: [
+          {
+            characterId: 'columbina',
+            artifactPlan: {
+              sets: ['crimson-witch-of-flames', 'aubade-of-morningstar-and-moon'],
+            },
+          },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.primarySetId).toBe('crimson-witch-of-flames');
+    expect(team.members[0]?.artifactPlan?.secondarySetId).toBe('aubade-of-morningstar-and-moon');
+    expect(team.members[0]?.artifactPlan).not.toHaveProperty('sets');
+  });
+
+  it('migrates a single-set v1 artifact plan to a primary set alone', () => {
+    const team = fromDocument(
+      1,
+      makeV1Document({
+        members: [
+          { characterId: 'columbina', artifactPlan: { sets: ['crimson-witch-of-flames'] } },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.primarySetId).toBe('crimson-witch-of-flames');
+    expect(team.members[0]?.artifactPlan).not.toHaveProperty('secondarySetId');
+  });
+
+  it('drops v1 sets past the second rather than failing the read', () => {
+    const team = fromDocument(
+      1,
+      makeV1Document({
+        members: [
+          {
+            characterId: 'columbina',
+            artifactPlan: {
+              sets: ['crimson-witch-of-flames', 'aubade-of-morningstar-and-moon', 'obsidian-codex'],
+            },
+          },
+          null,
+          null,
+          null,
+        ],
+      }),
+    );
+    expect(team.members[0]?.artifactPlan?.secondarySetId).toBe('aubade-of-morningstar-and-moon');
+  });
+
   it('throws for too many members', () => {
     expect(() =>
       fromDocument(1, makeV1Document({ members: [null, null, null, null, null] })),

--- a/apps/api/src/repositories/teams/document.ts
+++ b/apps/api/src/repositories/teams/document.ts
@@ -15,14 +15,15 @@ import { parseDocument } from '@/repositories/schema-version.js';
 import {
   entity,
   CURRENT_VERSION,
+  type V2Team,
   type V1Team,
   type V0Team,
-  type V1Member,
+  type V2Member,
 } from './schemas/index.js';
 
-export { CURRENT_VERSION, type V1Team, type V0Team };
+export { CURRENT_VERSION, type V2Team, type V1Team, type V0Team };
 
-function memberFromDocument(m: V1Member): CollectionTeamMember {
+function memberFromDocument(m: V2Member): CollectionTeamMember {
   return {
     characterId: m.characterId,
     ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
@@ -30,7 +31,7 @@ function memberFromDocument(m: V1Member): CollectionTeamMember {
   } as CollectionTeamMember;
 }
 
-function memberToDocument(m: CollectionTeamMember): V1Member {
+function memberToDocument(m: CollectionTeamMember): V2Member {
   return {
     characterId: m.characterId,
     ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
@@ -58,7 +59,7 @@ export function fromDocument(slot: TeamSlot, raw: Record<string, unknown>): Coll
   return team;
 }
 
-export function toDocument(team: CollectionTeam): V1Team {
+export function toDocument(team: CollectionTeam): V2Team {
   return {
     schemaVersion: CURRENT_VERSION,
     name: team.name,

--- a/apps/api/src/repositories/teams/schemas/index.ts
+++ b/apps/api/src/repositories/teams/schemas/index.ts
@@ -7,16 +7,18 @@ import { documentVersion } from '@/repositories/schema-version.js';
 
 import { v0 } from './v0.js';
 import { v1 } from './v1.js';
+import { v2 } from './v2.js';
 
 export { type V0Team } from './v0.js';
-export { type V1Member } from './v1.js';
+export { type V1Team } from './v1.js';
+export { type V2Member } from './v2.js';
 
-export const CURRENT_VERSION = 1 as const;
+export const CURRENT_VERSION = 2 as const;
 
 export const entity = createVersionedEntity({
   latestVersion: CURRENT_VERSION,
-  versionMap: { 0: v0, 1: v1 },
+  versionMap: { 0: v0, 1: v1, 2: v2 },
   getVersion: documentVersion,
 });
 
-export type V1Team = InferredEntity<typeof entity>;
+export type V2Team = InferredEntity<typeof entity>;

--- a/apps/api/src/repositories/teams/schemas/v1.ts
+++ b/apps/api/src/repositories/teams/schemas/v1.ts
@@ -22,6 +22,7 @@ export const V1MemberSchema = z.object({
     .optional(),
 });
 
+export type V1Member = z.infer<typeof V1MemberSchema>;
 export type V1Team = z.infer<typeof V1TeamSchema>;
 
 export const V1TeamSchema = z.object({

--- a/apps/api/src/repositories/teams/schemas/v2.ts
+++ b/apps/api/src/repositories/teams/schemas/v2.ts
@@ -5,9 +5,9 @@ import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { defineVersion } from 'verzod';
 import { z } from 'zod';
 
-import { type V0Team } from './v0.js';
+import { type V1Team } from './v1.js';
 
-export const V1MemberSchema = z.object({
+export const V2MemberSchema = z.object({
   characterId: z.string(),
   weaponInstanceId: z.string().optional(),
   artifactPlan: z
@@ -15,31 +15,32 @@ export const V1MemberSchema = z.object({
       sands: z.string().optional(),
       goblet: z.string().optional(),
       circlet: z.string().optional(),
-      sets: z.array(z.string()).optional(),
+      primarySetId: z.string().optional(),
+      secondarySetId: z.string().optional(),
       priorityMinorAffixes: z.array(z.string()).optional(),
       secondaryMinorAffixes: z.array(z.string()).optional(),
     })
     .optional(),
 });
 
-export type V1Team = z.infer<typeof V1TeamSchema>;
+export type V2Member = z.infer<typeof V2MemberSchema>;
 
-export const V1TeamSchema = z.object({
-  schemaVersion: z.literal(1),
+export const V2TeamSchema = z.object({
+  schemaVersion: z.literal(2),
   name: z.string(),
-  members: z.array(z.union([z.null(), V1MemberSchema])).max(MAX_TEAM_MEMBERS),
+  members: z.array(z.union([z.null(), V2MemberSchema])).max(MAX_TEAM_MEMBERS),
   description: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
 
-export const v1 = defineVersion({
+export const v2 = defineVersion({
   initial: false,
-  schema: V1TeamSchema,
-  up: (old: V0Team): z.infer<typeof V1TeamSchema> => ({
-    schemaVersion: 1,
+  schema: V2TeamSchema,
+  up: (old: V1Team): z.infer<typeof V2TeamSchema> => ({
+    schemaVersion: 2,
     name: old.name,
-    members: old.members.map((m): z.infer<typeof V1MemberSchema> | null => {
+    members: old.members.map((m): z.infer<typeof V2MemberSchema> | null => {
       if (m === null) return null;
       if (!m.artifactPlan) {
         return {
@@ -47,16 +48,8 @@ export const v1 = defineVersion({
           ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
         };
       }
-      const {
-        primaryStats,
-        secondaryStats,
-        sands,
-        goblet,
-        circlet,
-        sets,
-        priorityMinorAffixes,
-        secondaryMinorAffixes,
-      } = m.artifactPlan;
+      const { sands, goblet, circlet, sets, priorityMinorAffixes, secondaryMinorAffixes } =
+        m.artifactPlan;
       return {
         characterId: m.characterId,
         ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
@@ -64,17 +57,13 @@ export const v1 = defineVersion({
           ...(sands !== undefined ? { sands } : {}),
           ...(goblet !== undefined ? { goblet } : {}),
           ...(circlet !== undefined ? { circlet } : {}),
-          ...(sets !== undefined ? { sets } : {}),
-          ...(primaryStats !== undefined
-            ? { priorityMinorAffixes: primaryStats }
-            : priorityMinorAffixes !== undefined
-              ? { priorityMinorAffixes }
-              : {}),
-          ...(secondaryStats !== undefined
-            ? { secondaryMinorAffixes: secondaryStats }
-            : secondaryMinorAffixes !== undefined
-              ? { secondaryMinorAffixes }
-              : {}),
+          // v1 typed `sets` as an unbounded array, so a hand-edited document can
+          // carry more than the two the domain ever accepted. Anything past the
+          // second entry is dropped rather than failing the read.
+          ...(sets?.[0] !== undefined ? { primarySetId: sets[0] } : {}),
+          ...(sets?.[1] !== undefined ? { secondarySetId: sets[1] } : {}),
+          ...(priorityMinorAffixes !== undefined ? { priorityMinorAffixes } : {}),
+          ...(secondaryMinorAffixes !== undefined ? { secondaryMinorAffixes } : {}),
         },
       };
     }),

--- a/apps/api/src/repositories/teams/schemas/v2.ts
+++ b/apps/api/src/repositories/teams/schemas/v2.ts
@@ -5,9 +5,9 @@ import { MAX_TEAM_MEMBERS } from '@genshin/domain';
 import { defineVersion } from 'verzod';
 import { z } from 'zod';
 
-import { type V1Team } from './v1.js';
+import { type V1Member, type V1Team } from './v1.js';
 
-export const V2MemberSchema = z.object({
+const V2MemberSchema = z.object({
   characterId: z.string(),
   weaponInstanceId: z.string().optional(),
   artifactPlan: z
@@ -34,41 +34,35 @@ export const V2TeamSchema = z.object({
   updatedAt: z.string(),
 });
 
+type V1ArtifactPlan = NonNullable<V1Member['artifactPlan']>;
+type V2ArtifactPlan = NonNullable<V2Member['artifactPlan']>;
+
+/** Splits `sets` across the named fields; every other field carries through. */
+function migrateArtifactPlan({ sets, ...carried }: V1ArtifactPlan): V2ArtifactPlan {
+  return {
+    ...carried,
+    // v1 typed `sets` as an unbounded array, so a hand-edited document can carry
+    // more than the two the domain ever accepted. Anything past the second entry
+    // is dropped rather than failing the read.
+    ...(sets?.[0] !== undefined ? { primarySetId: sets[0] } : {}),
+    ...(sets?.[1] !== undefined ? { secondarySetId: sets[1] } : {}),
+  };
+}
+
+function migrateMember(member: V1Member): V2Member {
+  const { artifactPlan, ...carried } = member;
+  return {
+    ...carried,
+    ...(artifactPlan !== undefined ? { artifactPlan: migrateArtifactPlan(artifactPlan) } : {}),
+  };
+}
+
 export const v2 = defineVersion({
   initial: false,
   schema: V2TeamSchema,
   up: (old: V1Team): z.infer<typeof V2TeamSchema> => ({
+    ...old,
     schemaVersion: 2,
-    name: old.name,
-    members: old.members.map((m): z.infer<typeof V2MemberSchema> | null => {
-      if (m === null) return null;
-      if (!m.artifactPlan) {
-        return {
-          characterId: m.characterId,
-          ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
-        };
-      }
-      const { sands, goblet, circlet, sets, priorityMinorAffixes, secondaryMinorAffixes } =
-        m.artifactPlan;
-      return {
-        characterId: m.characterId,
-        ...(m.weaponInstanceId !== undefined ? { weaponInstanceId: m.weaponInstanceId } : {}),
-        artifactPlan: {
-          ...(sands !== undefined ? { sands } : {}),
-          ...(goblet !== undefined ? { goblet } : {}),
-          ...(circlet !== undefined ? { circlet } : {}),
-          // v1 typed `sets` as an unbounded array, so a hand-edited document can
-          // carry more than the two the domain ever accepted. Anything past the
-          // second entry is dropped rather than failing the read.
-          ...(sets?.[0] !== undefined ? { primarySetId: sets[0] } : {}),
-          ...(sets?.[1] !== undefined ? { secondarySetId: sets[1] } : {}),
-          ...(priorityMinorAffixes !== undefined ? { priorityMinorAffixes } : {}),
-          ...(secondaryMinorAffixes !== undefined ? { secondaryMinorAffixes } : {}),
-        },
-      };
-    }),
-    ...(old.description !== undefined ? { description: old.description } : {}),
-    createdAt: old.createdAt,
-    updatedAt: old.updatedAt,
+    members: old.members.map((member) => (member === null ? null : migrateMember(member))),
   }),
 });

--- a/apps/api/src/repositories/teams/schemas/v2.ts
+++ b/apps/api/src/repositories/teams/schemas/v2.ts
@@ -37,13 +37,11 @@ export const V2TeamSchema = z.object({
 type V1ArtifactPlan = NonNullable<V1Member['artifactPlan']>;
 type V2ArtifactPlan = NonNullable<V2Member['artifactPlan']>;
 
-/** Splits `sets` across the named fields; every other field carries through. */
 function migrateArtifactPlan({ sets, ...carried }: V1ArtifactPlan): V2ArtifactPlan {
   return {
     ...carried,
-    // v1 typed `sets` as an unbounded array, so a hand-edited document can carry
-    // more than the two the domain ever accepted. Anything past the second entry
-    // is dropped rather than failing the read.
+    // Stored `sets` arrays are unbounded, so entries past the second are dropped
+    // rather than failing the read.
     ...(sets?.[0] !== undefined ? { primarySetId: sets[0] } : {}),
     ...(sets?.[1] !== undefined ? { secondarySetId: sets[1] } : {}),
   };

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -518,7 +518,7 @@ describe('Team routes', () => {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
                   circlet: 'CRIT DMG',
-                  sets: ['fake-set'],
+                  primarySetId: 'fake-set',
                   priorityMinorAffixes: ['CRIT Rate'],
                   secondaryMinorAffixes: ['ATK Percentage'],
                 },
@@ -546,7 +546,7 @@ describe('Team routes', () => {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
                   circlet: 'CRIT DMG',
-                  sets: ['crimson-witch-of-flames'],
+                  primarySetId: 'crimson-witch-of-flames',
                   priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
                   secondaryMinorAffixes: ['CRIT Rate', 'ATK Percentage'],
                 },
@@ -579,7 +579,7 @@ describe('Team routes', () => {
                   sands: 'HP Percentage',
                   goblet: 'Pyro DMG Bonus',
                   circlet: 'CRIT DMG',
-                  sets: ['crimson-witch-of-flames'],
+                  primarySetId: 'crimson-witch-of-flames',
                   priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
                   secondaryMinorAffixes: ['ATK Percentage', 'HP Percentage'],
                 },
@@ -622,7 +622,7 @@ describe('Team routes', () => {
         expect(res.status).toBe(201);
       });
 
-      it('accepts partial artifact plan with only sets', async () => {
+      it('accepts partial artifact plan with only a set ID', async () => {
         vi.mocked(Teams.save).mockResolvedValue({
           team: FAKE_TEAM,
           created: true,
@@ -635,7 +635,7 @@ describe('Team routes', () => {
                 characterId: 'hu-tao',
                 weaponInstanceId: 'uuid-1',
                 artifactPlan: {
-                  sets: ['crimson-witch-of-flames'],
+                  primarySetId: 'crimson-witch-of-flames',
                 },
               },
               { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },

--- a/apps/web/src/features/teams/artifact-planner/artifact-planner.tsx
+++ b/apps/web/src/features/teams/artifact-planner/artifact-planner.tsx
@@ -55,7 +55,11 @@ export function ArtifactPlanner({ plan, onChange }: ArtifactPlannerProps): JSX.E
           onChange={(value) => updatePlan({ circlet: value })}
         />
 
-        <SetConfiguration sets={plan?.sets} onChange={(sets) => updatePlan({ sets })} />
+        <SetConfiguration
+          primarySetId={plan?.primarySetId}
+          secondarySetId={plan?.secondarySetId}
+          onChange={updatePlan}
+        />
 
         <SubstatList
           label="Priority substats"

--- a/apps/web/src/features/teams/artifact-planner/set-configuration.tsx
+++ b/apps/web/src/features/teams/artifact-planner/set-configuration.tsx
@@ -7,34 +7,33 @@ import type { JSX } from 'react';
 
 import { ArtifactSetSearch } from './artifact-set-search';
 
+type SetFields = Pick<ArtifactPlan, 'primarySetId' | 'secondarySetId'>;
+
 export function SetConfiguration({
-  sets,
+  primarySetId,
+  secondarySetId,
   onChange,
 }: {
-  sets: ArtifactPlan['sets'] | undefined;
-  onChange: (sets: ArtifactPlan['sets'] | undefined) => void;
+  primarySetId: ArtifactPlan['primarySetId'];
+  secondarySetId: ArtifactPlan['secondarySetId'];
+  onChange: (fields: SetFields) => void;
 }): JSX.Element {
-  const handleFirstChange = (setId: ArtifactSet['id']) => {
-    if (sets?.length === 2) {
-      onChange([setId, sets[1]]);
-    } else {
-      onChange([setId]);
-    }
+  const handlePrimaryChange = (setId: ArtifactSet['id']) => {
+    onChange({ primarySetId: setId, secondarySetId });
   };
 
-  const handleSecondChange = (setId: ArtifactSet['id']) => {
-    if (sets === undefined) return;
-    onChange([sets[0], setId]);
+  const handleSecondaryChange = (setId: ArtifactSet['id']) => {
+    onChange({ primarySetId, secondarySetId: setId });
   };
 
-  const handleClearSecond = () => {
-    if (sets) {
-      onChange([sets[0]]);
-    }
+  // A second 2-piece has nothing to pair with once the primary is gone, so
+  // clearing the primary clears both.
+  const handleClearPrimary = () => {
+    onChange({ primarySetId: undefined, secondarySetId: undefined });
   };
 
-  const handleClearFirst = () => {
-    onChange(undefined);
+  const handleClearSecondary = () => {
+    onChange({ primarySetId, secondarySetId: undefined });
   };
 
   return (
@@ -43,17 +42,17 @@ export function SetConfiguration({
 
       <ArtifactSetSearch
         label="Search artifact set..."
-        value={sets?.[0]}
-        onChange={handleFirstChange}
-        onClear={sets?.[0] ? handleClearFirst : undefined}
+        value={primarySetId}
+        onChange={handlePrimaryChange}
+        onClear={primarySetId ? handleClearPrimary : undefined}
       />
 
-      {sets && sets.length >= 1 && (
+      {primarySetId && (
         <ArtifactSetSearch
           label="Optional second 2-piece set..."
-          value={sets?.[1]}
-          onChange={handleSecondChange}
-          onClear={sets?.[1] ? handleClearSecond : undefined}
+          value={secondarySetId}
+          onChange={handleSecondaryChange}
+          onClear={secondarySetId ? handleClearSecondary : undefined}
         />
       )}
     </div>

--- a/apps/web/src/features/teams/artifact-planner/set-configuration.tsx
+++ b/apps/web/src/features/teams/artifact-planner/set-configuration.tsx
@@ -18,23 +18,16 @@ export function SetConfiguration({
   secondarySetId: ArtifactPlan['secondarySetId'];
   onChange: (fields: SetFields) => void;
 }): JSX.Element {
-  const handlePrimaryChange = (setId: ArtifactSet['id']) => {
-    onChange({ primarySetId: setId, secondarySetId });
+  const update = (fields: Partial<SetFields>) => {
+    onChange({ primarySetId, secondarySetId, ...fields });
   };
 
-  const handleSecondaryChange = (setId: ArtifactSet['id']) => {
-    onChange({ primarySetId, secondarySetId: setId });
-  };
+  const handlePrimaryChange = (setId: ArtifactSet['id']) => update({ primarySetId: setId });
+  const handleSecondaryChange = (setId: ArtifactSet['id']) => update({ secondarySetId: setId });
+  const handleClearSecondary = () => update({ secondarySetId: undefined });
 
-  // A second 2-piece has nothing to pair with once the primary is gone, so
-  // clearing the primary clears both.
-  const handleClearPrimary = () => {
-    onChange({ primarySetId: undefined, secondarySetId: undefined });
-  };
-
-  const handleClearSecondary = () => {
-    onChange({ primarySetId, secondarySetId: undefined });
-  };
+  // A second 2-piece has nothing to pair with once the primary is gone.
+  const handleClearPrimary = () => update({ primarySetId: undefined, secondarySetId: undefined });
 
   return (
     <div className="space-y-2">

--- a/packages/domain/src/artifact/artifact-plan-validation.test.ts
+++ b/packages/domain/src/artifact/artifact-plan-validation.test.ts
@@ -16,7 +16,8 @@ describe('validateArtifactPlan', () => {
       sands: 'ATK Percentage',
       goblet: 'Pyro DMG Bonus',
       circlet: 'CRIT Rate',
-      sets: ['aubade-of-morningstar-and-moon'],
+      primarySetId: 'aubade-of-morningstar-and-moon',
+      secondarySetId: 'a-day-carved-from-rising-winds',
       priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
       secondaryMinorAffixes: ['ATK Percentage'],
     });
@@ -41,28 +42,24 @@ describe('validateArtifactPlan', () => {
     expect(issues.some((i) => i.path === 'circlet')).toBe(true);
   });
 
-  it('rejects zero sets', () => {
-    const issues = validateArtifactPlan({ sets: [] });
+  it('rejects an unknown primary artifact set ID', () => {
+    const issues = validateArtifactPlan({ primarySetId: 'nonexistent-set' });
     expect(issues.length).toBeGreaterThan(0);
-    expect(issues.some((i) => i.path === 'sets')).toBe(true);
+    expect(issues.some((i) => i.path === 'primarySetId')).toBe(true);
   });
 
-  it('rejects more than 2 sets', () => {
+  it('rejects an unknown secondary artifact set ID', () => {
     const issues = validateArtifactPlan({
-      sets: [
-        'aubade-of-morningstar-and-moon',
-        'a-day-carved-from-rising-winds',
-        'silken-moons-serenade',
-      ],
+      primarySetId: 'aubade-of-morningstar-and-moon',
+      secondarySetId: 'nonexistent-set',
     });
     expect(issues.length).toBeGreaterThan(0);
-    expect(issues.some((i) => i.path === 'sets')).toBe(true);
+    expect(issues.some((i) => i.path === 'secondarySetId')).toBe(true);
   });
 
-  it('rejects an unknown artifact set ID', () => {
-    const issues = validateArtifactPlan({ sets: ['nonexistent-set'] });
-    expect(issues.length).toBeGreaterThan(0);
-    expect(issues.some((i) => i.path === 'sets[0]')).toBe(true);
+  it('rejects a secondary artifact set without a primary set', () => {
+    const issues = validateArtifactPlan({ secondarySetId: 'aubade-of-morningstar-and-moon' });
+    expect(issues.some((i) => i.path === 'secondarySetId')).toBe(true);
   });
 
   it('rejects more than 3 priority minor affixes', () => {

--- a/packages/domain/src/artifact/artifact-plan-validation.ts
+++ b/packages/domain/src/artifact/artifact-plan-validation.ts
@@ -18,6 +18,8 @@ import {
 import type { ValidationIssue } from '@genshin/validation';
 import { issue } from '@genshin/validation';
 
+import { hasSecondarySetWithoutPrimary } from './artifact-plan.js';
+
 // Intentionally uses loose string types instead of ArtifactPlan's branded types
 // (SandsMainAffix, etc.). The validator's job is to check raw input *before* it
 // becomes a domain object. Accepting ArtifactPlan would make the call circular.
@@ -58,13 +60,12 @@ export function validateArtifactPlan(plan: {
     issues.push(issue(`Unknown artifact set: ${plan.primarySetId}`, 'primarySetId'));
   }
 
-  if (plan.secondarySetId !== undefined) {
-    if (plan.primarySetId === undefined) {
-      issues.push(issue('A secondary artifact set requires a primary set', 'secondarySetId'));
-    }
-    if (!getArtifactSetById(plan.secondarySetId)) {
-      issues.push(issue(`Unknown artifact set: ${plan.secondarySetId}`, 'secondarySetId'));
-    }
+  if (hasSecondarySetWithoutPrimary(plan)) {
+    issues.push(issue('A secondary artifact set requires a primary set', 'secondarySetId'));
+  }
+
+  if (plan.secondarySetId !== undefined && !getArtifactSetById(plan.secondarySetId)) {
+    issues.push(issue(`Unknown artifact set: ${plan.secondarySetId}`, 'secondarySetId'));
   }
 
   // Minor affixes ------------------------------------------------------

--- a/packages/domain/src/artifact/artifact-plan-validation.ts
+++ b/packages/domain/src/artifact/artifact-plan-validation.ts
@@ -27,7 +27,8 @@ export function validateArtifactPlan(plan: {
   sands?: string;
   goblet?: string;
   circlet?: string;
-  sets?: string[];
+  primarySetId?: string;
+  secondarySetId?: string;
   priorityMinorAffixes?: string[];
   secondaryMinorAffixes?: string[];
 }): ValidationIssue[] {
@@ -53,15 +54,16 @@ export function validateArtifactPlan(plan: {
   }
 
   // Sets ---------------------------------------------------------------
-  if (plan.sets !== undefined) {
-    if (plan.sets.length < 1 || plan.sets.length > 2) {
-      issues.push(issue('Artifact plan must have 1-2 sets', 'sets'));
-    } else {
-      for (const [i, setId] of plan.sets.entries()) {
-        if (!getArtifactSetById(setId)) {
-          issues.push(issue(`Unknown artifact set: ${setId}`, `sets[${i}]`));
-        }
-      }
+  if (plan.primarySetId !== undefined && !getArtifactSetById(plan.primarySetId)) {
+    issues.push(issue(`Unknown artifact set: ${plan.primarySetId}`, 'primarySetId'));
+  }
+
+  if (plan.secondarySetId !== undefined) {
+    if (plan.primarySetId === undefined) {
+      issues.push(issue('A secondary artifact set requires a primary set', 'secondarySetId'));
+    }
+    if (!getArtifactSetById(plan.secondarySetId)) {
+      issues.push(issue(`Unknown artifact set: ${plan.secondarySetId}`, 'secondarySetId'));
     }
   }
 

--- a/packages/domain/src/artifact/artifact-plan.test.ts
+++ b/packages/domain/src/artifact/artifact-plan.test.ts
@@ -24,8 +24,7 @@ describe('assertArtifactPlan', () => {
     expect(() => assertArtifactPlan({})).not.toThrow();
   });
 
-  // primarySetId is omitted separately: dropping it alone strands secondarySetId,
-  // which is its own rejection case below.
+  // primarySetId is absent from this list: dropping it alone strands secondarySetId.
   it.each([
     'sands',
     'goblet',

--- a/packages/domain/src/artifact/artifact-plan.test.ts
+++ b/packages/domain/src/artifact/artifact-plan.test.ts
@@ -9,7 +9,8 @@ const VALID_PLAN = {
   sands: 'ATK Percentage',
   goblet: 'Hydro DMG Bonus',
   circlet: 'CRIT Rate',
-  sets: ['aubade-of-morningstar-and-moon'],
+  primarySetId: 'aubade-of-morningstar-and-moon',
+  secondarySetId: 'a-day-carved-from-rising-winds',
   priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
   secondaryMinorAffixes: ['ATK Percentage'],
 };
@@ -23,13 +24,24 @@ describe('assertArtifactPlan', () => {
     expect(() => assertArtifactPlan({})).not.toThrow();
   });
 
-  it.each(['sands', 'goblet', 'circlet', 'sets', 'priorityMinorAffixes', 'secondaryMinorAffixes'])(
-    'accepts a plan omitting %s',
-    (field) => {
-      const { [field]: _omitted, ...rest } = VALID_PLAN as Record<string, unknown>;
-      expect(() => assertArtifactPlan(rest)).not.toThrow();
-    },
-  );
+  // primarySetId is omitted separately: dropping it alone strands secondarySetId,
+  // which is its own rejection case below.
+  it.each([
+    'sands',
+    'goblet',
+    'circlet',
+    'secondarySetId',
+    'priorityMinorAffixes',
+    'secondaryMinorAffixes',
+  ])('accepts a plan omitting %s', (field) => {
+    const { [field]: _omitted, ...rest } = VALID_PLAN as Record<string, unknown>;
+    expect(() => assertArtifactPlan(rest)).not.toThrow();
+  });
+
+  it('accepts a plan omitting both set IDs', () => {
+    const { primarySetId: _p, secondarySetId: _s, ...rest } = VALID_PLAN;
+    expect(() => assertArtifactPlan(rest)).not.toThrow();
+  });
 
   it('throws for a non-object', () => {
     expect(() => assertArtifactPlan('not-an-object')).toThrow(
@@ -47,27 +59,16 @@ describe('assertArtifactPlan', () => {
     );
   });
 
-  it('throws for sets that is not an array', () => {
-    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: 'one-set' })).toThrow(
-      /artifactPlan\.sets must be an array/,
+  it.each(['primarySetId', 'secondarySetId'])('throws for a non-string %s', (field) => {
+    expect(() => assertArtifactPlan({ ...VALID_PLAN, [field]: 42 })).toThrow(
+      new RegExp(`artifactPlan\\.${field} must be a string`),
     );
   });
 
-  it('throws for a non-string set entry', () => {
-    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: [42] })).toThrow(
-      /artifactPlan\.sets\[0\] must be a string/,
-    );
-  });
-
-  it('throws for an empty sets array', () => {
-    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: [] })).toThrow(
-      /artifactPlan\.sets must have between 1 and 2/,
-    );
-  });
-
-  it('throws for more than two sets', () => {
-    expect(() => assertArtifactPlan({ ...VALID_PLAN, sets: ['a', 'b', 'c'] })).toThrow(
-      /artifactPlan\.sets must have between 1 and 2/,
+  it('throws for a secondary set without a primary set', () => {
+    const { primarySetId: _omitted, ...rest } = VALID_PLAN;
+    expect(() => assertArtifactPlan(rest)).toThrow(
+      /artifactPlan\.secondarySetId requires artifactPlan\.primarySetId/,
     );
   });
 

--- a/packages/domain/src/artifact/artifact-plan.ts
+++ b/packages/domain/src/artifact/artifact-plan.ts
@@ -27,16 +27,16 @@ export interface ArtifactPlan {
   goblet?: GobletMainAffix;
   /** Desired main affix for Circlet of Logos */
   circlet?: CircletMainAffix;
-  /** 1–2 artifact set IDs from game-data */
-  sets?: [ArtifactSet['id']] | [ArtifactSet['id'], ArtifactSet['id']];
+  /** Primary artifact set: a 4-piece bonus, or the first half of a 2+2 split */
+  primarySetId?: ArtifactSet['id'];
+  /** Second 2-piece set of a 2+2 split; only meaningful alongside primarySetId */
+  secondarySetId?: ArtifactSet['id'];
   /** 0–3 priority minor affixes to prioritize */
   priorityMinorAffixes?: ArtifactMinorAffix[];
   /** 0–3 secondary minor affixes (must be disjoint from priorityMinorAffixes) */
   secondaryMinorAffixes?: ArtifactMinorAffix[];
 }
 
-const MIN_SETS = 1;
-const MAX_SETS = 2;
 const MIN_MINOR_AFFIXES = 0;
 const MAX_MINOR_AFFIXES = 3;
 
@@ -56,7 +56,13 @@ export function assertArtifactPlan(
   assertOptionalString(plan.sands, `${path}.sands`);
   assertOptionalString(plan.goblet, `${path}.goblet`);
   assertOptionalString(plan.circlet, `${path}.circlet`);
-  assertOptionalStringArray(plan.sets, `${path}.sets`, MIN_SETS, MAX_SETS);
+  assertOptionalString(plan.primarySetId, `${path}.primarySetId`);
+  assertOptionalString(plan.secondarySetId, `${path}.secondarySetId`);
+  // The retired `sets` tuple made a lone second set unrepresentable; two
+  // independent fields do not, so the pairing is asserted explicitly.
+  if (plan.secondarySetId !== undefined && plan.primarySetId === undefined) {
+    throw new TypeError(`${path}.secondarySetId requires ${path}.primarySetId`);
+  }
   assertOptionalStringArray(
     plan.priorityMinorAffixes,
     `${path}.priorityMinorAffixes`,

--- a/packages/domain/src/artifact/artifact-plan.ts
+++ b/packages/domain/src/artifact/artifact-plan.ts
@@ -41,6 +41,18 @@ const MIN_MINOR_AFFIXES = 0;
 const MAX_MINOR_AFFIXES = 3;
 
 /**
+ * A second 2-piece set has nothing to pair with on its own. The retired `sets`
+ * tuple made the state unrepresentable; two independent fields do not, so every
+ * boundary that accepts a plan has to reject it.
+ */
+export function hasSecondarySetWithoutPrimary(plan: {
+  primarySetId?: unknown;
+  secondarySetId?: unknown;
+}): boolean {
+  return plan.secondarySetId !== undefined && plan.primarySetId === undefined;
+}
+
+/**
  * Structural check only. Affix names and set IDs are validated against
  * game-data by `validateArtifactPlan`, which collects every problem instead of
  * throwing on the first.
@@ -58,9 +70,7 @@ export function assertArtifactPlan(
   assertOptionalString(plan.circlet, `${path}.circlet`);
   assertOptionalString(plan.primarySetId, `${path}.primarySetId`);
   assertOptionalString(plan.secondarySetId, `${path}.secondarySetId`);
-  // The retired `sets` tuple made a lone second set unrepresentable; two
-  // independent fields do not, so the pairing is asserted explicitly.
-  if (plan.secondarySetId !== undefined && plan.primarySetId === undefined) {
+  if (hasSecondarySetWithoutPrimary(plan)) {
     throw new TypeError(`${path}.secondarySetId requires ${path}.primarySetId`);
   }
   assertOptionalStringArray(

--- a/packages/domain/src/artifact/artifact-plan.ts
+++ b/packages/domain/src/artifact/artifact-plan.ts
@@ -40,11 +40,7 @@ export interface ArtifactPlan {
 const MIN_MINOR_AFFIXES = 0;
 const MAX_MINOR_AFFIXES = 3;
 
-/**
- * A second 2-piece set has nothing to pair with on its own. The retired `sets`
- * tuple made the state unrepresentable; two independent fields do not, so every
- * boundary that accepts a plan has to reject it.
- */
+/** A 2-piece set bonus needs a partner set, so a lone secondary is incoherent. */
 export function hasSecondarySetWithoutPrimary(plan: {
   primarySetId?: unknown;
   secondarySetId?: unknown;

--- a/packages/domain/src/assertions.ts
+++ b/packages/domain/src/assertions.ts
@@ -5,7 +5,7 @@
  * Field-level assertion primitives shared by the `assertCollection*` guards.
  *
  * Passing the path in is what lets a guard over a nested structure report the
- * position that failed, such as `CollectionTeam.members[0].artifactPlan.sets`,
+ * position that failed, such as `CollectionTeam.members[0].artifactPlan.sands`,
  * rather than the outermost type.
  */
 

--- a/packages/domain/src/representations/collection-json/teams.test.ts
+++ b/packages/domain/src/representations/collection-json/teams.test.ts
@@ -71,7 +71,8 @@ describe('team serialisation round-trip', () => {
             sands: 'ATK Percentage',
             goblet: 'Hydro DMG Bonus',
             circlet: 'CRIT Rate',
-            sets: ['aubade-of-morningstar-and-moon'],
+            primarySetId: 'aubade-of-morningstar-and-moon',
+            secondarySetId: 'a-day-carved-from-rising-winds',
             priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
             secondaryMinorAffixes: ['ATK Percentage'],
           },
@@ -92,7 +93,7 @@ describe('deserialiseTeam artifact plan validation', () => {
     sands: 'ATK Percentage',
     goblet: 'Hydro DMG Bonus',
     circlet: 'CRIT Rate',
-    sets: ['aubade-of-morningstar-and-moon'],
+    primarySetId: 'aubade-of-morningstar-and-moon',
     priorityMinorAffixes: ['CRIT Rate'],
     secondaryMinorAffixes: ['ATK Percentage'],
   };
@@ -121,14 +122,11 @@ describe('deserialiseTeam artifact plan validation', () => {
     expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sands must be a string/);
   });
 
-  it('rejects a set field that is not an array', () => {
-    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: 'aubade-of-morningstar-and-moon' });
-    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets must be an array/);
-  });
-
-  it('rejects a non-string element in sets', () => {
-    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: [42] });
-    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets\[0\] must be a string/);
+  it.each(['primarySetId', 'secondarySetId'])('rejects a non-string %s', (field) => {
+    const item = itemWithArtifactPlan({ ...VALID_PLAN, [field]: 42 });
+    expect(() => deserialiseTeam(item)).toThrow(
+      new RegExp(`artifactPlan\\.${field} must be a string`),
+    );
   });
 
   it('rejects a non-string element in a minor affix array', () => {
@@ -138,14 +136,13 @@ describe('deserialiseTeam artifact plan validation', () => {
     );
   });
 
-  it('rejects sets with fewer than 1 element', () => {
-    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: [] });
-    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets must have between 1 and 2/);
-  });
-
-  it('rejects sets with more than 2 elements', () => {
-    const item = itemWithArtifactPlan({ ...VALID_PLAN, sets: ['a', 'b', 'c'] });
-    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.sets must have between 1 and 2/);
+  it('rejects a secondary set without a primary set', () => {
+    const { primarySetId: _omitted, ...rest } = VALID_PLAN;
+    const item = itemWithArtifactPlan({
+      ...rest,
+      secondarySetId: 'a-day-carved-from-rising-winds',
+    });
+    expect(() => deserialiseTeam(item)).toThrow(/artifactPlan\.primarySetId must be a string/);
   });
 
   it('rejects a minor affix array with more than 3 elements', () => {
@@ -193,7 +190,7 @@ describe('deserialiseTeam member sanitisation', () => {
           sands: 'ATK Percentage',
           goblet: 'Hydro DMG Bonus',
           circlet: 'CRIT Rate',
-          sets: ['aubade-of-morningstar-and-moon'],
+          primarySetId: 'aubade-of-morningstar-and-moon',
           priorityMinorAffixes: [],
           secondaryMinorAffixes: [],
           injected: 'evil',

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -74,7 +74,7 @@ export function teamItemDocument(team: CollectionTeam, baseUrl: string): Collect
 const MIN_MINOR_AFFIXES = 0;
 const MAX_MINOR_AFFIXES = 3;
 
-/** Every field carried across the wire; anything else is dropped on receipt. */
+/** Allow-list for deserialisation: any other property on the wire is dropped. */
 const ARTIFACT_PLAN_FIELDS = [
   'sands',
   'goblet',
@@ -85,11 +85,7 @@ const ARTIFACT_PLAN_FIELDS = [
   'secondaryMinorAffixes',
 ] as const;
 
-/**
- * The wire format spells an absent list as `[]`, so unlike the domain guard
- * these arrays must be present.
- */
-function assertStringArray(value: unknown, path: string, min: number, max: number): void {
+function assertRequiredStringArray(value: unknown, path: string, min: number, max: number): void {
   if (value === undefined) {
     throw new TypeError(`${path} must be an array, got: undefined`);
   }
@@ -107,7 +103,12 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
   assertString(plan.primarySetId, 'artifactPlan.primarySetId');
   assertOptionalString(plan.secondarySetId, 'artifactPlan.secondarySetId');
   for (const field of ['priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
-    assertStringArray(plan[field], `artifactPlan.${field}`, MIN_MINOR_AFFIXES, MAX_MINOR_AFFIXES);
+    assertRequiredStringArray(
+      plan[field],
+      `artifactPlan.${field}`,
+      MIN_MINOR_AFFIXES,
+      MAX_MINOR_AFFIXES,
+    );
   }
   return Object.fromEntries(
     ARTIFACT_PLAN_FIELDS.filter((field) => plan[field] !== undefined).map((field) => [

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -22,6 +22,7 @@ import {
 } from '@genshin/collection-json';
 
 import type { ArtifactPlan } from '../../artifact/artifact-plan.js';
+import { assertOptionalString, assertOptionalStringArray, assertString } from '../../assertions.js';
 import type { CollectionTeamMember } from '../../team/collection-team-member.js';
 import type { CollectionTeam, CollectionTeamMembers } from '../../team/collection-team.js';
 import { assertCollectionTeam, MAX_TEAM_MEMBERS } from '../../team/collection-team.js';
@@ -70,40 +71,29 @@ export function teamItemDocument(team: CollectionTeam, baseUrl: string): Collect
   });
 }
 
-function assertString(plan: Record<string, unknown>, field: string): void {
-  if (typeof plan[field] !== 'string') {
-    throw new TypeError(
-      `artifactPlan.${field} must be a string, got: ${JSON.stringify(plan[field])}`,
-    );
-  }
-}
+const MIN_MINOR_AFFIXES = 0;
+const MAX_MINOR_AFFIXES = 3;
 
-function assertOptionalString(plan: Record<string, unknown>, field: string): void {
-  if (plan[field] !== undefined) assertString(plan, field);
-}
+/** Every field carried across the wire; anything else is dropped on receipt. */
+const ARTIFACT_PLAN_FIELDS = [
+  'sands',
+  'goblet',
+  'circlet',
+  'primarySetId',
+  'secondarySetId',
+  'priorityMinorAffixes',
+  'secondaryMinorAffixes',
+] as const;
 
-function assertStringArray(
-  plan: Record<string, unknown>,
-  field: string,
-  min: number,
-  max: number,
-): void {
-  const arr = plan[field];
-  if (!Array.isArray(arr)) {
-    throw new TypeError(`artifactPlan.${field} must be an array, got: ${JSON.stringify(arr)}`);
+/**
+ * The wire format spells an absent list as `[]`, so unlike the domain guard
+ * these arrays must be present.
+ */
+function assertStringArray(value: unknown, path: string, min: number, max: number): void {
+  if (value === undefined) {
+    throw new TypeError(`${path} must be an array, got: undefined`);
   }
-  if (arr.length < min || arr.length > max) {
-    throw new TypeError(
-      `artifactPlan.${field} must have between ${min} and ${max} elements, got: ${arr.length}`,
-    );
-  }
-  arr.forEach((element, index) => {
-    if (typeof element !== 'string') {
-      throw new TypeError(
-        `artifactPlan.${field}[${index}] must be a string, got: ${JSON.stringify(element)}`,
-      );
-    }
-  });
+  assertOptionalStringArray(value, path, min, max);
 }
 
 function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
@@ -111,24 +101,20 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
     throw new TypeError(`artifactPlan must be a non-null object, got: ${JSON.stringify(value)}`);
   }
   const plan = value as Record<string, unknown>;
-  assertString(plan, 'sands');
-  assertString(plan, 'goblet');
-  assertString(plan, 'circlet');
-  assertString(plan, 'primarySetId');
-  assertOptionalString(plan, 'secondarySetId');
-  assertStringArray(plan, 'priorityMinorAffixes', 0, 3);
-  assertStringArray(plan, 'secondaryMinorAffixes', 0, 3);
-  return {
-    sands: plan.sands as ArtifactPlan['sands'],
-    goblet: plan.goblet as ArtifactPlan['goblet'],
-    circlet: plan.circlet as ArtifactPlan['circlet'],
-    primarySetId: plan.primarySetId as ArtifactPlan['primarySetId'],
-    ...(plan.secondarySetId !== undefined
-      ? { secondarySetId: plan.secondarySetId as ArtifactPlan['secondarySetId'] }
-      : {}),
-    priorityMinorAffixes: plan.priorityMinorAffixes as ArtifactPlan['priorityMinorAffixes'],
-    secondaryMinorAffixes: plan.secondaryMinorAffixes as ArtifactPlan['secondaryMinorAffixes'],
-  };
+  assertString(plan.sands, 'artifactPlan.sands');
+  assertString(plan.goblet, 'artifactPlan.goblet');
+  assertString(plan.circlet, 'artifactPlan.circlet');
+  assertString(plan.primarySetId, 'artifactPlan.primarySetId');
+  assertOptionalString(plan.secondarySetId, 'artifactPlan.secondarySetId');
+  for (const field of ['priorityMinorAffixes', 'secondaryMinorAffixes'] as const) {
+    assertStringArray(plan[field], `artifactPlan.${field}`, MIN_MINOR_AFFIXES, MAX_MINOR_AFFIXES);
+  }
+  return Object.fromEntries(
+    ARTIFACT_PLAN_FIELDS.filter((field) => plan[field] !== undefined).map((field) => [
+      field,
+      plan[field],
+    ]),
+  ) as ArtifactPlan;
 }
 
 function deserialiseCollectionTeamMember(value: unknown, index: number): CollectionTeamMember {

--- a/packages/domain/src/representations/collection-json/teams.ts
+++ b/packages/domain/src/representations/collection-json/teams.ts
@@ -78,6 +78,10 @@ function assertString(plan: Record<string, unknown>, field: string): void {
   }
 }
 
+function assertOptionalString(plan: Record<string, unknown>, field: string): void {
+  if (plan[field] !== undefined) assertString(plan, field);
+}
+
 function assertStringArray(
   plan: Record<string, unknown>,
   field: string,
@@ -110,14 +114,18 @@ function deserialiseArtifactPlan(value: unknown): ArtifactPlan {
   assertString(plan, 'sands');
   assertString(plan, 'goblet');
   assertString(plan, 'circlet');
-  assertStringArray(plan, 'sets', 1, 2);
+  assertString(plan, 'primarySetId');
+  assertOptionalString(plan, 'secondarySetId');
   assertStringArray(plan, 'priorityMinorAffixes', 0, 3);
   assertStringArray(plan, 'secondaryMinorAffixes', 0, 3);
   return {
     sands: plan.sands as ArtifactPlan['sands'],
     goblet: plan.goblet as ArtifactPlan['goblet'],
     circlet: plan.circlet as ArtifactPlan['circlet'],
-    sets: plan.sets as ArtifactPlan['sets'],
+    primarySetId: plan.primarySetId as ArtifactPlan['primarySetId'],
+    ...(plan.secondarySetId !== undefined
+      ? { secondarySetId: plan.secondarySetId as ArtifactPlan['secondarySetId'] }
+      : {}),
     priorityMinorAffixes: plan.priorityMinorAffixes as ArtifactPlan['priorityMinorAffixes'],
     secondaryMinorAffixes: plan.secondaryMinorAffixes as ArtifactPlan['secondaryMinorAffixes'],
   };

--- a/packages/domain/src/team/collection-team.test.ts
+++ b/packages/domain/src/team/collection-team.test.ts
@@ -36,7 +36,7 @@ const VALID_PLAN = {
   sands: 'ATK Percentage',
   goblet: 'Hydro DMG Bonus',
   circlet: 'CRIT Rate',
-  sets: ['aubade-of-morningstar-and-moon'],
+  primarySetId: 'aubade-of-morningstar-and-moon',
   priorityMinorAffixes: ['CRIT Rate', 'CRIT DMG'],
   secondaryMinorAffixes: ['ATK Percentage'],
 };
@@ -224,9 +224,9 @@ describe('assertCollectionTeam', () => {
   it('throws for a malformed artifact plan on a later member', () => {
     expect(() =>
       assertCollectionTeam(
-        teamWithMember({ characterId: 'durin', artifactPlan: { sets: 'not-an-array' } }, 2),
+        teamWithMember({ characterId: 'durin', artifactPlan: { primarySetId: 42 } }, 2),
       ),
-    ).toThrow(/members\[2\]\.artifactPlan\.sets must be an array/);
+    ).toThrow(/members\[2\]\.artifactPlan\.primarySetId must be a string/);
   });
 
   it('throws for invalid createdAt', () => {


### PR DESCRIPTION
Closes #601

## Summary

An artifact plan names its two set slots — `primarySetId` and `secondarySetId` — instead of packing them into a `sets` faux-tuple. The `[0]`/`[1]` indexing and `.length` branching are gone from the domain type, its validators, the Collection+JSON wire format, Firestore storage, the request and ALPS profiles, and the planner UI.

## Gotchas

- **Storage gets a v2, not the in-place v1 edit the issue scoped.** Dropping `sets` from v1 narrows it and `check-schema-compat.ts` rejects that, so `teams/schemas/v2.ts` carries a v1→v2 migration. That file is where to spend review attention.
- **The migration truncates.** v1 typed `sets` as an unbounded array, so a document holding three or more sets loses everything past the second rather than failing the read.
- **The JSON-Schema and ALPS profiles are edited in place, not versioned.** No compatibility gate covers them, nothing ships before 1.0.0, and the transition machinery is unbuilt (#920).
- **`turbo run lint` fails on `teams/index.integration.test.ts:109`.** Pre-existing from #1318, untouched here; ESLint runs in neither pre-commit nor CI (#888).