### PR TITLE
docs: point code quality at the pre-commit config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,6 @@ pnpm dev
 > [Configure Firestore credentials](docs/how-tos/configure-firestore-credentials.md)
 > for setup instructions.
 
-### Quality checks overview
-
-Pre-commit enforces formatting, linting, documentation, and hygiene checks on every commit and on pull requests. If checks fail, fix the issues—[`.pre-commit-config.yaml`](.pre-commit-config.yaml) names the tool behind each one.
-
 ### What your pull request has to pass
 
 - Every pre-commit hook. Run `pre-commit install` once, and the same hooks run on each commit that CI runs over the whole tree—so a clean commit is a clean build. The first commit afterward builds each hook's environment and can take several minutes. `pre-commit run --all-files` reproduces CI exactly.
@@ -100,7 +96,7 @@ Broken external URLs are the one exception: a weekly run files them as a GitHub 
 
 ## Code quality
 
-Pre-commit runs the formatting, linting, and hygiene checks. [`.pre-commit-config.yaml`](.pre-commit-config.yaml) is the source of truth for which ones. Two of them enforce conventions you can't read off the tool:
+Pre-commit runs the formatting, linting, documentation, and hygiene checks. [`.pre-commit-config.yaml`](.pre-commit-config.yaml) is the source of truth for which ones. Two of them enforce conventions you can't read off the tool:
 
 - Dependency versions stay exact: `package.json` dependencies carry no `^` or `~` ranges. Run `pnpm exec syncpack fix` to pin offenders.
 - Every source file carries an SPDX license header—see [Add SPDX headers](docs/how-tos/add-spdx-headers.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ pnpm dev
 
 ### Quality checks overview
 
-Pre-commit enforces formatting, linting, documentation, and hygiene checks on every commit and on pull requests. If checks fail, fix the issues—see [Code quality](#code-quality) for the tools involved.
+Pre-commit enforces formatting, linting, documentation, and hygiene checks on every commit and on pull requests. If checks fail, fix the issues—[`.pre-commit-config.yaml`](.pre-commit-config.yaml) names the tool behind each one.
 
 ### What your pull request has to pass
 
@@ -100,15 +100,10 @@ Broken external URLs are the one exception: a weekly run files them as a GitHub 
 
 ## Code quality
 
-Pre-commit hooks automatically enforce key checks, including:
+Pre-commit runs the formatting, linting, and hygiene checks. [`.pre-commit-config.yaml`](.pre-commit-config.yaml) is the source of truth for which ones. Two of them enforce conventions you can't read off the tool:
 
-- **Prettier** - Code formatting
-- **ESLint** - JavaScript/TypeScript linting with automatic fixes when possible
-- CSS linting with Tailwind directives
-- Documentation and config linting for Markdown, YAML, and prose
-- Safety and repository hygiene checks for merge conflict markers, large files, trailing whitespace, line endings, and YAML/JSON validation
-- Exact dependency versions via [syncpack](https://jamiemason.github.io/syncpack/): `package.json` dependencies stay pinned with no `^` or `~` ranges. Run `pnpm exec syncpack fix` to pin offenders
-- SPDX license headers via [REUSE](https://reuse.software/): every source file needs one—see [Add SPDX headers](docs/how-tos/add-spdx-headers.md)
+- Dependency versions stay exact: `package.json` dependencies carry no `^` or `~` ranges. Run `pnpm exec syncpack fix` to pin offenders.
+- Every source file carries an SPDX license header—see [Add SPDX headers](docs/how-tos/add-spdx-headers.md).
 
 Pull requests must pass type checks in [ci.yml](.github/workflows/ci.yml). Run type checks locally before committing when your change affects TypeScript code:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,9 @@ Broken external URLs are the one exception: a weekly run files them as a GitHub 
 
 ## Code quality
 
-Pre-commit runs the formatting, linting, documentation, and hygiene checks. [`.pre-commit-config.yaml`](.pre-commit-config.yaml) is the source of truth for which ones. Two of them enforce conventions you can't read off the tool:
+[`.pre-commit-config.yaml`](.pre-commit-config.yaml) is the source of truth for which checks run. Two of them enforce project rules:
 
-- Dependency versions stay exact: `package.json` dependencies carry no `^` or `~` ranges. Run `pnpm exec syncpack fix` to pin offenders.
+- `package.json` dependencies stay pinned exactly, with no `^` or `~` ranges. Run `pnpm exec syncpack fix` to pin offenders.
 - Every source file carries an SPDX license header—see [Add SPDX headers](docs/how-tos/add-spdx-headers.md).
 
 Pull requests must pass type checks in [ci.yml](.github/workflows/ci.yml). Run type checks locally before committing when your change affects TypeScript code:


### PR DESCRIPTION
Closes #908

The "Code quality" section enumerated Prettier, ESLint, CSS linting, doc/config linting, and the hygiene checks — duplicating both the "Quality checks overview" paragraph above it and `.pre-commit-config.yaml`. It now opens with the config as the source of truth, and each fact about the checks has one home: "What your pull request has to pass" says when they run, "Code quality" says which tools run and what rules they enforce.

## Gotchas

**"Quality checks overview" is gone, not just trimmed.** Dropping the enumeration turned that paragraph's cross-reference (*see [Code quality] for the tools involved*) into a copy of what "Code quality" says — same claim, same link, forty lines apart. Its one remaining sentence was already stated, and stated better, by the first bullet of "What your pull request has to pass". Nothing in the repo linked to either anchor.

**No category summary replaces the list.** "Formatting, linting, documentation, and hygiene checks" reads as a safe abstraction but is a smaller enumeration with the same drift, and an inaccurate one — no room for the security scanners, the unused-code analysis, or the file-naming check. The config pointer stands alone.

**Two bullets survive the trim.** Exact dependency pinning (no `^`/`~`) and SPDX headers stay because each states a project rule a contributor can't infer from seeing `syncpack` or `reuse` in the hook list.

**The issue's "keep the Quality gate ownership runner map" no longer applies.** That section left `CONTRIBUTING.md` in #949; the runner map lives in `docs/reference/workflow-conventions.md`, already linked from "What your pull request has to pass".
