### PR TITLE
chore(vale): lint AI instruction files mechanically only

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,11 +1,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<!-- vale Microsoft.Headings = NO -->
-
 # GitHub Copilot instructions for genshin.dungeon.studio
-
-<!-- vale Microsoft.Headings = YES -->
 
 AI decision rules. Human contribution guidance lives in
 [`CONTRIBUTING.md`](../CONTRIBUTING.md) and

--- a/.vale.ini
+++ b/.vale.ini
@@ -26,7 +26,7 @@ Google.WordList = NO
 
 alex.ProfanityUnlikely = NO
 
-# AI instruction files get mechanical checks only. BasedOnStyles replaces the
-# inherited list rather than extending it, so naming Vale drops the rest.
+# AI instruction files: spelling and terminology, no voice rules. BasedOnStyles
+# replaces the inherited list rather than extending it, so no opt-outs needed.
 [{CLAUDE.md,.github/copilot-instructions.md,.claude/commands/*.md}]
 BasedOnStyles = Vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -25,3 +25,10 @@ Google.WordList = NO
 # Google.Latin stays enabled: no Microsoft equivalent exists.
 
 alex.ProfanityUnlikely = NO
+
+# AI instruction files get mechanical checks only. Voice rules tune prose for
+# human readers, so they contort machine instructions without making an agent
+# follow them any better. BasedOnStyles replaces the inherited list rather than
+# extending it, leaving Vale.Spelling, Vale.Terms, and the Project vocabulary.
+[{CLAUDE.md,.github/copilot-instructions.md,.claude/commands/*.md}]
+BasedOnStyles = Vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -26,9 +26,7 @@ Google.WordList = NO
 
 alex.ProfanityUnlikely = NO
 
-# AI instruction files get mechanical checks only. Voice rules tune prose for
-# human readers, so they contort machine instructions without making an agent
-# follow them any better. BasedOnStyles replaces the inherited list rather than
-# extending it, leaving Vale.Spelling, Vale.Terms, and the Project vocabulary.
+# AI instruction files get mechanical checks only. BasedOnStyles replaces the
+# inherited list rather than extending it, so naming Vale drops the rest.
 [{CLAUDE.md,.github/copilot-instructions.md,.claude/commands/*.md}]
 BasedOnStyles = Vale


### PR DESCRIPTION
Closes #895

AI instruction files were linted against a human-facing voice bar --- sentence-case headings, forced contractions, no-space em-dashes, parenthesis avoidance, inclusive language --- that tunes prose for human readers without making an agent follow an instruction any better. A scoped Vale section keeps the mechanical checks and drops the rest, taking those files from 12 warnings and 70 suggestions to zero.

## Gotchas

- **The issue's scope moved.** `#895` named `.github/copilot/`, which a1ede2d (#1197) deleted when it folded eleven prompt files into `.github/copilot-instructions.md`. This targets the corpus as it stands: `.claude/commands/*.md`, `.github/copilot-instructions.md`, and `CLAUDE.md`. The last of those is a deliberate addition --- it existed when #895 was filed and went unnamed, but it is the archetypal machine-audience file and was the noisiest of the set.
- **`BasedOnStyles` replaces, everything else merges.** A later path-scoped section layers onto `[*.md]` rather than superseding it, so the `Google.* = NO` lines still apply --- but redefining `BasedOnStyles` swaps the list wholesale. Naming `Vale` alone is what leaves `Vale.Spelling`, `Vale.Terms`, and the Project vocabulary live while dropping Microsoft, Google, and alex. Verified against a scratch config, since a section that merged instead would have silently kept every voice rule.
- **The criterion, not the deny list.** #895 enumerates eight rules to disable. Several that actually fire are missing from it (`Microsoft.HeadingAcronyms`, `Microsoft.Vocab`, `Microsoft.Acronyms`, `Microsoft.SentenceLength`, `Google.Colons`), and any such list rots as the upstream packages add rules. One `BasedOnStyles` line states the rule instead.
- **One workaround removed.** `copilot-instructions.md` carried a `<!-- vale Microsoft.Headings = NO -->` toggle pair around its title, hand-written to dodge the rule this change scopes away. It comes out here rather than lingering as dead config.
