### PR TITLE
refactor: rename hook addCharacter to ensureCharacter

### DIFF
--- a/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-store.test.ts
@@ -16,9 +16,9 @@ describe('useCollectionStore', () => {
     useCollectionStore.getState().clearCharacters();
   });
 
-  describe('addCharacter', () => {
+  describe('ensureCharacter', () => {
     it('adds a character with minimum constellation level', () => {
-      useCollectionStore.getState().addCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('amber');
 
       expect(useCollectionStore.getState().characters).toMatchObject({
         amber: { constellationLevel: 0 },
@@ -26,10 +26,10 @@ describe('useCollectionStore', () => {
     });
 
     it('does not overwrite an existing character', () => {
-      useCollectionStore.getState().addCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('amber');
       const original = useCollectionStore.getState().characters['amber'];
 
-      useCollectionStore.getState().addCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('amber');
       const after = useCollectionStore.getState().characters['amber'];
 
       expect(original).toBeDefined();
@@ -39,7 +39,7 @@ describe('useCollectionStore', () => {
 
   describe('removeCharacter', () => {
     it('removes a character from the collection', () => {
-      useCollectionStore.getState().addCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('amber');
       useCollectionStore.getState().removeCharacter('amber');
 
       expect(useCollectionStore.getState().characters['amber']).toBeUndefined();
@@ -54,7 +54,7 @@ describe('useCollectionStore', () => {
 
   describe('setConstellationLevel', () => {
     it('updates the constellation level of an owned character', () => {
-      useCollectionStore.getState().addCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('amber');
       useCollectionStore.getState().setConstellationLevel('amber', 3);
 
       expect(useCollectionStore.getState().characters).toMatchObject({
@@ -71,7 +71,7 @@ describe('useCollectionStore', () => {
 
   describe('isOwned', () => {
     it('returns true for owned characters', () => {
-      useCollectionStore.getState().addCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('amber');
 
       expect(useCollectionStore.getState().isOwned('amber')).toBe(true);
     });
@@ -83,7 +83,7 @@ describe('useCollectionStore', () => {
 
   describe('replaceCharacters', () => {
     it('replaces the entire collection', () => {
-      useCollectionStore.getState().addCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('amber');
       useCollectionStore.getState().replaceCharacters({ xiangling: makeCharacter('xiangling') });
 
       expect(useCollectionStore.getState().characters['amber']).toBeUndefined();
@@ -93,8 +93,8 @@ describe('useCollectionStore', () => {
 
   describe('clearCharacters', () => {
     it('empties the collection', () => {
-      useCollectionStore.getState().addCharacter('amber');
-      useCollectionStore.getState().addCharacter('xiangling');
+      useCollectionStore.getState().ensureCharacter('amber');
+      useCollectionStore.getState().ensureCharacter('xiangling');
       useCollectionStore.getState().clearCharacters();
 
       expect(Object.keys(useCollectionStore.getState().characters)).toHaveLength(0);

--- a/apps/web/src/features/collection/characters/use-character-collection-store.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection-store.ts
@@ -47,7 +47,7 @@ export function mergeCollections(
 
 interface CollectionState {
   characters: CharacterCollection;
-  addCharacter: (characterId: CharacterId) => void;
+  ensureCharacter: (characterId: CharacterId) => void;
   removeCharacter: (characterId: CharacterId) => void;
   setConstellationLevel: (characterId: CharacterId, level: ConstellationLevel) => void;
   isOwned: (characterId: CharacterId) => boolean;
@@ -61,7 +61,7 @@ export const useCollectionStore = create<CollectionState>()(
     (set, get) => ({
       characters: {},
 
-      addCharacter: (characterId) => {
+      ensureCharacter: (characterId) => {
         if (get().characters[characterId]) return;
 
         const now = nowTimestamp();

--- a/apps/web/src/features/collection/characters/use-character-collection.test.tsx
+++ b/apps/web/src/features/collection/characters/use-character-collection.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
 describe('useCollection merge-on-first-login', () => {
   it('merges the local collection into the store and syncs new entries to the server', async () => {
     // Anonymous local collection built before signing in.
-    useCollectionStore.getState().addCharacter(SKIRK);
+    useCollectionStore.getState().ensureCharacter(SKIRK);
     useCollectionStore.getState().setConstellationLevel(SKIRK, 3);
 
     const putBodies: unknown[] = [];
@@ -54,7 +54,7 @@ describe('useCollection merge-on-first-login', () => {
   });
 
   it('does not re-push local entries when the same user refetches', async () => {
-    useCollectionStore.getState().addCharacter(SKIRK);
+    useCollectionStore.getState().ensureCharacter(SKIRK);
     useCollectionStore.getState().setConstellationLevel(SKIRK, 3);
 
     let getCount = 0;
@@ -85,7 +85,7 @@ describe('useCollection merge-on-first-login', () => {
   });
 
   it('clears the collection on logout so a different user merges fresh', async () => {
-    useCollectionStore.getState().addCharacter(SKIRK);
+    useCollectionStore.getState().ensureCharacter(SKIRK);
     useCollectionStore.getState().setConstellationLevel(SKIRK, 3);
 
     let serverCharacters = charactersDocument([]);

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -39,7 +39,7 @@ function entriesAheadOfServer(
 
 export interface UseCollectionResult {
   characters: CharacterCollection;
-  addCharacter: (characterId: CharacterId) => void;
+  ensureCharacter: (characterId: CharacterId) => void;
   removeCharacter: (characterId: CharacterId) => void;
   setConstellationLevel: (characterId: CharacterId, level: ConstellationLevel) => void;
   isOwned: (characterId: CharacterId) => boolean;
@@ -133,7 +133,7 @@ export function useCollection(): UseCollectionResult {
   // against races from rapid user interactions). Errors are surfaced via toast
   // side-effects — no retry is attempted.
 
-  const addCharacter = useCallback(
+  const ensureCharacter = useCallback(
     (id: CharacterId) => {
       const alreadyOwned = id in useCollectionStore.getState().characters;
       if (alreadyOwned) return;
@@ -227,7 +227,7 @@ export function useCollection(): UseCollectionResult {
 
   return {
     characters,
-    addCharacter,
+    ensureCharacter,
     removeCharacter,
     setConstellationLevel,
     isOwned,

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -54,7 +54,7 @@ export function useCollection(): UseCollectionResult {
 
   // Zustand store — always the read layer
   const characters = useCollectionStore((s) => s.characters);
-  const storeAddCharacter = useCollectionStore((s) => s.addCharacter);
+  const storeEnsureCharacter = useCollectionStore((s) => s.ensureCharacter);
   const storeRemoveCharacter = useCollectionStore((s) => s.removeCharacter);
   const storeSetConstellationLevel = useCollectionStore((s) => s.setConstellationLevel);
   const replaceCharacters = useCollectionStore((s) => s.replaceCharacters);
@@ -138,7 +138,7 @@ export function useCollection(): UseCollectionResult {
       const alreadyOwned = id in useCollectionStore.getState().characters;
       if (alreadyOwned) return;
 
-      storeAddCharacter(id);
+      storeEnsureCharacter(id);
       if (isAuthenticated) {
         addCharacterApi(id, {
           onSuccess: applyMutationResult,
@@ -157,7 +157,7 @@ export function useCollection(): UseCollectionResult {
     [
       isAuthenticated,
       addCharacterApi,
-      storeAddCharacter,
+      storeEnsureCharacter,
       storeRemoveCharacter,
       applyMutationResult,
     ],
@@ -174,7 +174,7 @@ export function useCollection(): UseCollectionResult {
           onError: () => {
             const stillAbsent = !(id in useCollectionStore.getState().characters);
             if (stillAbsent) {
-              storeAddCharacter(id);
+              storeEnsureCharacter(id);
               storeSetConstellationLevel(id, current.constellationLevel);
               toast.error('Failed to remove character. Change has been reverted.');
             } else {
@@ -188,7 +188,7 @@ export function useCollection(): UseCollectionResult {
       isAuthenticated,
       removeCharacterApi,
       storeRemoveCharacter,
-      storeAddCharacter,
+      storeEnsureCharacter,
       storeSetConstellationLevel,
     ],
   );

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -52,7 +52,7 @@ export function useCollection(): UseCollectionResult {
   const { user, loading: authLoading } = useAuth();
   const isAuthenticated = user !== null;
 
-  // Zustand store — always the read layer
+  // The store is the read layer for collection data; the query only syncs into it.
   const characters = useCollectionStore((s) => s.characters);
   const storeEnsureCharacter = useCollectionStore((s) => s.ensureCharacter);
   const storeRemoveCharacter = useCollectionStore((s) => s.removeCharacter);
@@ -60,7 +60,6 @@ export function useCollection(): UseCollectionResult {
   const replaceCharacters = useCollectionStore((s) => s.replaceCharacters);
   const clearCharacters = useCollectionStore((s) => s.clearCharacters);
 
-  // TanStack Query — background sync when authenticated
   const {
     data: apiCharacters,
     error: queryError,
@@ -71,7 +70,6 @@ export function useCollection(): UseCollectionResult {
   const { mutate: removeCharacterApi } = useRemoveCharacterMutation(user?.uid);
   const { mutate: setConstellationLevelApi } = useSetConstellationLevelMutation(user?.uid);
 
-  // Patch zustand with confirmed server data
   const applyMutationResult = useCallback(
     ({ characterId, entry }: MutationResult) => {
       storeSetConstellationLevel(characterId, entry.constellationLevel);
@@ -79,14 +77,11 @@ export function useCollection(): UseCollectionResult {
     [storeSetConstellationLevel],
   );
 
-  // Merge anonymous localStorage data with server data on first query resolution
-  // per user session. Subsequent resolutions (refetches) merge additively to
-  // avoid overwriting optimistic state while merge mutations are in flight.
+  // Gates the anonymous-localStorage merge to the first query resolution per user.
   const mergedForUser = useRef<string | null>(null);
 
-  // Reset merge tracking and clear persisted collection on logout so
-  // re-login triggers a fresh merge and a different account cannot
-  // inherit the previous user's local data.
+  // Re-login must trigger a fresh merge, and a different account must not inherit
+  // the previous user's local data.
   useEffect(() => {
     if (!user) {
       mergedForUser.current = null;
@@ -126,12 +121,9 @@ export function useCollection(): UseCollectionResult {
     }
   }, [apiCharacters, user, replaceCharacters, setConstellationLevelApi, applyMutationResult]);
 
-  // Mutation error strategy: optimistic rollback + toast notification.
-  // Each mutation writes to zustand first for instant UI feedback, then fires
-  // the API call. On failure the onError callback rolls back the zustand change
-  // only if the store still reflects this mutation's optimistic value (guards
-  // against races from rapid user interactions). Errors are surfaced via toast
-  // side-effects — no retry is attempted.
+  // Each mutation rolls back its optimistic store write only if the store still
+  // holds that write, so rapid interactions don't clobber each other. Nothing is
+  // retried.
 
   const ensureCharacter = useCallback(
     (id: CharacterId) => {

--- a/apps/web/src/features/collection/characters/use-character-collection.ts
+++ b/apps/web/src/features/collection/characters/use-character-collection.ts
@@ -54,11 +54,11 @@ export function useCollection(): UseCollectionResult {
 
   // The store is the read layer for collection data; the query only syncs into it.
   const characters = useCollectionStore((s) => s.characters);
-  const storeEnsureCharacter = useCollectionStore((s) => s.ensureCharacter);
-  const storeRemoveCharacter = useCollectionStore((s) => s.removeCharacter);
-  const storeSetConstellationLevel = useCollectionStore((s) => s.setConstellationLevel);
-  const replaceCharacters = useCollectionStore((s) => s.replaceCharacters);
-  const clearCharacters = useCollectionStore((s) => s.clearCharacters);
+  const ensureCharacterLocally = useCollectionStore((s) => s.ensureCharacter);
+  const removeCharacterLocally = useCollectionStore((s) => s.removeCharacter);
+  const setConstellationLevelLocally = useCollectionStore((s) => s.setConstellationLevel);
+  const replaceCharactersLocally = useCollectionStore((s) => s.replaceCharacters);
+  const clearCharactersLocally = useCollectionStore((s) => s.clearCharacters);
 
   const {
     data: apiCharacters,
@@ -66,15 +66,15 @@ export function useCollection(): UseCollectionResult {
     isLoading: queryLoading,
   } = useCharacterCollectionQuery(user?.uid);
 
-  const { mutate: addCharacterApi } = useAddCharacterMutation(user?.uid);
-  const { mutate: removeCharacterApi } = useRemoveCharacterMutation(user?.uid);
-  const { mutate: setConstellationLevelApi } = useSetConstellationLevelMutation(user?.uid);
+  const { mutate: addCharacterRemotely } = useAddCharacterMutation(user?.uid);
+  const { mutate: removeCharacterRemotely } = useRemoveCharacterMutation(user?.uid);
+  const { mutate: setConstellationLevelRemotely } = useSetConstellationLevelMutation(user?.uid);
 
   const applyMutationResult = useCallback(
     ({ characterId, entry }: MutationResult) => {
-      storeSetConstellationLevel(characterId, entry.constellationLevel);
+      setConstellationLevelLocally(characterId, entry.constellationLevel);
     },
-    [storeSetConstellationLevel],
+    [setConstellationLevelLocally],
   );
 
   // Gates the anonymous-localStorage merge to the first query resolution per user.
@@ -85,9 +85,9 @@ export function useCollection(): UseCollectionResult {
   useEffect(() => {
     if (!user) {
       mergedForUser.current = null;
-      clearCharacters();
+      clearCharactersLocally();
     }
-  }, [user, clearCharacters]);
+  }, [user, clearCharactersLocally]);
 
   useEffect(() => {
     if (!apiCharacters) return;
@@ -95,12 +95,12 @@ export function useCollection(): UseCollectionResult {
     if (user && mergedForUser.current !== user.uid) {
       const localData = useCollectionStore.getState().characters;
       const merged = mergeCollections(localData, apiCharacters);
-      replaceCharacters(merged);
+      replaceCharactersLocally(merged);
 
       const diffs = entriesAheadOfServer(merged, apiCharacters);
 
       for (const diff of diffs) {
-        setConstellationLevelApi(diff, {
+        setConstellationLevelRemotely(diff, {
           onSuccess: applyMutationResult,
           onError: () => {
             toast.error('Failed to sync a merged character to the server.');
@@ -117,9 +117,15 @@ export function useCollection(): UseCollectionResult {
       // Keep refetches additive so in-flight merge mutations aren't overwritten.
       const currentCharacters = useCollectionStore.getState().characters;
       const merged = mergeCollections(currentCharacters, apiCharacters);
-      replaceCharacters(merged);
+      replaceCharactersLocally(merged);
     }
-  }, [apiCharacters, user, replaceCharacters, setConstellationLevelApi, applyMutationResult]);
+  }, [
+    apiCharacters,
+    user,
+    replaceCharactersLocally,
+    setConstellationLevelRemotely,
+    applyMutationResult,
+  ]);
 
   // Each mutation rolls back its optimistic store write only if the store still
   // holds that write, so rapid interactions don't clobber each other. Nothing is
@@ -130,14 +136,14 @@ export function useCollection(): UseCollectionResult {
       const alreadyOwned = id in useCollectionStore.getState().characters;
       if (alreadyOwned) return;
 
-      storeEnsureCharacter(id);
+      ensureCharacterLocally(id);
       if (isAuthenticated) {
-        addCharacterApi(id, {
+        addCharacterRemotely(id, {
           onSuccess: applyMutationResult,
           onError: () => {
             const current = useCollectionStore.getState().characters[id];
             if (current?.constellationLevel === MIN_CONSTELLATION_LEVEL) {
-              storeRemoveCharacter(id);
+              removeCharacterLocally(id);
               toast.error('Failed to add character. Change has been reverted.');
             } else {
               toast.error('Failed to add character.');
@@ -148,9 +154,9 @@ export function useCollection(): UseCollectionResult {
     },
     [
       isAuthenticated,
-      addCharacterApi,
-      storeEnsureCharacter,
-      storeRemoveCharacter,
+      addCharacterRemotely,
+      ensureCharacterLocally,
+      removeCharacterLocally,
       applyMutationResult,
     ],
   );
@@ -160,14 +166,14 @@ export function useCollection(): UseCollectionResult {
       const current = useCollectionStore.getState().characters[id];
       if (!current) return;
 
-      storeRemoveCharacter(id);
+      removeCharacterLocally(id);
       if (isAuthenticated) {
-        removeCharacterApi(id, {
+        removeCharacterRemotely(id, {
           onError: () => {
             const stillAbsent = !(id in useCollectionStore.getState().characters);
             if (stillAbsent) {
-              storeEnsureCharacter(id);
-              storeSetConstellationLevel(id, current.constellationLevel);
+              ensureCharacterLocally(id);
+              setConstellationLevelLocally(id, current.constellationLevel);
               toast.error('Failed to remove character. Change has been reverted.');
             } else {
               toast.error('Failed to remove character.');
@@ -178,10 +184,10 @@ export function useCollection(): UseCollectionResult {
     },
     [
       isAuthenticated,
-      removeCharacterApi,
-      storeRemoveCharacter,
-      storeEnsureCharacter,
-      storeSetConstellationLevel,
+      removeCharacterRemotely,
+      removeCharacterLocally,
+      ensureCharacterLocally,
+      setConstellationLevelLocally,
     ],
   );
 
@@ -190,16 +196,16 @@ export function useCollection(): UseCollectionResult {
       const previousLevel = useCollectionStore.getState().characters[id]?.constellationLevel;
       if (previousLevel === undefined || previousLevel === level) return;
 
-      storeSetConstellationLevel(id, level);
+      setConstellationLevelLocally(id, level);
       if (isAuthenticated) {
-        setConstellationLevelApi(
+        setConstellationLevelRemotely(
           { characterId: id, level },
           {
             onSuccess: applyMutationResult,
             onError: () => {
               const currentLevel = useCollectionStore.getState().characters[id]?.constellationLevel;
               if (previousLevel !== undefined && currentLevel === level) {
-                storeSetConstellationLevel(id, previousLevel);
+                setConstellationLevelLocally(id, previousLevel);
                 toast.error('Failed to update constellation level. Change has been reverted.');
               } else {
                 toast.error('Failed to update constellation level.');
@@ -209,7 +215,12 @@ export function useCollection(): UseCollectionResult {
         );
       }
     },
-    [isAuthenticated, setConstellationLevelApi, storeSetConstellationLevel, applyMutationResult],
+    [
+      isAuthenticated,
+      setConstellationLevelRemotely,
+      setConstellationLevelLocally,
+      applyMutationResult,
+    ],
   );
 
   const isOwned = useCallback((id: CharacterId) => id in characters, [characters]);

--- a/apps/web/src/features/collection/weapons/use-weapon-collection.ts
+++ b/apps/web/src/features/collection/weapons/use-weapon-collection.ts
@@ -35,11 +35,11 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
   const isAuthenticated = user !== null;
 
   const weapons = useWeaponCollectionStore((s) => s.weapons);
-  const storeSetWeapons = useWeaponCollectionStore((s) => s.setWeapons);
-  const storeAddWeapon = useWeaponCollectionStore((s) => s.addWeapon);
-  const storeRemoveWeapon = useWeaponCollectionStore((s) => s.removeWeapon);
-  const storeSetRefinementLevel = useWeaponCollectionStore((s) => s.setRefinementLevel);
-  const clearWeapons = useWeaponCollectionStore((s) => s.clearWeapons);
+  const setWeaponsLocally = useWeaponCollectionStore((s) => s.setWeapons);
+  const addWeaponLocally = useWeaponCollectionStore((s) => s.addWeapon);
+  const removeWeaponLocally = useWeaponCollectionStore((s) => s.removeWeapon);
+  const setRefinementLevelLocally = useWeaponCollectionStore((s) => s.setRefinementLevel);
+  const clearWeaponsLocally = useWeaponCollectionStore((s) => s.clearWeapons);
 
   const {
     data: apiWeapons,
@@ -47,31 +47,31 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
     isLoading: queryLoading,
   } = useWeaponCollectionQuery(user?.uid);
 
-  const { mutate: addWeaponApi } = useAddWeaponMutation(user?.uid);
-  const { mutate: removeWeaponApi } = useRemoveWeaponMutation(user?.uid);
-  const { mutate: setRefinementLevelApi } = useSetRefinementLevelMutation(user?.uid);
+  const { mutate: addWeaponRemotely } = useAddWeaponMutation(user?.uid);
+  const { mutate: removeWeaponRemotely } = useRemoveWeaponMutation(user?.uid);
+  const { mutate: setRefinementLevelRemotely } = useSetRefinementLevelMutation(user?.uid);
 
   const applyMutationResult = useCallback(
     ({ weapon }: WeaponMutationResult) => {
-      storeAddWeapon(weapon);
+      addWeaponLocally(weapon);
     },
-    [storeAddWeapon],
+    [addWeaponLocally],
   );
 
   useEffect(() => {
     if (!user) {
-      clearWeapons();
+      clearWeaponsLocally();
     }
-  }, [user, clearWeapons]);
+  }, [user, clearWeaponsLocally]);
 
   useEffect(() => {
     if (!apiWeapons) return;
-    storeSetWeapons(apiWeapons);
-  }, [apiWeapons, storeSetWeapons]);
+    setWeaponsLocally(apiWeapons);
+  }, [apiWeapons, setWeaponsLocally]);
 
   const runAdd = useCallback(
     (weaponId: Weapon['id'], onSettled?: () => void) => {
-      addWeaponApi(weaponId, {
+      addWeaponRemotely(weaponId, {
         onSuccess: applyMutationResult,
         onError: () => {
           toast.error('Failed to add weapon.');
@@ -79,7 +79,7 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
         onSettled,
       });
     },
-    [addWeaponApi, applyMutationResult],
+    [addWeaponRemotely, applyMutationResult],
   );
 
   // Additive: every call creates a new instance. Contrast ensureWeapon.
@@ -120,12 +120,12 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
       const current = useWeaponCollectionStore.getState().weapons[collectionWeaponId];
       if (!current) return;
 
-      storeRemoveWeapon(collectionWeaponId);
-      removeWeaponApi(collectionWeaponId, {
+      removeWeaponLocally(collectionWeaponId);
+      removeWeaponRemotely(collectionWeaponId, {
         onError: () => {
           const stillAbsent = !(collectionWeaponId in useWeaponCollectionStore.getState().weapons);
           if (stillAbsent) {
-            storeAddWeapon(current);
+            addWeaponLocally(current);
             toast.error('Failed to remove weapon. Change has been reverted.');
           } else {
             toast.error('Failed to remove weapon.');
@@ -133,7 +133,7 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
         },
       });
     },
-    [isAuthenticated, removeWeaponApi, storeRemoveWeapon, storeAddWeapon],
+    [isAuthenticated, removeWeaponRemotely, removeWeaponLocally, addWeaponLocally],
   );
 
   const setRefinementLevel = useCallback(
@@ -144,8 +144,8 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
       const previous = useWeaponCollectionStore.getState().weapons[collectionWeaponId];
       if (!previous || previous.refinementLevel === level) return;
 
-      storeSetRefinementLevel(collectionWeaponId, level);
-      setRefinementLevelApi(
+      setRefinementLevelLocally(collectionWeaponId, level);
+      setRefinementLevelRemotely(
         { collectionWeaponId, level },
         {
           onSuccess: applyMutationResult,
@@ -153,7 +153,7 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
             const currentLevel =
               useWeaponCollectionStore.getState().weapons[collectionWeaponId]?.refinementLevel;
             if (currentLevel === level) {
-              storeSetRefinementLevel(collectionWeaponId, previous.refinementLevel);
+              setRefinementLevelLocally(collectionWeaponId, previous.refinementLevel);
               toast.error('Failed to update refinement level. Change has been reverted.');
             } else {
               toast.error('Failed to update refinement level.');
@@ -162,7 +162,7 @@ export function useWeaponCollection(): UseWeaponCollectionResult {
         },
       );
     },
-    [isAuthenticated, setRefinementLevelApi, storeSetRefinementLevel, applyMutationResult],
+    [isAuthenticated, setRefinementLevelRemotely, setRefinementLevelLocally, applyMutationResult],
   );
 
   const getWeaponsByWeaponId = useCallback(

--- a/apps/web/src/pages/characters-page.tsx
+++ b/apps/web/src/pages/characters-page.tsx
@@ -19,7 +19,7 @@ import { ownedCharacterIds } from '@/features/collection/characters/use-characte
 export function CharactersPage(): JSX.Element {
   const {
     characters,
-    addCharacter,
+    ensureCharacter,
     removeCharacter,
     setConstellationLevel,
     isOwned,
@@ -95,7 +95,7 @@ export function CharactersPage(): JSX.Element {
                   character={character}
                   owned={owned}
                   constellationLevel={entry?.constellationLevel}
-                  onAdd={addCharacter}
+                  onAdd={ensureCharacter}
                   onRemove={removeCharacter}
                   onConstellationChange={handleConstellationChange}
                 />


### PR DESCRIPTION
## Summary

`ensure*` and `add*` now mean the same thing everywhere in the collection
features: guarantee presence versus append a new instance. Both the character
hook and the character store had an idempotent operation named `add`, which
meant `addCharacter` and `addWeapon` said opposite things.

Two follow-on commits clean up what that rename exposed. Comments in
`use-character-collection.ts` that restated the code beneath them are gone —
three section labels naming the library the call already names, and two blocks
that narrated their statements before reaching the reason. The reasons survive.

The private aliases in both collection hooks also marked their layer at opposite
ends — a `store` prefix in front, an `Api` suffix behind — and the prefix broke
the verb phrase, so `storeEnsureCharacter` parsed as a compound verb and read
nothing like the `ensureCharacter` beside it. Both now take a trailing adverb
naming the effect scope, which is the question a reader actually has at the call
site:

```
ensureCharacter            // public: local + remote
ensureCharacterLocally     // store write
addCharacterRemotely       // POST
```

## Gotchas

- **#933 scoped the store out on a premise that turned out to be false**, so
  this PR is wider than the issue as filed. The issue called the store's
  `addCharacter` "the additive low-level mutation, parallel to the weapon
  store's `addWeapon`" — but it guards on presence and returns
  (`use-character-collection-store.ts:65`), while the weapon store keys by
  `weaponInstanceId` with no guard. Never parallel. Renaming the hook alone
  would have left the sharper trap one layer down. Issue body amended to record
  this.
- **The two guards are not redundant** — the hook's `alreadyOwned` check
  suppresses the duplicate POST, which the store's guard cannot see. Both stay.
- **`use-teams.ts` still uses the `store*` prefix.** The adverb rename covers
  the two collection hooks, which is what this PR is about; teams has ten more
  aliases on the old pattern and wants its own change.
- **Renaming a bare alias hits the selector body too.** `replaceCharacters` and
  `clearWeapons` name both the local binding and the store property, so a blind
  rename rewrites `(s) => s.clearWeapons` into a property that doesn't exist.
  Both were fixed by hand; the compiler caught them.

## Verification

- Ran the full `@genshin/web` suite after each commit — 290 passed, 35 files.
- One run showed 4 failures in `teams-page`, `delete-account-dialog`, and
  `artifact-planner`. All three pass in isolation and on a quiet re-run, the
  messages carried no assertion detail (vitest's timeout shape), and two of the
  files have no path to the collection hooks. Box contention from repeated
  pre-commit runs, not a regression.
- Grepped for surviving `addCharacter`: only the API-mutation references remain.
- Spotted two dead `CollectionState` queries while reading the store
  (`getCharacter` has no callers at all; `isOwned` only its own test). knip
  can't see them — it resolves module exports, not properties inside the
  `create()` literal. Filed as #1402 rather than folded in here.

Closes #933
