### PR TITLE
fix: fail lint on any warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,9 +137,9 @@ repos:
       # rules seeing `any`, so it invents findings `eslint .` never reports.
       # Turbo arranges both, and caches on inputs, which is why `--fix` cannot
       # live here: a cache hit replays the log without rewriting anything.
-      # `--max-warnings=0` belongs in each workspace's `lint` script for the
-      # same reason: flags added here reach only the commit gate, not the
-      # `turbo run lint` a contributor or CI job runs directly.
+      # `--max-warnings=0` lives in each workspace's `lint` script instead: a
+      # flag here reaches the commit gate but not the `turbo run lint` a
+      # contributor or CI job runs directly.
       #
       # No file matcher: turbo.json decides staleness, and its `lint` inputs
       # reach past the module extensions.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,6 +137,9 @@ repos:
       # rules seeing `any`, so it invents findings `eslint .` never reports.
       # Turbo arranges both, and caches on inputs, which is why `--fix` cannot
       # live here: a cache hit replays the log without rewriting anything.
+      # `--max-warnings=0` belongs in each workspace's `lint` script for the
+      # same reason: flags added here reach only the commit gate, not the
+      # `turbo run lint` a contributor or CI job runs directly.
       #
       # No file matcher: turbo.json decides staleness, and its `lint` inputs
       # reach past the module extensions.
@@ -158,7 +161,7 @@ repos:
         entry: pnpm exec stylelint
         language: system
         types: [css]
