### PR TITLE
test(api): drop the duplicated team save suite

### DIFF
--- a/apps/api/src/repositories/teams/index.integration.test.ts
+++ b/apps/api/src/repositories/teams/index.integration.test.ts
@@ -106,30 +106,6 @@ describe('get', () => {
   });
 });
 
-describe('save', () => {
-  it('reports the first save as a creation and later ones as updates', async () => {
-    const userId = newUserId();
-
-    const first = await save(userId, SLOT, { name: TEAM_NAME });
-    const second = await save(userId, SLOT, { name: TEAM_NAME });
-
-    expect(first.created).toBe(true);
-    expect(second.created).toBe(false);
-  });
-
-  it('merges a later save into the team already stored', async () => {
-    const userId = newUserId();
-    await save(userId, SLOT, { name: TEAM_NAME, description: 'Melt the shield first' });
-
-    await save(userId, SLOT, { name: 'Renamed' });
-
-    expect(await get(userId, SLOT)).toMatchObject({
-      name: 'Renamed',
-      description: 'Melt the shield first',
-    });
-  });
-});
-
 describe('remove', () => {
   it('leaves nothing to get', async () => {
     const { userId } = await userWithTeam({ name: TEAM_NAME });


### PR DESCRIPTION
Develop has failed ESLint since #1318 with `vitest/no-identical-title`, which turns every lockfile-touching Renovate PR's Verify toolchain check red. #1318 branched before #1317 landed, so its merge re-added a second top-level `describe('save')` in the teams integration suite. This deletes it.

## Gotchas

- **Both re-added cases were already covered, so nothing moved.** `reports the first save as a creation and later ones as updates` is name-for-name identical to the case at line 43; `merges a later save into the team already stored` is a subset of `leaves the fields an update omits as they were`, which asserts the same name-changed/description-preserved pair plus `members` and `createdAt`. The integration run still puts `repositories/teams/index.ts` at 100% statements, branches, functions and lines.
- **The break reached develop because the Devcontainer job is path-gated.** ESLint runs nowhere else — not pre-commit, not `ci.yml` — and the gate is `.devcontainer/**`, `scripts/install-reuse.sh`, `.github/workflows/devcontainer.yml`, `package.json`, `pnpm-lock.yaml`. #1318 touched none of them, so the error surfaced four days later on #1357 rather than on the PR that introduced it. #888 tracks closing that gap; this PR only clears the current red.
- **Open Renovate PRs stay red until each rebases.** A base-branch change fires no `pull_request` event and a re-run replays the recorded merge SHA, so #1357, #1360, #1361, #1362, #1353, #1350 and #1348 keep the failing check until Renovate rebases them on its own.
- **The check this fixes will not run on this PR, or on the merge.** The same path gate covers the `push` trigger, and these files are a `.ts` test. Verified locally instead with the job's own command — `pnpm lint && pnpm typecheck && pnpm knip && pnpm reuse:check` — all four clean. Verify toolchain goes green on the next Renovate lockfile PR.
