### PR TITLE
test: share the domain test-object builders across apps

### DIFF
--- a/apps/api/src/repositories/characters/merge.test.ts
+++ b/apps/api/src/repositories/characters/merge.test.ts
@@ -11,7 +11,7 @@ import { nextCharacter } from './merge.js';
 const CHARACTER = CHARACTER_ROSTER[0];
 const NOW = '2026-01-02T00:00:00.000Z' as ISOTimestamp;
 
-const stored = makeCharacter(CHARACTER.id, 1);
+const stored = makeCharacter(CHARACTER.id, { constellationLevel: 1 });
 
 describe('nextCharacter', () => {
   it('dates a character nothing ever collected to the save', () => {

--- a/apps/api/src/repositories/characters/merge.test.ts
+++ b/apps/api/src/repositories/characters/merge.test.ts
@@ -1,22 +1,17 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionCharacter, ISOTimestamp } from '@genshin/domain';
+import type { ISOTimestamp } from '@genshin/domain';
+import { makeCharacter } from '@genshin/domain/testing';
 import { CHARACTER_ROSTER } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
 import { nextCharacter } from './merge.js';
 
 const CHARACTER = CHARACTER_ROSTER[0];
-const CREATED_AT = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
 const NOW = '2026-01-02T00:00:00.000Z' as ISOTimestamp;
 
-const stored = {
-  characterId: CHARACTER.id,
-  constellationLevel: 1,
-  createdAt: CREATED_AT,
-  updatedAt: CREATED_AT,
-} satisfies CollectionCharacter;
+const stored = makeCharacter(CHARACTER.id, 1);
 
 describe('nextCharacter', () => {
   it('dates a character nothing ever collected to the save', () => {
@@ -24,6 +19,6 @@ describe('nextCharacter', () => {
   });
 
   it('keeps the createdAt of a character already collected', () => {
-    expect(nextCharacter(CHARACTER.id, 4, stored, NOW).createdAt).toBe(CREATED_AT);
+    expect(nextCharacter(CHARACTER.id, 4, stored, NOW).createdAt).toBe(stored.createdAt);
   });
 });

--- a/apps/api/src/repositories/teams/merge.test.ts
+++ b/apps/api/src/repositories/teams/merge.test.ts
@@ -1,22 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionTeam, ISOTimestamp, TeamSlot } from '@genshin/domain';
+import type { ISOTimestamp, TeamSlot } from '@genshin/domain';
+import { makeTeam } from '@genshin/domain/testing';
 import { describe, expect, it } from 'vitest';
 
 import { nextTeam } from './merge.js';
 
 const SLOT: TeamSlot = 1;
-const CREATED_AT = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
 const NOW = '2026-01-02T00:00:00.000Z' as ISOTimestamp;
 
-const stored = {
-  slot: SLOT,
-  name: 'Vaporise',
-  members: [null, null, null, null],
-  createdAt: CREATED_AT,
-  updatedAt: CREATED_AT,
-} satisfies CollectionTeam;
+const stored = makeTeam(SLOT, { name: 'Vaporise' });
 
 describe('nextTeam', () => {
   it('names a slot nothing ever saved after its number', () => {
@@ -31,11 +25,11 @@ describe('nextTeam', () => {
   });
 
   it('keeps the createdAt of a team already stored', () => {
-    expect(nextTeam(SLOT, { name: 'Renamed' }, stored, NOW).createdAt).toBe(CREATED_AT);
+    expect(nextTeam(SLOT, { name: 'Renamed' }, stored, NOW).createdAt).toBe(stored.createdAt);
   });
 
   it('keeps the description a later save leaves out', () => {
-    const existing = { ...stored, description: 'Melt the shield first' } satisfies CollectionTeam;
+    const existing = { ...stored, description: 'Melt the shield first' };
 
     expect(nextTeam(SLOT, { name: 'Renamed' }, existing, NOW).description).toBe(
       'Melt the shield first',
@@ -43,7 +37,7 @@ describe('nextTeam', () => {
   });
 
   it('replaces the description a later save supplies', () => {
-    const existing = { ...stored, description: 'Melt the shield first' } satisfies CollectionTeam;
+    const existing = { ...stored, description: 'Melt the shield first' };
 
     expect(nextTeam(SLOT, { description: 'Freeze instead' }, existing, NOW).description).toBe(
       'Freeze instead',
@@ -51,7 +45,7 @@ describe('nextTeam', () => {
   });
 
   it('keeps an empty description a save supplies rather than the stored one', () => {
-    const existing = { ...stored, description: 'Melt the shield first' } satisfies CollectionTeam;
+    const existing = { ...stored, description: 'Melt the shield first' };
 
     expect(nextTeam(SLOT, { description: '' }, existing, NOW).description).toBe('');
   });

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -29,7 +29,7 @@ vi.mock('@genshin/game-data', () => ({
   getCharacterById: vi.fn(),
 }));
 
-const FAKE_CHARACTER = makeCharacter('albedo', 2);
+const FAKE_CHARACTER = makeCharacter('albedo', { constellationLevel: 2 });
 
 const EXPECTED_CONTENT_TYPE = toMediaTypeString(
   { mediaType: COLLECTION_JSON, profile: characterItemV1 },

--- a/apps/api/src/routes/characters.test.ts
+++ b/apps/api/src/routes/characters.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
-import type { CollectionCharacter } from '@genshin/domain';
 import { MAX_CONSTELLATION_LEVEL, MIN_CONSTELLATION_LEVEL } from '@genshin/domain';
+import { makeCharacter } from '@genshin/domain/testing';
 import { getCharacterById } from '@genshin/game-data';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -29,12 +29,7 @@ vi.mock('@genshin/game-data', () => ({
   getCharacterById: vi.fn(),
 }));
 
-const FAKE_CHARACTER: CollectionCharacter = {
-  characterId: 'albedo',
-  constellationLevel: 2,
-  createdAt: '2026-01-01T00:00:00.000Z' as CollectionCharacter['createdAt'],
-  updatedAt: '2026-03-13T00:00:00.000Z' as CollectionCharacter['updatedAt'],
-};
+const FAKE_CHARACTER = makeCharacter('albedo', 2);
 
 const EXPECTED_CONTENT_TYPE = toMediaTypeString(
   { mediaType: COLLECTION_JSON, profile: characterItemV1 },

--- a/apps/api/src/routes/teams.test.ts
+++ b/apps/api/src/routes/teams.test.ts
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
-import type {
-  CollectionCharacter,
-  CollectionTeam,
-  CollectionTeamMember,
-  CollectionWeapon,
-} from '@genshin/domain';
+import type { CollectionTeam, CollectionTeamMember } from '@genshin/domain';
+import { makeCharacter, makeTeam, makeWeapon } from '@genshin/domain/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { app } from '@/app.js';
@@ -42,26 +38,16 @@ function soloMembers(member: CollectionTeamMember): CollectionTeam['members'] {
   return [member, null, null, null];
 }
 
-const FAKE_TEAM: CollectionTeam = {
-  slot: 1,
-  name: 'Team 1',
+const FAKE_TEAM = makeTeam(1, {
   members: [
     { characterId: 'hu-tao', weaponInstanceId: 'uuid-1' },
     { characterId: 'xingqiu', weaponInstanceId: 'uuid-2' },
     { characterId: 'zhongli', weaponInstanceId: 'uuid-3' },
     { characterId: 'albedo', weaponInstanceId: 'uuid-4' },
   ],
-  createdAt: '2026-01-01T00:00:00.000Z' as CollectionTeam['createdAt'],
-  updatedAt: '2026-03-13T00:00:00.000Z' as CollectionTeam['updatedAt'],
-};
+});
 
-const FAKE_EMPTY_TEAM: CollectionTeam = {
-  slot: 2,
-  name: 'Team 2',
-  members: [null, null, null, null],
-  createdAt: '2026-01-01T00:00:00.000Z' as CollectionTeam['createdAt'],
-  updatedAt: '2026-03-13T00:00:00.000Z' as CollectionTeam['updatedAt'],
-};
+const FAKE_EMPTY_TEAM = makeTeam(2);
 
 const EXPECTED_CONTENT_TYPE = toMediaTypeString(
   { mediaType: COLLECTION_JSON, profile: teamItemV1 },
@@ -69,22 +55,11 @@ const EXPECTED_CONTENT_TYPE = toMediaTypeString(
 );
 
 function mockCharacterOwned() {
-  vi.mocked(Characters.get).mockResolvedValue({
-    characterId: 'hu-tao',
-    constellationLevel: 0,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-  } as CollectionCharacter);
+  vi.mocked(Characters.get).mockResolvedValue(makeCharacter('hu-tao'));
 }
 
 function mockWeaponOwned() {
-  vi.mocked(Weapons.get).mockResolvedValue({
-    weaponInstanceId: 'uuid-1',
-    weaponId: 'staff-of-homa',
-    refinementLevel: 1,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-  } as CollectionWeapon);
+  vi.mocked(Weapons.get).mockResolvedValue(makeWeapon('uuid-1', 'staff-of-homa'));
 }
 
 describe('Team routes', () => {

--- a/apps/api/src/routes/weapons.test.ts
+++ b/apps/api/src/routes/weapons.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { COLLECTION_JSON, type CollectionDocument } from '@genshin/collection-json';
-import type { CollectionWeapon } from '@genshin/domain';
 import { MAX_REFINEMENT_LEVEL, MIN_REFINEMENT_LEVEL } from '@genshin/domain';
+import { makeWeapon } from '@genshin/domain/testing';
 import { getWeaponById } from '@genshin/game-data';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -30,20 +30,14 @@ vi.mock('@genshin/game-data', () => ({
   getWeaponById: vi.fn(),
 }));
 
-const FAKE_WEAPON: CollectionWeapon = {
-  weaponInstanceId: 'instance-uuid-1',
-  weaponId: 'mistsplitter-reforged',
-  refinementLevel: 1,
-  createdAt: '2026-01-01T00:00:00.000Z' as CollectionWeapon['createdAt'],
-  updatedAt: '2026-03-13T00:00:00.000Z' as CollectionWeapon['updatedAt'],
-};
+const FAKE_WEAPON = makeWeapon('instance-uuid-1', 'mistsplitter-reforged');
 
 const FAKE_WEAPON_ITEM_DATA = [
-  { name: 'weaponInstanceId', value: 'instance-uuid-1' },
-  { name: 'weaponId', value: 'mistsplitter-reforged' },
-  { name: 'refinementLevel', value: 1 },
-  { name: 'createdAt', value: '2026-01-01T00:00:00.000Z' },
-  { name: 'updatedAt', value: '2026-03-13T00:00:00.000Z' },
+  { name: 'weaponInstanceId', value: FAKE_WEAPON.weaponInstanceId },
+  { name: 'weaponId', value: FAKE_WEAPON.weaponId },
+  { name: 'refinementLevel', value: FAKE_WEAPON.refinementLevel },
+  { name: 'createdAt', value: FAKE_WEAPON.createdAt },
+  { name: 'updatedAt', value: FAKE_WEAPON.updatedAt },
 ];
 
 const EXPECTED_CONTENT_TYPE = toMediaTypeString(

--- a/apps/web/src/features/collection/characters/use-character-collection-api.test.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-api.test.ts
@@ -24,7 +24,9 @@ describe('useCharacterCollectionQuery', () => {
   it('returns the deserialised characters keyed by id', async () => {
     server.use(
       http.get('http://localhost:8080/characters', () =>
-        HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 2)])),
+        HttpResponse.json(
+          charactersDocument([makeCharacter(CHARACTER, { constellationLevel: 2 })]),
+        ),
       ),
     );
 
@@ -45,7 +47,9 @@ describe('useAddCharacterMutation', () => {
     server.use(
       http.put('http://localhost:8080/characters/skirk', async ({ request }) => {
         putBody = await request.json();
-        return HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 0)]));
+        return HttpResponse.json(
+          charactersDocument([makeCharacter(CHARACTER, { constellationLevel: 0 })]),
+        );
       }),
     );
 
@@ -75,7 +79,9 @@ describe('useAddCharacterMutation', () => {
         return HttpResponse.json(charactersDocument([]));
       }),
       http.put('http://localhost:8080/characters/skirk', () =>
-        HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 0)])),
+        HttpResponse.json(
+          charactersDocument([makeCharacter(CHARACTER, { constellationLevel: 0 })]),
+        ),
       ),
     );
 
@@ -104,7 +110,9 @@ describe('useSetConstellationLevelMutation', () => {
     server.use(
       http.put('http://localhost:8080/characters/skirk', async ({ request }) => {
         putBody = await request.json();
-        return HttpResponse.json(charactersDocument([makeCharacter(CHARACTER, 4)]));
+        return HttpResponse.json(
+          charactersDocument([makeCharacter(CHARACTER, { constellationLevel: 4 })]),
+        );
       }),
     );
 

--- a/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
@@ -114,8 +114,8 @@ describe('mergeCollections', () => {
   });
 
   it('keeps the higher constellation level on conflict', () => {
-    const local = { amber: makeCharacter('amber', 3) };
-    const server = { amber: makeCharacter('amber', 1) };
+    const local = { amber: makeCharacter('amber', { constellationLevel: 3 }) };
+    const server = { amber: makeCharacter('amber', { constellationLevel: 1 }) };
 
     const merged = mergeCollections(local, server);
 
@@ -123,8 +123,8 @@ describe('mergeCollections', () => {
   });
 
   it('keeps server value when server constellation is higher', () => {
-    const local = { amber: makeCharacter('amber', 1) };
-    const server = { amber: makeCharacter('amber', 5) };
+    const local = { amber: makeCharacter('amber', { constellationLevel: 1 }) };
+    const server = { amber: makeCharacter('amber', { constellationLevel: 5 }) };
 
     const merged = mergeCollections(local, server);
 
@@ -132,7 +132,7 @@ describe('mergeCollections', () => {
   });
 
   it('returns server collection when local is empty', () => {
-    const server = { amber: makeCharacter('amber', 2) };
+    const server = { amber: makeCharacter('amber', { constellationLevel: 2 }) };
 
     const merged = mergeCollections({}, server);
 

--- a/apps/web/src/features/collection/characters/use-character-collection.test.tsx
+++ b/apps/web/src/features/collection/characters/use-character-collection.test.tsx
@@ -39,7 +39,9 @@ describe('useCollection merge-on-first-login', () => {
       http.get('http://localhost:8080/characters', () => HttpResponse.json(charactersDocument([]))),
       http.put('http://localhost:8080/characters/skirk', async ({ request }) => {
         putBodies.push(await request.json());
-        return HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)]));
+        return HttpResponse.json(
+          charactersDocument([makeCharacter(SKIRK, { constellationLevel: 3 })]),
+        );
       }),
     );
 
@@ -65,7 +67,9 @@ describe('useCollection merge-on-first-login', () => {
       }),
       http.put('http://localhost:8080/characters/skirk', () => {
         putCount += 1;
-        return HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)]));
+        return HttpResponse.json(
+          charactersDocument([makeCharacter(SKIRK, { constellationLevel: 3 })]),
+        );
       }),
     );
 
@@ -89,7 +93,7 @@ describe('useCollection merge-on-first-login', () => {
     server.use(
       http.get('http://localhost:8080/characters', () => HttpResponse.json(serverCharacters)),
       http.put('http://localhost:8080/characters/skirk', () =>
-        HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)])),
+        HttpResponse.json(charactersDocument([makeCharacter(SKIRK, { constellationLevel: 3 })])),
       ),
     );
 
@@ -110,7 +114,7 @@ describe('useCollection merge-on-first-login', () => {
     await waitFor(() => expect(result.current.getCharacter(SKIRK)).toBeDefined());
 
     // A second account signs in.
-    serverCharacters = charactersDocument([makeCharacter(ESCOFFIER, 2)]);
+    serverCharacters = charactersDocument([makeCharacter(ESCOFFIER, { constellationLevel: 2 })]);
     authUser = null;
     rerender();
     await waitFor(() => expect(result.current.getCharacter(SKIRK)).toBeUndefined());
@@ -127,7 +131,7 @@ describe('useCollection mutations', () => {
   it('restores a removed character when the delete fails', async () => {
     server.use(
       http.get('http://localhost:8080/characters', () =>
-        HttpResponse.json(charactersDocument([makeCharacter(SKIRK, 3)])),
+        HttpResponse.json(charactersDocument([makeCharacter(SKIRK, { constellationLevel: 3 })])),
       ),
       http.delete(
         'http://localhost:8080/characters/skirk',

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-api.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-api.test.ts
@@ -25,7 +25,9 @@ describe('useWeaponCollectionQuery', () => {
   it('returns the deserialised weapons keyed by instance id', async () => {
     server.use(
       http.get('http://localhost:8080/weapons', () =>
-        HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 3)])),
+        HttpResponse.json(
+          weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 3 })]),
+        ),
       ),
     );
 
@@ -46,7 +48,9 @@ describe('useAddWeaponMutation', () => {
     server.use(
       http.post('http://localhost:8080/weapons', async ({ request }) => {
         postBody = await request.json();
-        return HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]));
+        return HttpResponse.json(
+          weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 })]),
+        );
       }),
     );
 
@@ -71,7 +75,9 @@ describe('useAddWeaponMutation', () => {
         return HttpResponse.json(weaponsDocument([]));
       }),
       http.post('http://localhost:8080/weapons', () =>
-        HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
+        HttpResponse.json(
+          weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 })]),
+        ),
       ),
     );
 
@@ -97,7 +103,9 @@ describe('useSetRefinementLevelMutation', () => {
     server.use(
       http.patch('http://localhost:8080/weapons/weapon-instance-1', async ({ request }) => {
         patchBody = await request.json();
-        return HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 5)]));
+        return HttpResponse.json(
+          weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 5 })]),
+        );
       }),
     );
 

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-store.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-store.test.ts
@@ -9,8 +9,8 @@ import { makeWeapon } from '@/test/fixtures';
 
 import { useWeaponCollectionStore } from './use-weapon-collection-store';
 