-        args: [--fix]
+        args: [--fix, --max-warnings, '0']
 
       # No file matcher: turbo.json decides staleness, and its `typecheck`
       # inputs reach past the module extensions.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "dev": "DEV=true tsx watch src/main.ts",
     "build": "tsc --project tsconfig.build.json && tsc-alias --project tsconfig.build.json && cp -r src/profiles dist/",
     "start": "node dist/main.js",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "test": "vitest run",
     "test:integration": "firebase emulators:exec --only firestore --project demo-dungeon-studio-genshin-dev \"vitest run --coverage --config vitest.integration.config.ts\"",
     "typecheck": "tsc --noEmit && tsc --project tsconfig.scripts.json --noEmit",

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -94,11 +94,9 @@ export default defineConfig([
   {
     files: SHADCN_SCAFFOLDS,
     rules: {
-      // The vendored kit wraps each component in `React.forwardRef`, which trips
-      // both of these: one wants a function declaration, the other wants the
-      // React 19 `ref` prop. Upstream's maintained registry has already dropped
-      // the wrapper, so regenerating the kit clears both; hand-editing the call
-      // sites here would only fight that regeneration.
+      // Both trip on the `React.forwardRef` wrapper in the vendored kit, which
+      // a regeneration from upstream removes. Fixes applied here do not survive
+      // that regeneration.
       'react/function-component-definition': 'off',
       '@eslint-react/no-forward-ref': 'off',
       // `CardTitle` spreads children into its `<h3>`, so content lives at the call site.

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -97,6 +97,10 @@ export default defineConfig([
       // Upstream scaffolds are `const X = React.forwardRef(...)`, not function
       // declarations; rewriting them would fight every regeneration.
       'react/function-component-definition': 'off',
+      // Same `React.forwardRef` wrapper, seen from the React 19 side. Upstream's
+      // current registry has dropped it, so the fix is to regenerate the kit
+      // rather than hand-edit 27 call sites here.
+      '@eslint-react/no-forward-ref': 'off',
       // `CardTitle` spreads children into its `<h3>`, so content lives at the call site.
       'jsx-a11y-x/heading-has-content': 'off',
     },

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -94,12 +94,12 @@ export default defineConfig([
   {
     files: SHADCN_SCAFFOLDS,
     rules: {
-      // Upstream scaffolds are `const X = React.forwardRef(...)`, not function
-      // declarations; rewriting them would fight every regeneration.
+      // The vendored kit wraps each component in `React.forwardRef`, which trips
+      // both of these: one wants a function declaration, the other wants the
+      // React 19 `ref` prop. Upstream's maintained registry has already dropped
+      // the wrapper, so regenerating the kit clears both; hand-editing the call
+      // sites here would only fight that regeneration.
       'react/function-component-definition': 'off',
-      // Same `React.forwardRef` wrapper, seen from the React 19 side. Upstream's
-      // current registry has dropped it, so the fix is to regenerate the kit
-      // rather than hand-edit 27 call sites here.
       '@eslint-react/no-forward-ref': 'off',
       // `CardTitle` spreads children into its `<h3>`, so content lives at the call site.
       'jsx-a11y-x/heading-has-content': 'off',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "lint:css": "stylelint 'src/**/*.css' --fix",
+    "lint": "eslint . --max-warnings=0",
+    "lint:css": "stylelint 'src/**/*.css' --fix --max-warnings 0",
     "preview": "vite preview",
     "schemas:export": "tsx scripts/export-schemas.ts",
     "test": "vitest run",

--- a/apps/web/src/components/chrome/container.tsx
+++ b/apps/web/src/components/chrome/container.tsx
@@ -6,11 +6,10 @@ import type { ComponentProps, JSX } from 'react';
 import { cn } from '@/lib/utils';
 
 /**
- * Centers content and constrains it to the app's horizontal gutter
- * (`mx-auto max-w-7xl px-4`). Apply to the inner element of a full-bleed
- * wrapper so backgrounds and borders span the viewport while content stays
- * aligned with the rest of the app. Vertical spacing is left to each call
- * site via `className`.
+ * Centers content and constrains it to the app's horizontal gutter. Apply it to
+ * the inner element of a full-bleed wrapper so backgrounds and borders span the
+ * viewport while content stays aligned with the rest of the app. Each call site
+ * sets its own vertical spacing through `className`.
  */
 function Container({ className, ...props }: ComponentProps<'div'>): JSX.Element {
   return <div className={cn('max-w-7xl px-4 mx-auto', className)} {...props} />;

--- a/apps/web/src/components/chrome/container.tsx
+++ b/apps/web/src/components/chrome/container.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import * as React from 'react';
+import type { ComponentProps, JSX } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -12,11 +12,8 @@ import { cn } from '@/lib/utils';
  * aligned with the rest of the app. Vertical spacing is left to each call
  * site via `className`.
  */
-const Container = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('max-w-7xl px-4 mx-auto', className)} {...props} />
-  ),
-);
-Container.displayName = 'Container';
+function Container({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return <div className={cn('max-w-7xl px-4 mx-auto', className)} {...props} />;
+}
 
 export { Container };

--- a/apps/web/src/components/chrome/use-theme.ts
+++ b/apps/web/src/components/chrome/use-theme.ts
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { useContext } from 'react';
+import { use } from 'react';
 
 import type { ThemeContextValue } from './theme-context';
 import { ThemeContext } from './theme-context';
 
 export function useTheme(): ThemeContextValue {
-  const context = useContext(ThemeContext);
+  const context = use(ThemeContext);
 
   if (context === undefined) {
     throw new Error('useTheme must be used within a ThemeProvider');

--- a/apps/web/src/features/auth/use-auth.ts
+++ b/apps/web/src/features/auth/use-auth.ts
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { useContext } from 'react';
+import { use } from 'react';
 
 import type { AuthContextValue } from './auth-context';
 import { AuthContext } from './auth-context';
 
 export function useAuth(): AuthContextValue {
-  const context = useContext(AuthContext);
+  const context = use(AuthContext);
 
   if (context === undefined) {
     throw new Error('useAuth must be used within an AuthProvider');

--- a/apps/web/src/features/collection/characters/use-character-collection.test.tsx
+++ b/apps/web/src/features/collection/characters/use-character-collection.test.tsx
@@ -102,9 +102,7 @@ describe('useCollection merge-on-first-login', () => {
     function Wrapper({ children }: { children: ReactNode }) {
       return (
         <QueryClientProvider client={queryClient}>
-          <AuthContext.Provider value={{ user: authUser, loading: false }}>
-            {children}
-          </AuthContext.Provider>
+          <AuthContext value={{ user: authUser, loading: false }}>{children}</AuthContext>
         </QueryClientProvider>
       );
     }

--- a/apps/web/src/features/collection/characters/use-character-collection.test.tsx
+++ b/apps/web/src/features/collection/characters/use-character-collection.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import type { CharacterId } from '@genshin/domain';
-import { QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { User } from 'firebase/auth';
 import { http, HttpResponse } from 'msw';
@@ -10,9 +9,9 @@ import type { ReactNode } from 'react';
 import { toast } from 'sonner';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AuthContext } from '@/features/auth/auth-context';
 import { charactersDocument, makeCharacter } from '@/test/fixtures';
 import { server } from '@/test/msw/server';
+import { TestProviders } from '@/test/providers';
 import { createTestQueryClient, createWrapper, fakeUser } from '@/test/render';
 
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
@@ -101,9 +100,9 @@ describe('useCollection merge-on-first-login', () => {
     let authUser: User | null = fakeUser('user-1');
     function Wrapper({ children }: { children: ReactNode }) {
       return (
-        <QueryClientProvider client={queryClient}>
-          <AuthContext value={{ user: authUser, loading: false }}>{children}</AuthContext>
-        </QueryClientProvider>
+        <TestProviders queryClient={queryClient} user={authUser}>
+          {children}
+        </TestProviders>
       );
     }
 

--- a/apps/web/src/test/providers.tsx
+++ b/apps/web/src/test/providers.tsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import type { QueryClient } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { User } from 'firebase/auth';
+import type { JSX, ReactNode } from 'react';
+
+import { AuthContext } from '@/features/auth/auth-context';
+
+interface TestProvidersProps {
+  children: ReactNode;
+  queryClient: QueryClient;
+  user?: User | null;
+  loading?: boolean;
+}
+
+/**
+ * The TanStack Query and auth context the collection and team hooks need.
+ *
+ * Auth arrives as props rather than bound at wrapper-construction time so a
+ * test can sign a different user in between `rerender()` calls. `createWrapper`
+ * binds them for the tests that never do.
+ */
+export function TestProviders({
+  children,
+  queryClient,
+  user = null,
+  loading = false,
+}: TestProvidersProps): JSX.Element {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContext value={{ user, loading }}>{children}</AuthContext>
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/src/test/providers.tsx
+++ b/apps/web/src/test/providers.tsx
@@ -18,9 +18,8 @@ interface TestProvidersProps {
 /**
  * The TanStack Query and auth context the collection and team hooks need.
  *
- * Auth arrives as props rather than bound at wrapper-construction time so a
- * test can sign a different user in between `rerender()` calls. `createWrapper`
- * binds them for the tests that never do.
+ * Auth arrives as props so a test can sign a different user in between
+ * `rerender()` calls.
  */
 export function TestProviders({
   children,

--- a/apps/web/src/test/render.tsx
+++ b/apps/web/src/test/render.tsx
@@ -37,7 +37,7 @@ export function createWrapper(
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
-        <AuthContext.Provider value={{ user, loading }}>{children}</AuthContext.Provider>
+        <AuthContext value={{ user, loading }}>{children}</AuthContext>
       </QueryClientProvider>
     );
   };

--- a/apps/web/src/test/render.tsx
+++ b/apps/web/src/test/render.tsx
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import type { User } from 'firebase/auth';
 import type { ReactNode } from 'react';
 
-import { AuthContext } from '@/features/auth/auth-context';
+import { TestProviders } from '@/test/providers';
 
 // The composite hooks only read `user.uid`; a partial User is sufficient.
 export function fakeUser(uid: string): User {
@@ -28,7 +28,7 @@ interface WrapperOptions {
   queryClient?: QueryClient;
 }
 
-// Provides the TanStack Query and auth context the collection/team hooks need.
+// Binds one set of provider values for the tests that never change them.
 export function createWrapper(
   options: WrapperOptions = {},
 ): (props: { children: ReactNode }) => ReactNode {
@@ -36,9 +36,9 @@ export function createWrapper(
 
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
-      <QueryClientProvider client={queryClient}>
-        <AuthContext value={{ user, loading }}>{children}</AuthContext>
-      </QueryClientProvider>
+      <TestProviders queryClient={queryClient} user={user} loading={loading}>
+        {children}
+      </TestProviders>
     );
   };
 }

--- a/packages/collection-json/package.json
+++ b/packages/collection-json/package.json
@@ -16,7 +16,7 @@
     "build": "tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "lint": "eslint ."
+    "lint": "eslint . --max-warnings=0"
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit",
     "build": "tsc --project tsconfig.build.json",
     "test": "vitest run",
-    "lint": "eslint ."
+    "lint": "eslint . --max-warnings=0"
   },
   "dependencies": {
     "@genshin/collection-json": "workspace:*",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,7 +12,7 @@
     "index.js"
   ],
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint . --max-warnings=0"
   },
   "dependencies": {
     "@eslint/js": "10.0.1",

--- a/packages/game-data/package.json
+++ b/packages/game-data/package.json
@@ -17,7 +17,7 @@
     "build": "tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "lint": "eslint ."
+    "lint": "eslint . --max-warnings=0"
   },
   "devDependencies": {
     "@genshin/eslint-config": "workspace:*",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsc --project tsconfig.build.json",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/tools/e2e/package.json
+++ b/tools/e2e/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "test:e2e": "firebase --config ../../firebase.json emulators:exec --only auth,firestore --project demo-dungeon-studio-genshin-dev 'playwright test'",
     "test:deployed": ": \"${E2E_BASE_URL:?must name the origin of the deployment under test}\" && playwright test --grep @deployed --fully-parallel --workers 4 --retries 2",
     "typecheck": "tsc --noEmit"

--- a/tools/game-data-codegen/package.json
+++ b/tools/game-data-codegen/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "generate": "node ./dist/cli.js"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #516
Closes #1378
Closes #1195

ESLint and stylelint now fail on any warning, clearing the 32 `@eslint-react`
findings #1196 left ungated.

## Gotchas

- **`--max-warnings=0` is in each workspace's `lint` script, not on the
  pre-commit hook.** The hook delegates to `turbo run lint` (#888), so a flag
  there would gate commits but not the `turbo run lint` a contributor or the
  Devcontainer job runs directly.
- **The 27 `forwardRef` warnings in the vendored shadcn kit are opted out, not
  fixed.** `components.json` still names the deprecated `new-york` style while
  the repo runs Tailwind 4 and React 19. Upstream's maintained registry dropped
  the wrapper, so #1194 clears them by regenerating; edits here would not
  survive that.
- **#1378 duplicates #516** — same warnings, same gate, filed a day later. #516
  carries the broader scope, so it is the one that stays.
- **Vale has the same gap and keeps it.** Its exit code answers only to `error`
  alerts, so 221 warnings and 238 suggestions pass today. Clearing those is a
  prose project — #1397.

## Verification

Reintroduced a warning and confirmed `turbo run lint` fails on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7UQS1zpvKotBNTTPe2mvS