-// Two distinct weapons, so a filtered read has something to leave out. Taken
-// from game data, so a roster change cannot strand the suite.
+// Two weapons from game data, so a filtered read has something to leave out
+// and a roster change cannot strand the suite.
 const [WEAPON, OTHER_WEAPON] = WEAPON_ROSTER;
 
 function storedWeapon(weaponInstanceId: CollectionWeaponId): CollectionWeapon | undefined {

--- a/apps/web/src/features/collection/weapons/use-weapon-collection-store.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection-store.test.ts
@@ -1,25 +1,17 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionWeapon, CollectionWeaponId, ISOTimestamp } from '@genshin/domain';
-import type { Weapon } from '@genshin/game-data';
+import type { CollectionWeapon, CollectionWeaponId } from '@genshin/domain';
+import { WEAPON_ROSTER } from '@genshin/game-data';
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import { makeWeapon } from '@/test/fixtures';
 
 import { useWeaponCollectionStore } from './use-weapon-collection-store';
 
-function makeWeapon(
-  weaponInstanceId: string,
-  weaponId: string,
-  refinementLevel = 1,
-): CollectionWeapon {
-  return {
-    weaponInstanceId,
-    weaponId: weaponId as Weapon['id'],
-    refinementLevel,
-    createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-    updatedAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-  };
-}
+// Two distinct weapons, so a filtered read has something to leave out. Taken
+// from game data, so a roster change cannot strand the suite.
+const [WEAPON, OTHER_WEAPON] = WEAPON_ROSTER;
 
 function storedWeapon(weaponInstanceId: CollectionWeaponId): CollectionWeapon | undefined {
   return useWeaponCollectionStore.getState().weapons[weaponInstanceId];
@@ -32,7 +24,7 @@ describe('useWeaponCollectionStore', () => {
 
   describe('addWeapon', () => {
     it('adds a weapon to the collection', () => {
-      const weapon = makeWeapon('inst-1', 'sword-1');
+      const weapon = makeWeapon('inst-1', WEAPON.id);
       useWeaponCollectionStore.getState().addWeapon(weapon);
 
       expect(storedWeapon('inst-1')).toEqual(weapon);
@@ -41,7 +33,7 @@ describe('useWeaponCollectionStore', () => {
 
   describe('removeWeapon', () => {
     it('removes a weapon by instance id', () => {
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', WEAPON.id));
       useWeaponCollectionStore.getState().removeWeapon('inst-1');
 
       expect(storedWeapon('inst-1')).toBeUndefined();
@@ -50,14 +42,14 @@ describe('useWeaponCollectionStore', () => {
 
   describe('setRefinementLevel', () => {
     it('updates the refinement level', () => {
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', WEAPON.id));
       useWeaponCollectionStore.getState().setRefinementLevel('inst-1', 3);
 
       expect(storedWeapon('inst-1')?.refinementLevel).toBe(3);
     });
 
     it('ignores invalid refinement levels', () => {
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', WEAPON.id));
       useWeaponCollectionStore.getState().setRefinementLevel('inst-1', 0);
       useWeaponCollectionStore.getState().setRefinementLevel('inst-1', 6);
 
@@ -73,21 +65,17 @@ describe('useWeaponCollectionStore', () => {
 
   describe('getWeaponsByWeaponId', () => {
     it('returns all instances of a specific weapon', () => {
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-2', 'sword-1'));
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-3', 'bow-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', WEAPON.id));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-2', WEAPON.id));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-3', OTHER_WEAPON.id));
 
-      const swords = useWeaponCollectionStore
-        .getState()
-        .getWeaponsByWeaponId('sword-1' as Weapon['id']);
+      const instances = useWeaponCollectionStore.getState().getWeaponsByWeaponId(WEAPON.id);
 
-      expect(swords).toHaveLength(2);
+      expect(instances).toHaveLength(2);
     });
 
     it('returns empty array when no instances exist', () => {
-      const result = useWeaponCollectionStore
-        .getState()
-        .getWeaponsByWeaponId('missing' as Weapon['id']);
+      const result = useWeaponCollectionStore.getState().getWeaponsByWeaponId(OTHER_WEAPON.id);
 
       expect(result).toEqual([]);
     });
@@ -95,10 +83,10 @@ describe('useWeaponCollectionStore', () => {
 
   describe('setWeapons', () => {
     it('replaces the entire collection', () => {
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', WEAPON.id));
 
       const newWeapons = {
-        'inst-2': makeWeapon('inst-2', 'bow-1'),
+        'inst-2': makeWeapon('inst-2', OTHER_WEAPON.id),
       };
       useWeaponCollectionStore.getState().setWeapons(newWeapons);
 
@@ -109,8 +97,8 @@ describe('useWeaponCollectionStore', () => {
 
   describe('clearWeapons', () => {
     it('empties the collection', () => {
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', 'sword-1'));
-      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-2', 'bow-1'));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-1', WEAPON.id));
+      useWeaponCollectionStore.getState().addWeapon(makeWeapon('inst-2', OTHER_WEAPON.id));
       useWeaponCollectionStore.getState().clearWeapons();
 
       expect(Object.keys(useWeaponCollectionStore.getState().weapons)).toHaveLength(0);

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.test.ts
@@ -39,7 +39,9 @@ describe('useWeaponCollection', () => {
       server.use(
         http.get('http://localhost:8080/weapons', () => HttpResponse.json(serverWeapons)),
         http.post('http://localhost:8080/weapons', () => {
-          serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
+          serverWeapons = weaponsDocument([
+            makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 }),
+          ]);
           return HttpResponse.json(serverWeapons);
         }),
       );
@@ -57,10 +59,14 @@ describe('useWeaponCollection', () => {
     it('creates another instance even when the weapon is already owned', async () => {
       server.use(
         http.get('http://localhost:8080/weapons', () =>
-          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
+          HttpResponse.json(
+            weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 })]),
+          ),
         ),
         http.post('http://localhost:8080/weapons', () =>
-          HttpResponse.json(weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, 1)])),
+          HttpResponse.json(
+            weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 })]),
+          ),
         ),
       );
 
@@ -84,7 +90,9 @@ describe('useWeaponCollection', () => {
         http.get('http://localhost:8080/weapons', () => HttpResponse.json(serverWeapons)),
         http.post('http://localhost:8080/weapons', () => {
           posts += 1;
-          serverWeapons = weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)]);
+          serverWeapons = weaponsDocument([
+            makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 }),
+          ]);
           return HttpResponse.json(serverWeapons);
         }),
       );
@@ -106,11 +114,15 @@ describe('useWeaponCollection', () => {
       let posts = 0;
       server.use(
         http.get('http://localhost:8080/weapons', () =>
-          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 1)])),
+          HttpResponse.json(
+            weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 })]),
+          ),
         ),
         http.post('http://localhost:8080/weapons', () => {
           posts += 1;
-          return HttpResponse.json(weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, 1)]));
+          return HttpResponse.json(
+            weaponsDocument([makeWeapon(SECOND_INSTANCE_ID, WEAPON_ID, { refinementLevel: 1 })]),
+          );
         }),
       );
 
@@ -129,7 +141,9 @@ describe('useWeaponCollection', () => {
     it('restores a removed weapon when the delete fails', async () => {
       server.use(
         http.get('http://localhost:8080/weapons', () =>
-          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
+          HttpResponse.json(
+            weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 2 })]),
+          ),
         ),
         http.delete(
           'http://localhost:8080/weapons/weapon-instance-1',
@@ -155,7 +169,9 @@ describe('useWeaponCollection', () => {
     it('reverts a refinement change when the update fails', async () => {
       server.use(
         http.get('http://localhost:8080/weapons', () =>
-          HttpResponse.json(weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, 2)])),
+          HttpResponse.json(
+            weaponsDocument([makeWeapon(INSTANCE_ID, WEAPON_ID, { refinementLevel: 2 })]),
+          ),
         ),
         http.patch(
           'http://localhost:8080/weapons/weapon-instance-1',

--- a/apps/web/src/features/teams/character-pool.test.tsx
+++ b/apps/web/src/features/teams/character-pool.test.tsx
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { ISOTimestamp } from '@genshin/domain';
 import type { Character, WeaponType } from '@genshin/game-data';
 import { CHARACTER_ROSTER } from '@genshin/game-data';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CharacterCollection } from '@/features/collection/characters/use-character-collection-store';
+import { makeCharacter } from '@/test/fixtures';
 
 import { CharacterPool } from './character-pool';
 import { useTeamStore } from './use-team-store';
@@ -23,17 +23,7 @@ const BOW_USER = characterWielding('Bow');
 const CLAYMORE_USER = characterWielding('Claymore');
 
 function owned(...characters: Character[]): CharacterCollection {
-  return Object.fromEntries(
-    characters.map((c) => [
-      c.id,
-      {
-        characterId: c.id,
-        constellationLevel: 0,
-        createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-        updatedAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-      },
-    ]),
-  );
+  return Object.fromEntries(characters.map((c) => [c.id, makeCharacter(c.id)]));
 }
 
 describe('CharacterPool', () => {

--- a/apps/web/src/features/teams/use-team-store.test.ts
+++ b/apps/web/src/features/teams/use-team-store.test.ts
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionTeam, CollectionWeaponId, ISOTimestamp, TeamSlot } from '@genshin/domain';
+import type { CollectionWeaponId, TeamSlot } from '@genshin/domain';
 import { initialTeams } from '@genshin/domain';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeTeam } from '@/test/fixtures';
 
 import { useTeamStore } from './use-team-store';
 
@@ -280,13 +282,10 @@ describe('useTeamStore', () => {
 
   describe('setTeam', () => {
     it('replaces a single team', () => {
-      const custom: CollectionTeam = {
-        slot: 3,
+      const custom = makeTeam(3, {
         name: 'Freeze',
         members: [{ characterId: 'ganyu' }, null, null, null],
-        createdAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-        updatedAt: '2026-01-01T00:00:00.000Z' as ISOTimestamp,
-      };
+      });
       useTeamStore.getState().setTeam(3, custom);
 
       expect(useTeamStore.getState().teams[3]).toEqual(custom);

--- a/apps/web/src/pages/teams-page.test.tsx
+++ b/apps/web/src/pages/teams-page.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { CollectionWeaponId, ISOTimestamp } from '@genshin/domain';
+import type { CollectionWeaponId } from '@genshin/domain';
 import type { Character, Weapon, WeaponType } from '@genshin/game-data';
 import { CHARACTER_ROSTER, WEAPON_ROSTER } from '@genshin/game-data';
 import { act, configure, render, screen, within } from '@testing-library/react';
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { useCollectionStore } from '@/features/collection/characters/use-character-collection-store';
 import { useWeaponCollectionStore } from '@/features/collection/weapons/use-weapon-collection-store';
 import { useTeamStore } from '@/features/teams/use-team-store';
+import { makeCharacter, makeWeapon } from '@/test/fixtures';
 import { createWrapper } from '@/test/render';
 
 import { TeamsPage } from './teams-page';
@@ -41,8 +42,6 @@ const BOW_USER = characterWielding('Bow');
 const CLAYMORE_INSTANCE = 'claymore-instance' as CollectionWeaponId;
 const BOW_INSTANCE = 'bow-instance' as CollectionWeaponId;
 
-const TIMESTAMP = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
-
 function renderTeamsPage() {
   const view = render(
     <MemoryRouter>
@@ -53,34 +52,14 @@ function renderTeamsPage() {
 
   // Seeded after mount: the hooks clear their stores on finding no signed-in user.
   act(() => {
-    useCollectionStore.getState().replaceCharacters(
-      Object.fromEntries(
-        [CLAYMORE_USER, BOW_USER].map((c) => [
-          c.id,
-          {
-            characterId: c.id,
-            constellationLevel: 0,
-            createdAt: TIMESTAMP,
-            updatedAt: TIMESTAMP,
-          },
-        ]),
-      ),
-    );
+    useCollectionStore
+      .getState()
+      .replaceCharacters(
+        Object.fromEntries([CLAYMORE_USER, BOW_USER].map((c) => [c.id, makeCharacter(c.id)])),
+      );
     useWeaponCollectionStore.getState().setWeapons({
-      [CLAYMORE_INSTANCE]: {
-        weaponInstanceId: CLAYMORE_INSTANCE,
-        weaponId: CLAYMORE.id,
-        refinementLevel: 1,
-        createdAt: TIMESTAMP,
-        updatedAt: TIMESTAMP,
-      },
-      [BOW_INSTANCE]: {
-        weaponInstanceId: BOW_INSTANCE,
-        weaponId: BOW_WEAPON.id,
-        refinementLevel: 1,
-        createdAt: TIMESTAMP,
-        updatedAt: TIMESTAMP,
-      },
+      [CLAYMORE_INSTANCE]: makeWeapon(CLAYMORE_INSTANCE, CLAYMORE.id),
+      [BOW_INSTANCE]: makeWeapon(BOW_INSTANCE, BOW_WEAPON.id),
     });
   });
 

--- a/apps/web/src/test/fixtures.ts
+++ b/apps/web/src/test/fixtures.ts
@@ -1,86 +1,23 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { buildCollection, type CollectionDocument } from '@genshin/collection-json';
-import type {
-  CharacterId,
-  CollectionCharacter,
-  CollectionTeam,
-  CollectionWeapon,
-  ConstellationLevel,
-  ISOTimestamp,
-  TeamSlot,
-} from '@genshin/domain';
-import {
-  characterCollectionHref,
-  createEmptyTeam,
-  serialiseCharacter,
-  serialiseTeam,
-  serialiseWeapon,
-  teamCollectionHref,
-  weaponCollectionHref,
-} from '@genshin/domain';
-import type { WeaponId } from '@genshin/game-data';
+import type { CollectionDocument } from '@genshin/collection-json';
+import type { CollectionCharacter, CollectionTeam, CollectionWeapon } from '@genshin/domain';
+import * as testing from '@genshin/domain/testing';
+
+export { makeCharacter, makeTeam, makeWeapon } from '@genshin/domain/testing';
 
 // Origin the API client resolves relative paths against (see vitest.config.ts).
 const API_BASE_URL = 'http://localhost:8080';
 
-const FIXED_TIMESTAMP = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
-
-// Domain-object builders.
-export function makeCharacter(
-  id: CharacterId,
-  constellationLevel: ConstellationLevel = 0,
-): CollectionCharacter {
-  return {
-    characterId: id,
-    constellationLevel,
-    createdAt: FIXED_TIMESTAMP,
-    updatedAt: FIXED_TIMESTAMP,
-  };
-}
-
-export function makeWeapon(
-  instanceId: string,
-  weaponId: WeaponId,
-  refinementLevel = 1,
-): CollectionWeapon {
-  return {
-    weaponInstanceId: instanceId,
-    weaponId,
-    refinementLevel,
-    createdAt: FIXED_TIMESTAMP,
-    updatedAt: FIXED_TIMESTAMP,
-  };
-}
-
-export function makeTeam(slot: TeamSlot, overrides: Partial<CollectionTeam> = {}): CollectionTeam {
-  return {
-    ...createEmptyTeam(slot),
-    createdAt: FIXED_TIMESTAMP,
-    updatedAt: FIXED_TIMESTAMP,
-    ...overrides,
-  };
-}
-
-// Collection+JSON envelope builders producing the wire format the hooks parse.
 export function charactersDocument(characters: CollectionCharacter[]): CollectionDocument {
-  return buildCollection(
-    characterCollectionHref(API_BASE_URL),
-    characters.map((character) => serialiseCharacter(character, API_BASE_URL)),
-  );
+  return testing.charactersDocument(characters, API_BASE_URL);
 }
 
 export function weaponsDocument(weapons: CollectionWeapon[]): CollectionDocument {
-  return buildCollection(
-    weaponCollectionHref(API_BASE_URL),
-    weapons.map((weapon) => serialiseWeapon(weapon, API_BASE_URL)),
-  );
+  return testing.weaponsDocument(weapons, API_BASE_URL);
 }
 
 export function teamsDocument(teams: CollectionTeam[]): CollectionDocument {
-  return buildCollection(
-    teamCollectionHref(API_BASE_URL),
-    teams.map((team) => serialiseTeam(team, API_BASE_URL)),
-  );
+  return testing.teamsDocument(teams, API_BASE_URL);
 }

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/domain/src/testing.ts
+++ b/packages/domain/src/testing.ts
@@ -13,22 +13,22 @@
  * type is answered here rather than in every suite that builds one.
  */
 
-import { buildCollection, type CollectionDocument } from '@genshin/collection-json';
+import {
+  type CollectionDocument,
+  type CollectionJsonRepresentation,
+  serialiseCollection,
+} from '@genshin/collection-json';
 
-import type {
-  CharacterId,
-  CollectionCharacter,
-  ConstellationLevel,
-} from './character/collection-character.js';
+import type { CharacterId, CollectionCharacter } from './character/collection-character.js';
 import type { ISOTimestamp } from './iso-timestamp.js';
 import {
-  serialiseCharacter,
   characterCollectionHref,
+  characterRepresentation,
 } from './representations/collection-json/characters.js';
-import { serialiseTeam, teamCollectionHref } from './representations/collection-json/teams.js';
+import { teamCollectionHref, teamRepresentation } from './representations/collection-json/teams.js';
 import {
-  serialiseWeapon,
   weaponCollectionHref,
+  weaponRepresentation,
 } from './representations/collection-json/weapons.js';
 import type { CollectionTeam, TeamSlot } from './team/collection-team.js';
 import { createEmptyTeam } from './team/collection-team.js';
@@ -43,27 +43,29 @@ const UPDATED_AT = '2026-03-13T00:00:00.000Z' as ISOTimestamp;
 
 export function makeCharacter(
   characterId: CharacterId,
-  constellationLevel: ConstellationLevel = 0,
+  overrides: Partial<CollectionCharacter> = {},
 ): CollectionCharacter {
   return {
     characterId,
-    constellationLevel,
+    constellationLevel: 0,
     createdAt: CREATED_AT,
     updatedAt: UPDATED_AT,
+    ...overrides,
   };
 }
 
 export function makeWeapon(
   weaponInstanceId: CollectionWeaponId,
   weaponId: CollectionWeapon['weaponId'],
-  refinementLevel = 1,
+  overrides: Partial<CollectionWeapon> = {},
 ): CollectionWeapon {
   return {
     weaponInstanceId,
     weaponId,
-    refinementLevel,
+    refinementLevel: 1,
     createdAt: CREATED_AT,
     updatedAt: UPDATED_AT,
+    ...overrides,
   };
 }
 
@@ -76,26 +78,37 @@ export function makeTeam(slot: TeamSlot, overrides: Partial<CollectionTeam> = {}
   };
 }
 
+/**
+ * Wrap entities in the collection envelope the routes serve.
+ *
+ * Goes through `serialiseCollection` rather than `buildCollection` so a fixture
+ * carries the representation's template. A hand-rolled envelope omits it, and
+ * the suites then parse a document the API never sends.
+ */
+function collectionDocument<T>(
+  representation: CollectionJsonRepresentation<T>,
+  collectionHref: (baseUrl: string) => string,
+  entities: T[],
+  baseUrl: string,
+): CollectionDocument {
+  return serialiseCollection(
+    representation,
+    collectionHref(baseUrl),
+    entities.map((entity) => representation.serialise(entity, baseUrl)),
+  );
+}
+
 export function charactersDocument(
   characters: CollectionCharacter[],
   baseUrl: string,
 ): CollectionDocument {
-  return buildCollection(
-    characterCollectionHref(baseUrl),
-    characters.map((character) => serialiseCharacter(character, baseUrl)),
-  );
+  return collectionDocument(characterRepresentation, characterCollectionHref, characters, baseUrl);
 }
 
 export function weaponsDocument(weapons: CollectionWeapon[], baseUrl: string): CollectionDocument {
-  return buildCollection(
-    weaponCollectionHref(baseUrl),
-    weapons.map((weapon) => serialiseWeapon(weapon, baseUrl)),
-  );
+  return collectionDocument(weaponRepresentation, weaponCollectionHref, weapons, baseUrl);
 }
 
 export function teamsDocument(teams: CollectionTeam[], baseUrl: string): CollectionDocument {
-  return buildCollection(
-    teamCollectionHref(baseUrl),
-    teams.map((team) => serialiseTeam(team, baseUrl)),
-  );
+  return collectionDocument(teamRepresentation, teamCollectionHref, teams, baseUrl);
 }

--- a/packages/domain/src/testing.ts
+++ b/packages/domain/src/testing.ts
@@ -1,0 +1,101 @@
+/* SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> */
+/* SPDX-License-Identifier: MIT */
+
+/**
+ * Literal test objects for the collection domain types, shared by API and web.
+ *
+ * Example and contract tests want stable, named values, so these are builders
+ * rather than fast-check arbitraries: `fc.sample` is non-deterministic without
+ * a fixed seed, and a test asserting on a value would have to override the
+ * generated field anyway. Property-based suites keep their own arbitraries.
+ *
+ * Reachable from `@genshin/domain/testing` so a field added to a collection
+ * type is answered here rather than in every suite that builds one.
+ */
+
+import { buildCollection, type CollectionDocument } from '@genshin/collection-json';
+
+import type {
+  CharacterId,
+  CollectionCharacter,
+  ConstellationLevel,
+} from './character/collection-character.js';
+import type { ISOTimestamp } from './iso-timestamp.js';
+import {
+  serialiseCharacter,
+  characterCollectionHref,
+} from './representations/collection-json/characters.js';
+import { serialiseTeam, teamCollectionHref } from './representations/collection-json/teams.js';
+import {
+  serialiseWeapon,
+  weaponCollectionHref,
+} from './representations/collection-json/weapons.js';
+import type { CollectionTeam, TeamSlot } from './team/collection-team.js';
+import { createEmptyTeam } from './team/collection-team.js';
+import type { CollectionWeapon, CollectionWeaponId } from './weapon/collection-weapon.js';
+
+/**
+ * Distinct by default so a serialiser that emits `createdAt` where `updatedAt`
+ * belongs cannot pass a round-trip assertion.
+ */
+const CREATED_AT = '2026-01-01T00:00:00.000Z' as ISOTimestamp;
+const UPDATED_AT = '2026-03-13T00:00:00.000Z' as ISOTimestamp;
+
+export function makeCharacter(
+  characterId: CharacterId,
+  constellationLevel: ConstellationLevel = 0,
+): CollectionCharacter {
+  return {
+    characterId,
+    constellationLevel,
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
+  };
+}
+
+export function makeWeapon(
+  weaponInstanceId: CollectionWeaponId,
+  weaponId: CollectionWeapon['weaponId'],
+  refinementLevel = 1,
+): CollectionWeapon {
+  return {
+    weaponInstanceId,
+    weaponId,
+    refinementLevel,
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
+  };
+}
+
+export function makeTeam(slot: TeamSlot, overrides: Partial<CollectionTeam> = {}): CollectionTeam {
+  return {
+    ...createEmptyTeam(slot),
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
+    ...overrides,
+  };
+}
+
+export function charactersDocument(
+  characters: CollectionCharacter[],
+  baseUrl: string,
+): CollectionDocument {
+  return buildCollection(
+    characterCollectionHref(baseUrl),
+    characters.map((character) => serialiseCharacter(character, baseUrl)),
+  );
+}
+
+export function weaponsDocument(weapons: CollectionWeapon[], baseUrl: string): CollectionDocument {
+  return buildCollection(
+    weaponCollectionHref(baseUrl),
+    weapons.map((weapon) => serialiseWeapon(weapon, baseUrl)),
+  );
+}
+
+export function teamsDocument(teams: CollectionTeam[], baseUrl: string): CollectionDocument {
+  return buildCollection(
+    teamCollectionHref(baseUrl),
+    teams.map((team) => serialiseTeam(team, baseUrl)),
+  );
+}

--- a/packages/domain/src/testing.ts
+++ b/packages/domain/src/testing.ts
@@ -4,13 +4,9 @@
 /**
  * Literal test objects for the collection domain types, shared by API and web.
  *
- * Example and contract tests want stable, named values, so these are builders
- * rather than fast-check arbitraries: `fc.sample` is non-deterministic without
- * a fixed seed, and a test asserting on a value would have to override the
- * generated field anyway. Property-based suites keep their own arbitraries.
- *
- * Reachable from `@genshin/domain/testing` so a field added to a collection
- * type is answered here rather than in every suite that builds one.
+ * Example and contract tests assert on the values they build, so these hand
+ * back stable ones. Suites wanting generated values keep their own fast-check
+ * arbitraries.
  */
 
 import {
@@ -81,9 +77,8 @@ export function makeTeam(slot: TeamSlot, overrides: Partial<CollectionTeam> = {}
 /**
  * Wrap entities in the collection envelope the routes serve.
  *
- * Goes through `serialiseCollection` rather than `buildCollection` so a fixture
- * carries the representation's template. A hand-rolled envelope omits it, and
- * the suites then parse a document the API never sends.
+ * The envelope carries the representation's template, without which the suites
+ * assert against a document the API never sends.
  */
 function collectionDocument<T>(
   representation: CollectionJsonRepresentation<T>,


### PR DESCRIPTION
Closes #915

`makeCharacter`/`makeWeapon`/`makeTeam` and the Collection+JSON document helpers now live at `@genshin/domain/testing`, so a field added to `CollectionCharacter`, `CollectionWeapon` or `CollectionTeam` is answered in one file instead of both apps. It lands on `@genshin/domain` as a subpath export rather than a new `@genshin/test-fixtures`: the builders' only dependency is domain itself, and a package would cost a codecov flag with no tests behind it plus a Dockerfile copy pair.

## Gotchas

- **The fixture envelope was wrong before this branch, `apps/web`'s copy included.** The helpers called `buildCollection`; the routes call `serialiseCollection`, which attaches the representation's template, and all three representations carry one. The suites were asserting against documents missing `collection.template`. For teams the old helper also duplicated `teamListDocument`, which `routes/teams.ts` already uses.
- **`makeCharacter` and `makeWeapon` take an overrides object now**, matching `makeTeam`. That is most of the line count — `makeCharacter(SKIRK, 3)` becomes `makeCharacter(SKIRK, { constellationLevel: 3 })` across roughly 45 call sites, all mechanical.
- **`createdAt` and `updatedAt` default to different instants.** The old web fixtures used one timestamp for both, which lets a serialiser emitting `createdAt` where `updatedAt` belongs pass a round-trip assertion.
- **`packages/domain/dist` now ships test helpers.** First functional subpath export in the repo.
- **`characters/schemas/index.test.ts` keeps its local builder.** It feeds unversioned persisted blobs to a migration, including entries for characters that do not exist, so it needs a shape the `CharacterId` union rejects.
- **`use-weapon-collection-store.test.ts` swapped `'sword-1'`/`'bow-1'` for `WEAPON_ROSTER` entries.** The shared builder types `weaponId`, so the old casts past the union had to go.

## Verification

- Attaching the template changed no assertion: 290 web tests and 243 API tests pass unmodified.
- `pnpm turbo run build` is unverified for `apps/web`. The Vite config requires eight `VITE_*` variables a host session does not carry; unrelated to this branch and covered in CI.
