### PR TITLE
feat(tooling): scaffold workspace packages with turbo gen

### DIFF
--- a/.claude/commands/add-workspace-package.md
+++ b/.claude/commands/add-workspace-package.md
@@ -6,11 +6,8 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # Add workspace package
 
-Work the how-to top to bottom:
-[`add-workspace-package.md`](../../docs/how-tos/add-workspace-package.md). It's
-the source of truth for every integration point (scaffolding, workspace wiring,
-the CI matrix, the Codecov flag and component, and the `apps/api` Dockerfile
-copies).
+Run the generator, then work the residual from
+[`add-workspace-package.md`](../../docs/how-tos/add-workspace-package.md).
 
 ## Inputs
 
@@ -18,8 +15,13 @@ copies).
 
 ## Requirements
 
-1. Don't skip the Dockerfile section when the package is a runtime dependency
-   of `apps/api`. A missed COPY fails the Docker workflow build that runs on
-   every PR, with an opaque module-resolution error rather than a clear cause.
-2. Copy `packages/validation/` as the closest scaffolding template.
-3. Run the how-to's Verify section before opening a PR.
+1. Run `pnpm exec turbo gen package`. It writes the package, the Codecov flag,
+   component, and upload steps, and the `apps/api/Dockerfile` COPY lines.
+   Answer the tests and `apps/api` runtime dependency prompts from what the
+   package is actually for; both gate injections that fail silently or
+   opaquely when wrong.
+2. Ask the user for the description and the human-readable name rather than
+   inventing them.
+3. The generator leaves `pnpm install`, wiring the package into its consuming
+   packages, the `src/index.ts` stub, and the first test. Work those.
+4. Run the how-to's Verify section before opening a pull request.

--- a/.claude/commands/add-workspace-package.md
+++ b/.claude/commands/add-workspace-package.md
@@ -6,22 +6,10 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # Add workspace package
 
-Run the generator, then work the residual from
-[`add-workspace-package.md`](../../docs/how-tos/add-workspace-package.md).
+Work [`add-workspace-package.md`](../../docs/how-tos/add-workspace-package.md)
+top to bottom for **$1**, the `@genshin/<name>` short name.
 
-## Inputs
-
-- Package name: **$1** (the `@genshin/<name>` short name)
-
-## Requirements
-
-1. Run `pnpm exec turbo gen package`. It writes the package, the Codecov flag,
-   component, and upload steps, and the `apps/api/Dockerfile` COPY lines.
-   Answer the tests and `apps/api` runtime dependency prompts from what the
-   package is actually for; both gate injections that fail silently or
-   opaquely when wrong.
-2. Ask the user for the description and the human-readable name rather than
-   inventing them.
-3. The generator leaves `pnpm install`, wiring the package into its consuming
-   packages, the `src/index.ts` stub, and the first test. Work those.
-4. Run the how-to's Verify section before opening a pull request.
+`turbo gen package` prompts for a description, a human-readable name, and two
+answers that gate injections: whether the package has tests, and whether
+`apps/api` depends on it at runtime. Ask the user for all four. Inventing them
+produces a package wired for something it isn't.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -78,3 +78,13 @@ path = ".claude/commands/**.md"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Alex Brandt <alunduil@gmail.com>"
 SPDX-License-Identifier = "MIT"
+
+# A template's header belongs to the file it generates: the JSON ones have no
+# comment syntax to carry it, and the rest interpolate the year. Overriding
+# keeps `{{ currentYear }}` out of the copyright holders reuse reports.
+
+[[annotations]]
+path = "turbo/generators/templates/**"
+precedence = "override"
+SPDX-FileCopyrightText = "2026 Alex Brandt <alunduil@gmail.com>"
+SPDX-License-Identifier = "MIT"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -79,9 +79,9 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Alex Brandt <alunduil@gmail.com>"
 SPDX-License-Identifier = "MIT"
 
-# A template's header belongs to the file it generates: the JSON ones have no
-# comment syntax to carry it, and the rest interpolate the year. Overriding
-# keeps `{{ currentYear }}` out of the copyright holders reuse reports.
+# A template's own header belongs to the file it generates. Overriding rather
+# than aggregating keeps the interpolated `{{ currentYear }}` out of the
+# copyright holders reuse reports.
 
 [[annotations]]
 path = "turbo/generators/templates/**"

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -5,148 +5,60 @@ SPDX-License-Identifier: MIT
 
 # Add a workspace package
 
-This guide covers the integration points touched when adding a new package
-under `packages/` (or a tool under `tools/`). Several fail unhelpfully when
-omitted. A forgotten CI matrix entry or Codecov flag leaves the package
-uncovered with CI still green. A missing Dockerfile COPY fails the `apps/api`
-image build on every PR.
+This guide covers adding a new package under `packages/`. A generator writes
+the package and the integration points that fail unhelpfully when omitted: a
+forgotten Codecov flag leaves the package uncovered with CI still green, and a
+missing Dockerfile COPY fails the `apps/api` image build on every pull request.
+What remains needs a judgement the generator can't make.
 
-Work top to bottom. Each section ends at a committable state.
+Adding a tool under `tools/` follows the same shape, but the generator only
+writes to `packages/`. Copy `tools/game-data-codegen/` and work sections 2
+onward by hand.
 
 ---
 
-## 1) Scaffold the package
+## 1) Generate the package
 
-Create `packages/<name>/` with these files. Copy `packages/validation/` as the
-closest template.
+```bash
+pnpm exec turbo gen package
+```
 
-- [ ] `package.json`:
+It prompts for the package name, a human-readable name, a description, whether
+the package has tests, and whether `apps/api` depends on it at runtime. Answer
+the last two accurately: the first adds the `vitest.config.ts`, the Codecov
+flag, the Codecov component, and the upload steps; the second adds the
+`apps/api/Dockerfile` COPY lines.
 
-  ```json
-  {
-    "name": "@genshin/<name>",
-    "version": "0.0.0",
-    "description": "...",
-    "private": true,
-    "type": "module",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "files": ["dist"],
-    "scripts": {
-      "typecheck": "tsc --noEmit",
-      "build": "tsc --project tsconfig.build.json",
-      "lint": "eslint .",
-      "test": "vitest run"
-    },
-    "devDependencies": {
-      "@genshin/eslint-config": "workspace:*",
-      "@genshin/tsconfig": "workspace:*",
-      "@typescript/native": "npm:typescript@7.0.2",
-      "eslint": "10.4.0",
-      "typescript": "npm:@typescript/typescript6@6.0.2"
-    }
-  }
-  ```
+The generator refuses to guess when a file it injects into has changed shape,
+and names the file and the pattern that stopped matching. Delete
+`packages/<name>` before re-running, or the generator refuses the name as
+taken.
 
-  The `typecheck` and `build` scripts run `tsc` from `@typescript/native`. The
-  `typescript` name resolves to the TypeScript 6 compatibility package, because
-  `typescript-eslint` imports the compiler API through a `typescript` peer
-  dependency and rejects TypeScript 7.
-
-  Add `test` only once tests exist, along with the `vitest` and
-  `@vitest/coverage-v8` dev dependencies and a `vitest.config.ts`.
-
-- [ ] `tsconfig.json`: extends `@genshin/tsconfig/library.json` and adds only
-      `outDir`, `rootDir`, and `include`. TypeScript resolves those three
-      relative to the file declaring them, so the shared config can't carry
-      them. A package that uses Node APIs also adds `"types": ["node"]`.
-- [ ] `tsconfig.build.json`: extends `./tsconfig.json` and adds
-      `"exclude": ["src/**/*.test.ts"]`. The `build` script points here so test
-      files stay out of `dist`.
-- [ ] `eslint.config.js`: delegate to the shared config:
-
-  ```js
-  import genshinConfig from '@genshin/eslint-config';
-
-  export default genshinConfig(import.meta.dirname);
-  ```
-
-- [ ] SPDX headers on every source file. For files without comment syntax,
-      declare them in `REUSE.toml`. See [Add SPDX headers](./add-spdx-headers.md).
+`packages/validation/` is the template. The generated manifest takes its dev
+dependency versions from that package at run time, so a new package starts on
+whatever Renovate and syncpack currently hold.
 
 ## 2) Wire it into the workspace
 
-- [ ] The `packages/*` glob in `pnpm-workspace.yaml` already covers a new
-      `packages/<name>`. Only a new top-level directory needs a new glob.
-- [ ] In each consuming package, add `"@genshin/<name>": "workspace:*"` under
-      `dependencies`, not `devDependencies` (the Docker prune in step 4 drops
-      `devDependencies`).
 - [ ] Run `pnpm install` and commit the updated `pnpm-lock.yaml`.
+- [ ] In each consuming package, add `"@genshin/<name>": "workspace:*"` under
+      `dependencies`, not `devDependencies`. The Docker prune in the builder
+      stage drops `devDependencies`.
+- [ ] Replace the `export {}` stub in `src/index.ts`. Every source file needs
+      SPDX headers; for files without comment syntax, declare them in
+      `REUSE.toml`. See [Add SPDX headers](./add-spdx-headers.md).
+- [ ] Write the first test. `vitest run` exits non-zero on a package that has
+      none, so a package generated with tests stays red until one exists.
 
-## 3) Add it to continuous integration
+The `packages/*` glob in `pnpm-workspace.yaml` already covers the new
+directory, and the `workspace` job in `.github/workflows/ci.yml` runs the whole
+workspace through turbo, so neither needs an edit.
 
-- [ ] The `workspace` job in `.github/workflows/ci.yml` runs `typecheck`,
-      `test`, and `build` across the whole workspace, so turbo picks up the new
-      package from `pnpm-workspace.yaml`. No change to the job is required.
-
-- [ ] Add an upload pair to `.github/actions/codecov-upload/action.yml` so the
-      package reports under its own flag, and declare that flag in
-      `codecov.yml` under `flag_management.individual_flags`. Copy an existing
-      pair and change the paths and flag; one upload per flag is required, and
-      the action explains why.
-
-  Every entry runs the `typecheck`, `test`, and `build` tasks. Add the entry
-  only once the package has a `test` script, or the `test` task fails.
-
-- [ ] In `codecov.yml`, add both a flag and a component:
-
-  ```yaml
-  # under flag_management.individual_flags
-  - name: <name>
-    paths:
-      - packages/<name>/src/**
-
-  # under component_management.individual_components
-  - component_id: <name>
-    name: <Display Name>
-    paths:
-      - packages/<name>/src/**
-    flag_regexes:
-      - <name>
-  ```
-
-## 4) Update the Dockerfile (runtime dependency of a containerised app only)
-
-`apps/api` is the only containerised app. Skip this section if the new package
-is build- or test-only, or is consumed only by `apps/web`.
-
-- [ ] In the builder stage of `apps/api/Dockerfile`, add the manifest copy
-      alongside the other `packages/*/package.json` lines:
-
-  ```dockerfile
-  COPY packages/<name>/package.json ./packages/<name>/
-  ```
-
-- [ ] In the production stage, copy the built package:
-
-  ```dockerfile
-  COPY --from=builder /app/packages/<name> ./packages/<name>
-  ```
-
-- [ ] Confirm `.dockerignore` doesn't exclude the package. The `packages/`
-      tree is copied wholesale, so no change is needed unless you add a top-level
-      path.
-
-## 5) Verify
+## 3) Verify
 
 - [ ] `pnpm turbo run typecheck`
 - [ ] `pnpm turbo run test` (if the package has tests)
 - [ ] `pnpm turbo run build`
 - [ ] `pnpm reuse:check`
-- [ ] `docker build -f apps/api/Dockerfile .` (if you touched the Dockerfile)
+- [ ] `docker build -f apps/api/Dockerfile .` (if the package is an `apps/api`
+      runtime dependency)

--- a/docs/how-tos/add-workspace-package.md
+++ b/docs/how-tos/add-workspace-package.md
@@ -6,10 +6,9 @@ SPDX-License-Identifier: MIT
 # Add a workspace package
 
 This guide covers adding a new package under `packages/`. A generator writes
-the package and the integration points that fail unhelpfully when omitted: a
-forgotten Codecov flag leaves the package uncovered with CI still green, and a
+the package and the integration points that fail unhelpfully when omitted. A
+forgotten Codecov flag leaves the package uncovered with CI still green. A
 missing Dockerfile COPY fails the `apps/api` image build on every pull request.
-What remains needs a judgement the generator can't make.
 
 Adding a tool under `tools/` follows the same shape, but the generator only
 writes to `packages/`. Copy `tools/game-data-codegen/` and work sections 2
@@ -23,20 +22,18 @@ onward by hand.
 pnpm exec turbo gen package
 ```
 
-It prompts for the package name, a human-readable name, a description, whether
-the package has tests, and whether `apps/api` depends on it at runtime. Answer
-the last two accurately: the first adds the `vitest.config.ts`, the Codecov
-flag, the Codecov component, and the upload steps; the second adds the
-`apps/api/Dockerfile` COPY lines.
+Two of its answers gate injections, so answer them from what the package is
+actually for. Declaring tests adds `vitest.config.ts`, the Codecov flag and
+component, and the upload steps. Declaring an `apps/api` runtime dependency
+adds the `apps/api/Dockerfile` COPY lines.
 
-The generator refuses to guess when a file it injects into has changed shape,
-and names the file and the pattern that stopped matching. Delete
-`packages/<name>` before re-running, or the generator refuses the name as
-taken.
+When a file it injects into has changed shape, the generator stops and names
+the file and the pattern that stopped matching. Delete `packages/<name>` before
+re-running, or it refuses the name as taken.
 
-`packages/validation/` is the template. The generated manifest takes its dev
-dependency versions from that package at run time, so a new package starts on
-whatever Renovate and syncpack currently hold.
+The manifest's dev dependency versions come from `packages/validation/` as the
+generator runs, so a new package starts on the same versions as its siblings.
+Don't pin them by hand.
 
 ## 2) Wire it into the workspace
 
@@ -44,15 +41,14 @@ whatever Renovate and syncpack currently hold.
 - [ ] In each consuming package, add `"@genshin/<name>": "workspace:*"` under
       `dependencies`, not `devDependencies`. The Docker prune in the builder
       stage drops `devDependencies`.
-- [ ] Replace the `export {}` stub in `src/index.ts`. Every source file needs
-      SPDX headers; for files without comment syntax, declare them in
-      `REUSE.toml`. See [Add SPDX headers](./add-spdx-headers.md).
+- [ ] Replace the `export {}` stub in `src/index.ts`, giving every new source
+      file an SPDX header. See [Add SPDX headers](./add-spdx-headers.md).
 - [ ] Write the first test. `vitest run` exits non-zero on a package that has
-      none, so a package generated with tests stays red until one exists.
+      none.
 
-The `packages/*` glob in `pnpm-workspace.yaml` already covers the new
-directory, and the `workspace` job in `.github/workflows/ci.yml` runs the whole
-workspace through turbo, so neither needs an edit.
+Neither `pnpm-workspace.yaml` nor `.github/workflows/ci.yml` needs an edit. The
+`packages/*` glob already covers the new directory, and the `workspace` job
+runs the whole workspace through turbo.
 
 ## 3) Verify
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -9,6 +9,8 @@
 
   "workspaces": {
     ".": {
+      // `turbo gen` discovers its generator by path, so knip sees no importer.
+      "entry": ["turbo/generators/config.ts"],
       // These run at the repo root via pre-commit, which knip can't see. eslint
       // hides from knip's eslint plugin too: the flat configs live in each
       // workspace, so the plugin never activates at the root to claim it.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@ls-lint/ls-lint": "2.3.1",
+    "@turbo/gen": "2.10.11",
     "@types/node": "25.9.5",
     "eslint": "10.8.1",
     "firebase-tools": "15.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ls-lint/ls-lint':
         specifier: 2.3.1
         version: 2.3.1
+      '@turbo/gen':
+        specifier: 2.10.11
+        version: 2.10.11(@types/node@25.9.5)
       '@types/node':
         specifier: 25.9.5
         version: 25.9.5
@@ -2490,6 +2493,10 @@ packages:
     resolution: {integrity: sha512-R0a0CvGAeYYsBgPIgFNB3agGXh6qukjduNhFlwVVX1Ss2IdBJLXmgjytNGmo084bLKS0B6UdLRwKhXMHKKaObQ==}
     cpu: [arm64]
     os: [darwin]
+
+  '@turbo/gen@2.10.11':
+    resolution: {integrity: sha512-tVpy0jNGNOkOyQ8ykUPFlT+x1/eSTbY34fB3oU5pAyhtNUB0bsS7weCrSASn6kMZu8huVUiKQaErWsrCVnlcjA==}
+    hasBin: true
 
   '@turbo/linux-64@2.10.11':
     resolution: {integrity: sha512-dGlY2vg7jpsLjGS1bf9sD/cw1sGMAYbeHGQKGRFxd5Zaj+Ufbj8cNXl/vIit8ueCU97zhL/znn60ZV5iSfZAxw==}
@@ -9164,6 +9171,13 @@ snapshots:
 
   '@turbo/darwin-arm64@2.10.11':
     optional: true
+
+  '@turbo/gen@2.10.11(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/prompts': 7.10.1(@types/node@25.9.5)
+      esbuild: 0.28.2
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@turbo/linux-64@2.10.11':
     optional: true

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { PlopTypes } from '@turbo/gen';
@@ -24,8 +24,6 @@ interface Answers {
   displayName: string;
   tests: boolean;
   apiRuntimeDependency: boolean;
-  // Injected by @turbo/gen, not prompted.
-  turbo: { paths: { root: string } };
 }
 
 /**
@@ -66,16 +64,12 @@ function insertSorted(source: string, sibling: RegExp, line: string, what: strin
 }
 
 function edit(root: string, path: string, change: (source: string) => string): string {
-  const absolute = join(root, path);
-
-  writeFileSync(absolute, change(readFileSync(absolute, 'utf8')));
+  writeFileSync(join(root, path), change(readFileSync(join(root, path), 'utf8')));
 
   return path;
 }
 
-function writeManifest(answers: Answers): string {
-  const { root } = answers.turbo.paths;
-
+function writeManifest(root: string, answers: Answers): string {
   const reference = JSON.parse(
     readFileSync(join(root, REFERENCE_PACKAGE, 'package.json'), 'utf8'),
   ) as { devDependencies: Record<string, string> };
@@ -110,6 +104,8 @@ function writeManifest(answers: Answers): string {
 
   const path = join('packages', answers.name, 'package.json');
 
+  // This action runs before any `add`, so it owns creating the directory.
+  mkdirSync(join(root, 'packages', answers.name), { recursive: true });
   writeFileSync(join(root, path), `${JSON.stringify(manifest, null, 2)}\n`);
 
   return path;
@@ -118,10 +114,8 @@ function writeManifest(answers: Answers): string {
 // One upload per flag: Codecov applies a report's whole coverage to every flag
 // it carries, so a shared upload would report this package's coverage as the
 // workspace's. The action's own comment carries the full reasoning.
-function addCodecovUploads(answers: Answers): string {
-  const { name } = answers;
-
-  return edit(answers.turbo.paths.root, CODECOV_UPLOAD_ACTION, (source) =>
+function addCodecovUploads(root: string, { name }: Answers): string {
+  return edit(root, CODECOV_UPLOAD_ACTION, (source) =>
     insertAfterLast(
       source,
       /^ {4}- name: Upload .+\n(?: {6}.+\n)*/gm,
@@ -150,10 +144,8 @@ function addCodecovUploads(answers: Answers): string {
   );
 }
 
-function addCodecovFlagAndComponent(answers: Answers): string {
-  const { name, displayName } = answers;
-
-  return edit(answers.turbo.paths.root, CODECOV_CONFIG, (source) => {
+function addCodecovFlagAndComponent(root: string, { name, displayName }: Answers): string {
+  return edit(root, CODECOV_CONFIG, (source) => {
     const withFlag = insertAfterLast(
       source,
       /^ {4}- name: .+\n(?: {6}.+\n)*/gm,
@@ -181,10 +173,8 @@ function addCodecovFlagAndComponent(answers: Answers): string {
 
 // A missing COPY fails the image build on every pull request, and reports it as
 // a module-resolution error rather than a missing package.
-function addDockerfileCopies(answers: Answers): string {
-  const { name } = answers;
-
-  return edit(answers.turbo.paths.root, API_DOCKERFILE, (source) => {
+function addDockerfileCopies(root: string, { name }: Answers): string {
+  return edit(root, API_DOCKERFILE, (source) => {
     const withManifest = insertSorted(
       source,
       /^COPY packages\/[^/]+\/package\.json .+$/gm,
@@ -202,6 +192,11 @@ function addDockerfileCopies(answers: Answers): string {
 }
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
+  // `turbo gen` runs plop with the repository root as its destination base,
+  // whichever workspace the command was invoked from. Unlike the `turbo` object
+  // plop hands to templates, this is already resolved when prompts validate.
+  const root = plop.getDestBasePath();
+
   plop.setHelper('currentYear', () => String(new Date().getFullYear()));
 
   plop.setGenerator('package', {
@@ -212,17 +207,30 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         type: 'input',
         name: 'name',
         message: 'Package name, without the @genshin/ scope:',
-        validate: (input: string, answers: Answers) => {
+        validate: (input: string) => {
           if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(input)) {
             return 'Use kebab-case; .ls-lint.yml holds every directory to it.';
           }
 
-          if (existsSync(join(answers.turbo.paths.root, 'packages', input))) {
+          if (existsSync(join(root, 'packages', input))) {
             return `packages/${input} already exists.`;
           }
 
           return true;
         },
+      },
+      {
+        // Unconditional, though only the Codecov component consumes it: plop
+        // refuses to bypass a conditional prompt, which would cost the
+        // generator its non-interactive `--args` form.
+        type: 'input',
+        name: 'displayName',
+        message: 'Human-readable name, for its Codecov component:',
+        default: (answers: Answers) =>
+          answers.name
+            .split('-')
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' '),
       },
       {
         type: 'input',
@@ -237,17 +245,6 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         default: true,
       },
       {
-        type: 'input',
-        name: 'displayName',
-        message: 'Display name for its Codecov component:',
-        when: (answers: Answers) => answers.tests,
-        default: (answers: Answers) =>
-          answers.name
-            .split('-')
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' '),
-      },
-      {
         type: 'confirm',
         name: 'apiRuntimeDependency',
         message: 'Will apps/api depend on it at runtime? (adds the Dockerfile COPY lines)',
@@ -257,28 +254,28 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 
     actions: (data) => {
       const answers = data as Answers;
-      const destination = `{{ turbo.paths.root }}/packages/{{ name }}`;
+      const destination = join('packages', answers.name);
 
       const actions: PlopTypes.ActionType[] = [
-        writeManifest,
+        () => writeManifest(root, answers),
         {
           type: 'add',
-          path: `${destination}/tsconfig.json`,
+          path: join(destination, 'tsconfig.json'),
           templateFile: 'templates/tsconfig.json.hbs',
         },
         {
           type: 'add',
-          path: `${destination}/tsconfig.build.json`,
+          path: join(destination, 'tsconfig.build.json'),
           templateFile: 'templates/tsconfig.build.json.hbs',
         },
         {
           type: 'add',
-          path: `${destination}/eslint.config.js`,
+          path: join(destination, 'eslint.config.js'),
           templateFile: 'templates/eslint.config.js.hbs',
         },
         {
           type: 'add',
-          path: `${destination}/src/index.ts`,
+          path: join(destination, 'src', 'index.ts'),
           templateFile: 'templates/index.ts.hbs',
         },
       ];
@@ -287,22 +284,30 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         actions.push(
           {
             type: 'add',
-            path: `${destination}/vitest.config.ts`,
+            path: join(destination, 'vitest.config.ts'),
             templateFile: 'templates/vitest.config.ts.hbs',
           },
-          addCodecovUploads,
-          addCodecovFlagAndComponent,
+          () => addCodecovUploads(root, answers),
+          () => addCodecovFlagAndComponent(root, answers),
         );
       }
 
       if (answers.apiRuntimeDependency) {
-        actions.push(addDockerfileCopies);
+        actions.push(() => addDockerfileCopies(root, answers));
       }
 
-      // The residual the generator deliberately leaves; see the how-to.
+      // The residual the generator leaves by design; see the how-to.
+      const next = [
+        'run `pnpm install`',
+        `add "@genshin/${answers.name}": "workspace:*" to each consuming package's dependencies`,
+        ...(answers.tests
+          ? [`write the first test — \`vitest run\` fails while the package has none`]
+          : []),
+        'work the Verify section of docs/how-tos/add-workspace-package.md',
+      ];
+
       actions.push(
-        () =>
-          `\nNext: run \`pnpm install\`, add "@genshin/${answers.name}": "workspace:*" to each consuming package's dependencies, then work the Verify section of docs/how-tos/add-workspace-package.md.`,
+        () => `\nNext:\n${next.map((step, index) => `  ${index + 1}. ${step}`).join('\n')}`,
       );
 
       return actions;

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 import type { PlopTypes } from '@turbo/gen';
+
+const SCOPE = '@genshin';
+const PACKAGES_DIRECTORY = 'packages';
 
 // packages/validation is the template docs/how-tos/add-workspace-package.md
 // names. Reading its manifest rather than literalising versions here keeps a
 // generated package on whatever Renovate and syncpack currently hold, which a
 // template checked into this directory would not track.
-const REFERENCE_PACKAGE = join('packages', 'validation');
+const REFERENCE_PACKAGE = 'validation';
 
 const TEST_ONLY_DEV_DEPENDENCIES = ['vitest', '@vitest/coverage-v8'];
 
@@ -26,56 +29,85 @@ interface Answers {
   apiRuntimeDependency: boolean;
 }
 
+/** One occurrence of an anchor pattern, and where it sits in the file. */
+interface Entry {
+  text: string;
+  start: number;
+  end: number;
+}
+
+interface Anchors {
+  all: Entry[];
+  last: Entry;
+}
+
+const scopedName = (name: string): string => `${SCOPE}/${name}`;
+
+const packageDirectory = (name: string): string => join(PACKAGES_DIRECTORY, name);
+
+const splice = (source: string, at: number, text: string): string =>
+  `${source.slice(0, at)}${text}${source.slice(at)}`;
+
 /**
- * Insert `block` immediately after the last entry matching `entry`.
+ * Every occurrence of `pattern` in `source`, or a thrown error naming what
+ * stopped matching.
  *
- * Throws when nothing matches. Plop's own `modify` action delegates to
- * `String.replace`, which no-ops silently on a stale pattern — the exact
- * omission this generator exists to prevent, hidden one level deeper.
+ * Plop's own `modify` action delegates to `String.replace`, which no-ops
+ * silently on a stale pattern — the exact omission this generator exists to
+ * prevent, hidden one level deeper.
  */
-function insertAfterLast(source: string, entry: RegExp, block: string, what: string): string {
-  const last = [...source.matchAll(entry)].at(-1);
+function anchorsIn(source: string, pattern: RegExp, context: string): Anchors {
+  const all = [...source.matchAll(pattern)].map((match) => ({
+    text: match[0],
+    start: match.index,
+    end: match.index + match[0].length,
+  }));
 
-  if (last?.index === undefined) {
-    throw new Error(`${what}: nothing matched ${String(entry)}; the file's shape has changed`);
+  const last = all.at(-1);
+
+  if (last === undefined) {
+    throw new Error(`${context}: nothing matched ${String(pattern)}; the file's shape has changed`);
   }
 
-  const end = last.index + last[0].length;
-
-  return `${source.slice(0, end)}${block}${source.slice(end)}`;
+  return { all, last };
 }
 
-/**
- * Insert `line` among the lines matching `sibling`, preserving their sort
- * order. Throws when nothing matches, for the reason above.
- */
-function insertSorted(source: string, sibling: RegExp, line: string, what: string): string {
-  const matches = [...source.matchAll(sibling)];
-  const last = matches.at(-1);
-
-  if (last?.index === undefined) {
-    throw new Error(`${what}: nothing matched ${String(sibling)}; the file's shape has changed`);
-  }
-
-  const successor = matches.find((match) => match[0] > line);
-  const at = successor?.index ?? last.index + last[0].length + 1;
-
-  return `${source.slice(0, at)}${line}\n${source.slice(at)}`;
+/** Insert `block` immediately after the last entry matching `pattern`. */
+function insertAfterLast(source: string, pattern: RegExp, block: string, context: string): string {
+  return splice(source, anchorsIn(source, pattern, context).last.end, block);
 }
 
-function edit(root: string, path: string, change: (source: string) => string): string {
-  writeFileSync(join(root, path), change(readFileSync(join(root, path), 'utf8')));
+/** Insert `line` among the lines matching `pattern`, preserving their order. */
+function insertSorted(source: string, pattern: RegExp, line: string, context: string): string {
+  const { all, last } = anchorsIn(source, pattern, context);
+  const successor = all.find((entry) => entry.text > line);
+
+  return splice(source, successor ? successor.start : last.end + 1, `${line}\n`);
+}
+
+/** Rewrite a tracked file in place, returning its path as plop's change log. */
+function rewriteFile(root: string, path: string, change: (source: string) => string): string {
+  const absolute = join(root, path);
+
+  writeFileSync(absolute, change(readFileSync(absolute, 'utf8')));
 
   return path;
 }
 
-function writeManifest(root: string, answers: Answers): string {
+function referenceDevDependencies(root: string, tests: boolean): Record<string, string> {
   const reference = JSON.parse(
-    readFileSync(join(root, REFERENCE_PACKAGE, 'package.json'), 'utf8'),
+    readFileSync(join(root, packageDirectory(REFERENCE_PACKAGE), 'package.json'), 'utf8'),
   ) as { devDependencies: Record<string, string> };
 
-  const manifest = {
-    name: `@genshin/${answers.name}`,
+  const wanted = ([dependency]: [string, string]): boolean =>
+    tests || !TEST_ONLY_DEV_DEPENDENCIES.includes(dependency);
+
+  return Object.fromEntries(Object.entries(reference.devDependencies).filter(wanted));
+}
+
+function manifestFor(answers: Answers, devDependencies: Record<string, string>): object {
+  return {
+    name: scopedName(answers.name),
     version: '0.0.0',
     description: answers.description,
     private: true,
@@ -95,17 +127,16 @@ function writeManifest(root: string, answers: Answers): string {
       lint: 'eslint . --max-warnings=0',
       ...(answers.tests ? { test: 'vitest run' } : {}),
     },
-    devDependencies: Object.fromEntries(
-      Object.entries(reference.devDependencies).filter(
-        ([dependency]) => answers.tests || !TEST_ONLY_DEV_DEPENDENCIES.includes(dependency),
-      ),
-    ),
+    devDependencies,
   };
+}
 
-  const path = join('packages', answers.name, 'package.json');
+function writeManifest(root: string, answers: Answers): string {
+  const manifest = manifestFor(answers, referenceDevDependencies(root, answers.tests));
+  const path = join(packageDirectory(answers.name), 'package.json');
 
   // This action runs before any `add`, so it owns creating the directory.
-  mkdirSync(join(root, 'packages', answers.name), { recursive: true });
+  mkdirSync(join(root, packageDirectory(answers.name)), { recursive: true });
   writeFileSync(join(root, path), `${JSON.stringify(manifest, null, 2)}\n`);
 
   return path;
@@ -115,7 +146,7 @@ function writeManifest(root: string, answers: Answers): string {
 // it carries, so a shared upload would report this package's coverage as the
 // workspace's. The action's own comment carries the full reasoning.
 function addCodecovUploads(root: string, { name }: Answers): string {
-  return edit(root, CODECOV_UPLOAD_ACTION, (source) =>
+  return rewriteFile(root, CODECOV_UPLOAD_ACTION, (source) =>
     insertAfterLast(
       source,
       /^ {4}- name: Upload .+\n(?: {6}.+\n)*/gm,
@@ -145,7 +176,7 @@ function addCodecovUploads(root: string, { name }: Answers): string {
 }
 
 function addCodecovFlagAndComponent(root: string, { name, displayName }: Answers): string {
-  return edit(root, CODECOV_CONFIG, (source) => {
+  return rewriteFile(root, CODECOV_CONFIG, (source) => {
     const withFlag = insertAfterLast(
       source,
       /^ {4}- name: .+\n(?: {6}.+\n)*/gm,
@@ -174,7 +205,7 @@ function addCodecovFlagAndComponent(root: string, { name, displayName }: Answers
 // A missing COPY fails the image build on every pull request, and reports it as
 // a module-resolution error rather than a missing package.
 function addDockerfileCopies(root: string, { name }: Answers): string {
-  return edit(root, API_DOCKERFILE, (source) => {
+  return rewriteFile(root, API_DOCKERFILE, (source) => {
     const withManifest = insertSorted(
       source,
       /^COPY packages\/[^/]+\/package\.json .+$/gm,
@@ -191,6 +222,108 @@ function addDockerfileCopies(root: string, { name }: Answers): string {
   });
 }
 
+/** Each template is named for the file it produces, under `templates/`. */
+function addTemplate(name: string, file: string): PlopTypes.ActionType {
+  return {
+    type: 'add',
+    path: join(packageDirectory(name), file),
+    templateFile: join('templates', `${basename(file)}.hbs`),
+  };
+}
+
+function titleCase(name: string): string {
+  return name
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function packagePrompts(root: string): PlopTypes.PromptQuestion[] {
+  return [
+    {
+      type: 'input',
+      name: 'name',
+      message: `Package name, without the ${SCOPE}/ scope:`,
+      validate: (input: string) => {
+        if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(input)) {
+          return 'Use kebab-case; .ls-lint.yml holds every directory to it.';
+        }
+
+        if (existsSync(join(root, packageDirectory(input)))) {
+          return `${packageDirectory(input)} already exists.`;
+        }
+
+        return true;
+      },
+    },
+    {
+      // Unconditional, though only the Codecov component consumes it: plop
+      // refuses to bypass a conditional prompt, which would cost the generator
+      // its non-interactive `--args` form.
+      type: 'input',
+      name: 'displayName',
+      message: 'Human-readable name, for its Codecov component:',
+      default: (answers: Answers) => titleCase(answers.name),
+    },
+    {
+      type: 'input',
+      name: 'description',
+      message: 'One-line description for package.json:',
+      validate: (input: string) => input.trim().length > 0 || 'A description is required.',
+    },
+    {
+      type: 'confirm',
+      name: 'tests',
+      message: 'Will it have tests? (adds vitest, a Codecov flag, and a component)',
+      default: true,
+    },
+    {
+      type: 'confirm',
+      name: 'apiRuntimeDependency',
+      message: 'Will apps/api depend on it at runtime? (adds the Dockerfile COPY lines)',
+      default: false,
+    },
+  ];
+}
+
+/** The package's own files, none of which depend on the rest of the repository. */
+function scaffoldActions(root: string, answers: Answers): PlopTypes.ActionType[] {
+  const files = [
+    'tsconfig.json',
+    'tsconfig.build.json',
+    'eslint.config.js',
+    join('src', 'index.ts'),
+    ...(answers.tests ? ['vitest.config.ts'] : []),
+  ];
+
+  return [
+    () => writeManifest(root, answers),
+    ...files.map((file) => addTemplate(answers.name, file)),
+  ];
+}
+
+/** The cross-cutting edits, each gated on the answer that makes it necessary. */
+function wiringActions(root: string, answers: Answers): PlopTypes.ActionType[] {
+  return [
+    ...(answers.tests
+      ? [() => addCodecovUploads(root, answers), () => addCodecovFlagAndComponent(root, answers)]
+      : []),
+    ...(answers.apiRuntimeDependency ? [() => addDockerfileCopies(root, answers)] : []),
+  ];
+}
+
+/** The residual the generator leaves by design; see the how-to. */
+function nextSteps({ name, tests }: Answers): string {
+  const steps = [
+    'run `pnpm install`',
+    `add "${scopedName(name)}": "workspace:*" to each consuming package's dependencies`,
+    ...(tests ? ['write the first test — `vitest run` fails while the package has none'] : []),
+    'work the Verify section of docs/how-tos/add-workspace-package.md',
+  ];
+
+  return `\nNext:\n${steps.map((step, index) => `  ${index + 1}. ${step}`).join('\n')}`;
+}
+
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // `turbo gen` runs plop with the repository root as its destination base,
   // whichever workspace the command was invoked from. Unlike the `turbo` object
@@ -200,117 +333,16 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
   plop.setHelper('currentYear', () => String(new Date().getFullYear()));
 
   plop.setGenerator('package', {
-    description: 'Scaffold a packages/<name> workspace package with its Codecov and Docker wiring',
-
-    prompts: [
-      {
-        type: 'input',
-        name: 'name',
-        message: 'Package name, without the @genshin/ scope:',
-        validate: (input: string) => {
-          if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(input)) {
-            return 'Use kebab-case; .ls-lint.yml holds every directory to it.';
-          }
-
-          if (existsSync(join(root, 'packages', input))) {
-            return `packages/${input} already exists.`;
-          }
-
-          return true;
-        },
-      },
-      {
-        // Unconditional, though only the Codecov component consumes it: plop
-        // refuses to bypass a conditional prompt, which would cost the
-        // generator its non-interactive `--args` form.
-        type: 'input',
-        name: 'displayName',
-        message: 'Human-readable name, for its Codecov component:',
-        default: (answers: Answers) =>
-          answers.name
-            .split('-')
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' '),
-      },
-      {
-        type: 'input',
-        name: 'description',
-        message: 'One-line description for package.json:',
-        validate: (input: string) => input.trim().length > 0 || 'A description is required.',
-      },
-      {
-        type: 'confirm',
-        name: 'tests',
-        message: 'Will it have tests? (adds vitest, a Codecov flag, and a component)',
-        default: true,
-      },
-      {
-        type: 'confirm',
-        name: 'apiRuntimeDependency',
-        message: 'Will apps/api depend on it at runtime? (adds the Dockerfile COPY lines)',
-        default: false,
-      },
-    ],
-
+    description: `Scaffold a ${PACKAGES_DIRECTORY}/<name> workspace package with its Codecov and Docker wiring`,
+    prompts: packagePrompts(root),
     actions: (data) => {
       const answers = data as Answers;
-      const destination = join('packages', answers.name);
 
-      const actions: PlopTypes.ActionType[] = [
-        () => writeManifest(root, answers),
-        {
-          type: 'add',
-          path: join(destination, 'tsconfig.json'),
-          templateFile: 'templates/tsconfig.json.hbs',
-        },
-        {
-          type: 'add',
-          path: join(destination, 'tsconfig.build.json'),
-          templateFile: 'templates/tsconfig.build.json.hbs',
-        },
-        {
-          type: 'add',
-          path: join(destination, 'eslint.config.js'),
-          templateFile: 'templates/eslint.config.js.hbs',
-        },
-        {
-          type: 'add',
-          path: join(destination, 'src', 'index.ts'),
-          templateFile: 'templates/index.ts.hbs',
-        },
+      return [
+        ...scaffoldActions(root, answers),
+        ...wiringActions(root, answers),
+        () => nextSteps(answers),
       ];
-
-      if (answers.tests) {
-        actions.push(
-          {
-            type: 'add',
-            path: join(destination, 'vitest.config.ts'),
-            templateFile: 'templates/vitest.config.ts.hbs',
-          },
-          () => addCodecovUploads(root, answers),
-          () => addCodecovFlagAndComponent(root, answers),
-        );
-      }
-
-      if (answers.apiRuntimeDependency) {
-        actions.push(() => addDockerfileCopies(root, answers));
-      }
-
-      // The residual the generator leaves by design; see the how-to.
-      const next = [
-        'run `pnpm install`',
-        `add "@genshin/${answers.name}": "workspace:*" to each consuming package's dependencies`,
-        ...(answers.tests
-          ? [`write the first test — \`vitest run\` fails while the package has none`]
-          : []),
-        'work the Verify section of docs/how-tos/add-workspace-package.md',
-      ];
-
-      actions.push(
-        () => `\nNext:\n${next.map((step, index) => `  ${index + 1}. ${step}`).join('\n')}`,
-      );
-
-      return actions;
     },
   });
 }

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { PlopTypes } from '@turbo/gen';
+
+// packages/validation is the template docs/how-tos/add-workspace-package.md
+// names. Reading its manifest rather than literalising versions here keeps a
+// generated package on whatever Renovate and syncpack currently hold, which a
+// template checked into this directory would not track.
+const REFERENCE_PACKAGE = join('packages', 'validation');
+
+const TEST_ONLY_DEV_DEPENDENCIES = ['vitest', '@vitest/coverage-v8'];
+
+const CODECOV_UPLOAD_ACTION = join('.github', 'actions', 'codecov-upload', 'action.yml');
+const API_DOCKERFILE = join('apps', 'api', 'Dockerfile');
+const CODECOV_CONFIG = 'codecov.yml';
+
+interface Answers {
+  name: string;
+  description: string;
+  displayName: string;
+  tests: boolean;
+  apiRuntimeDependency: boolean;
+  // Injected by @turbo/gen, not prompted.
+  turbo: { paths: { root: string } };
+}
+
+/**
+ * Insert `block` immediately after the last entry matching `entry`.
+ *
+ * Throws when nothing matches. Plop's own `modify` action delegates to
+ * `String.replace`, which no-ops silently on a stale pattern — the exact
+ * omission this generator exists to prevent, hidden one level deeper.
+ */
+function insertAfterLast(source: string, entry: RegExp, block: string, what: string): string {
+  const last = [...source.matchAll(entry)].at(-1);
+
+  if (last?.index === undefined) {
+    throw new Error(`${what}: nothing matched ${String(entry)}; the file's shape has changed`);
+  }
+
+  const end = last.index + last[0].length;
+
+  return `${source.slice(0, end)}${block}${source.slice(end)}`;
+}
+
+/**
+ * Insert `line` among the lines matching `sibling`, preserving their sort
+ * order. Throws when nothing matches, for the reason above.
+ */
+function insertSorted(source: string, sibling: RegExp, line: string, what: string): string {
+  const matches = [...source.matchAll(sibling)];
+  const last = matches.at(-1);
+
+  if (last?.index === undefined) {
+    throw new Error(`${what}: nothing matched ${String(sibling)}; the file's shape has changed`);
+  }
+
+  const successor = matches.find((match) => match[0] > line);
+  const at = successor?.index ?? last.index + last[0].length + 1;
+
+  return `${source.slice(0, at)}${line}\n${source.slice(at)}`;
+}
+
+function edit(root: string, path: string, change: (source: string) => string): string {
+  const absolute = join(root, path);
+
+  writeFileSync(absolute, change(readFileSync(absolute, 'utf8')));
+
+  return path;
+}
+
+function writeManifest(answers: Answers): string {
+  const { root } = answers.turbo.paths;
+
+  const reference = JSON.parse(
+    readFileSync(join(root, REFERENCE_PACKAGE, 'package.json'), 'utf8'),
+  ) as { devDependencies: Record<string, string> };
+
+  const manifest = {
+    name: `@genshin/${answers.name}`,
+    version: '0.0.0',
+    description: answers.description,
+    private: true,
+    type: 'module',
+    exports: {
+      '.': {
+        types: './dist/index.d.ts',
+        default: './dist/index.js',
+      },
+    },
+    main: './dist/index.js',
+    types: './dist/index.d.ts',
+    files: ['dist'],
+    scripts: {
+      typecheck: 'tsc --noEmit',
+      build: 'tsc --project tsconfig.build.json',
+      lint: 'eslint . --max-warnings=0',
+      ...(answers.tests ? { test: 'vitest run' } : {}),
+    },
+    devDependencies: Object.fromEntries(
+      Object.entries(reference.devDependencies).filter(
+        ([dependency]) => answers.tests || !TEST_ONLY_DEV_DEPENDENCIES.includes(dependency),
+      ),
+    ),
+  };
+
+  const path = join('packages', answers.name, 'package.json');
+
+  writeFileSync(join(root, path), `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return path;
+}
+
+// One upload per flag: Codecov applies a report's whole coverage to every flag
+// it carries, so a shared upload would report this package's coverage as the
+// workspace's. The action's own comment carries the full reasoning.
+function addCodecovUploads(answers: Answers): string {
+  const { name } = answers;
+
+  return edit(answers.turbo.paths.root, CODECOV_UPLOAD_ACTION, (source) =>
+    insertAfterLast(
+      source,
+      /^ {4}- name: Upload .+\n(?: {6}.+\n)*/gm,
+      `
+    - name: Upload ${name} coverage
+      if: \${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        token: \${{ inputs.codecov-token }}
+        files: packages/${name}/coverage/lcov.info
+        flags: ${name}
+        fail_ci_if_error: false
+
+    - name: Upload ${name} test results
+      if: \${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        token: \${{ inputs.codecov-token }}
+        files: packages/${name}/test-results/junit.xml
+        flags: ${name}
+        report_type: test_results
+        fail_ci_if_error: false
+`,
+      CODECOV_UPLOAD_ACTION,
+    ),
+  );
+}
+
+function addCodecovFlagAndComponent(answers: Answers): string {
+  const { name, displayName } = answers;
+
+  return edit(answers.turbo.paths.root, CODECOV_CONFIG, (source) => {
+    const withFlag = insertAfterLast(
+      source,
+      /^ {4}- name: .+\n(?: {6}.+\n)*/gm,
+      `    - name: ${name}
+      paths:
+        - packages/${name}/src/**
+`,
+      `${CODECOV_CONFIG} flags`,
+    );
+
+    return insertAfterLast(
+      withFlag,
+      /^ {4}- component_id: .+\n(?: {6}.+\n)*/gm,
+      `    - component_id: ${name}
+      name: ${displayName}
+      paths:
+        - packages/${name}/src/**
+      flag_regexes:
+        - ${name}
+`,
+      `${CODECOV_CONFIG} components`,
+    );
+  });
+}
+
+// A missing COPY fails the image build on every pull request, and reports it as
+// a module-resolution error rather than a missing package.
+function addDockerfileCopies(answers: Answers): string {
+  const { name } = answers;
+
+  return edit(answers.turbo.paths.root, API_DOCKERFILE, (source) => {
+    const withManifest = insertSorted(
+      source,
+      /^COPY packages\/[^/]+\/package\.json .+$/gm,
+      `COPY packages/${name}/package.json ./packages/${name}/`,
+      `${API_DOCKERFILE} builder stage`,
+    );
+
+    return insertSorted(
+      withManifest,
+      /^COPY --from=builder \/app\/packages\/.+$/gm,
+      `COPY --from=builder /app/packages/${name} ./packages/${name}`,
+      `${API_DOCKERFILE} production stage`,
+    );
+  });
+}
+
+export default function generator(plop: PlopTypes.NodePlopAPI): void {
+  plop.setHelper('currentYear', () => String(new Date().getFullYear()));
+
+  plop.setGenerator('package', {
+    description: 'Scaffold a packages/<name> workspace package with its Codecov and Docker wiring',
+
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Package name, without the @genshin/ scope:',
+        validate: (input: string, answers: Answers) => {
+          if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(input)) {
+            return 'Use kebab-case; .ls-lint.yml holds every directory to it.';
+          }
+
+          if (existsSync(join(answers.turbo.paths.root, 'packages', input))) {
+            return `packages/${input} already exists.`;
+          }
+
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'description',
+        message: 'One-line description for package.json:',
+        validate: (input: string) => input.trim().length > 0 || 'A description is required.',
+      },
+      {
+        type: 'confirm',
+        name: 'tests',
+        message: 'Will it have tests? (adds vitest, a Codecov flag, and a component)',
+        default: true,
+      },
+      {
+        type: 'input',
+        name: 'displayName',
+        message: 'Display name for its Codecov component:',
+        when: (answers: Answers) => answers.tests,
+        default: (answers: Answers) =>
+          answers.name
+            .split('-')
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' '),
+      },
+      {
+        type: 'confirm',
+        name: 'apiRuntimeDependency',
+        message: 'Will apps/api depend on it at runtime? (adds the Dockerfile COPY lines)',
+        default: false,
+      },
+    ],
+
+    actions: (data) => {
+      const answers = data as Answers;
+      const destination = `{{ turbo.paths.root }}/packages/{{ name }}`;
+
+      const actions: PlopTypes.ActionType[] = [
+        writeManifest,
+        {
+          type: 'add',
+          path: `${destination}/tsconfig.json`,
+          templateFile: 'templates/tsconfig.json.hbs',
+        },
+        {
+          type: 'add',
+          path: `${destination}/tsconfig.build.json`,
+          templateFile: 'templates/tsconfig.build.json.hbs',
+        },
+        {
+          type: 'add',
+          path: `${destination}/eslint.config.js`,
+          templateFile: 'templates/eslint.config.js.hbs',
+        },
+        {
+          type: 'add',
+          path: `${destination}/src/index.ts`,
+          templateFile: 'templates/index.ts.hbs',
+        },
+      ];
+
+      if (answers.tests) {
+        actions.push(
+          {
+            type: 'add',
+            path: `${destination}/vitest.config.ts`,
+            templateFile: 'templates/vitest.config.ts.hbs',
+          },
+          addCodecovUploads,
+          addCodecovFlagAndComponent,
+        );
+      }
+
+      if (answers.apiRuntimeDependency) {
+        actions.push(addDockerfileCopies);
+      }
+
+      // The residual the generator deliberately leaves; see the how-to.
+      actions.push(
+        () =>
+          `\nNext: run \`pnpm install\`, add "@genshin/${answers.name}": "workspace:*" to each consuming package's dependencies, then work the Verify section of docs/how-tos/add-workspace-package.md.`,
+      );
+
+      return actions;
+    },
+  });
+}

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -9,10 +9,8 @@ import type { PlopTypes } from '@turbo/gen';
 const SCOPE = '@genshin';
 const PACKAGES_DIRECTORY = 'packages';
 
-// packages/validation is the template docs/how-tos/add-workspace-package.md
-// names. Reading its manifest rather than literalising versions here keeps a
-// generated package on whatever Renovate and syncpack currently hold, which a
-// template checked into this directory would not track.
+// Read at run time rather than literalised in a template: neither Renovate nor
+// syncpack reaches into a .hbs, so a pinned version here would start rotting.
 const REFERENCE_PACKAGE = 'validation';
 
 const TEST_ONLY_DEV_DEPENDENCIES = ['vitest', '@vitest/coverage-v8'];
@@ -29,7 +27,6 @@ interface Answers {
   apiRuntimeDependency: boolean;
 }
 
-/** One occurrence of an anchor pattern, and where it sits in the file. */
 interface Entry {
   text: string;
   start: number;
@@ -48,14 +45,9 @@ const packageDirectory = (name: string): string => join(PACKAGES_DIRECTORY, name
 const splice = (source: string, at: number, text: string): string =>
   `${source.slice(0, at)}${text}${source.slice(at)}`;
 
-/**
- * Every occurrence of `pattern` in `source`, or a thrown error naming what
- * stopped matching.
- *
- * Plop's own `modify` action delegates to `String.replace`, which no-ops
- * silently on a stale pattern — the exact omission this generator exists to
- * prevent, hidden one level deeper.
- */
+// Plop's own `modify` action delegates to `String.replace`, which no-ops
+// silently on a stale pattern. Throwing is what keeps a missed injection from
+// reporting itself as a success.
 function anchorsIn(source: string, pattern: RegExp, context: string): Anchors {
   const all = [...source.matchAll(pattern)].map((match) => ({
     text: match[0],
@@ -72,12 +64,10 @@ function anchorsIn(source: string, pattern: RegExp, context: string): Anchors {
   return { all, last };
 }
 
-/** Insert `block` immediately after the last entry matching `pattern`. */
 function insertAfterLast(source: string, pattern: RegExp, block: string, context: string): string {
   return splice(source, anchorsIn(source, pattern, context).last.end, block);
 }
 
-/** Insert `line` among the lines matching `pattern`, preserving their order. */
 function insertSorted(source: string, pattern: RegExp, line: string, context: string): string {
   const { all, last } = anchorsIn(source, pattern, context);
   const successor = all.find((entry) => entry.text > line);
@@ -85,7 +75,7 @@ function insertSorted(source: string, pattern: RegExp, line: string, context: st
   return splice(source, successor ? successor.start : last.end + 1, `${line}\n`);
 }
 
-/** Rewrite a tracked file in place, returning its path as plop's change log. */
+// Plop prints an action's return value as its change log.
 function rewriteFile(root: string, path: string, change: (source: string) => string): string {
   const absolute = join(root, path);
 
@@ -142,9 +132,7 @@ function writeManifest(root: string, answers: Answers): string {
   return path;
 }
 
-// One upload per flag: Codecov applies a report's whole coverage to every flag
-// it carries, so a shared upload would report this package's coverage as the
-// workspace's. The action's own comment carries the full reasoning.
+// Codecov needs one upload per flag; the action's own comment explains why.
 function addCodecovUploads(root: string, { name }: Answers): string {
   return rewriteFile(root, CODECOV_UPLOAD_ACTION, (source) =>
     insertAfterLast(
@@ -202,8 +190,9 @@ function addCodecovFlagAndComponent(root: string, { name, displayName }: Answers
   });
 }
 
-// A missing COPY fails the image build on every pull request, and reports it as
-// a module-resolution error rather than a missing package.
+// A missing COPY fails the image build on every pull request, reporting a
+// module-resolution error rather than a missing package. Both lists are kept
+// sorted, hence insertSorted over appending.
 function addDockerfileCopies(root: string, { name }: Answers): string {
   return rewriteFile(root, API_DOCKERFILE, (source) => {
     const withManifest = insertSorted(
@@ -257,9 +246,8 @@ function packagePrompts(root: string): PlopTypes.PromptQuestion[] {
       },
     },
     {
-      // Unconditional, though only the Codecov component consumes it: plop
-      // refuses to bypass a conditional prompt, which would cost the generator
-      // its non-interactive `--args` form.
+      // Asked even when nothing consumes it: plop refuses to bypass a
+      // conditional prompt, which would cost the generator its `--args` form.
       type: 'input',
       name: 'displayName',
       message: 'Human-readable name, for its Codecov component:',
@@ -286,7 +274,6 @@ function packagePrompts(root: string): PlopTypes.PromptQuestion[] {
   ];
 }
 
-/** The package's own files, none of which depend on the rest of the repository. */
 function scaffoldActions(root: string, answers: Answers): PlopTypes.ActionType[] {
   const files = [
     'tsconfig.json',
@@ -302,7 +289,6 @@ function scaffoldActions(root: string, answers: Answers): PlopTypes.ActionType[]
   ];
 }
 
-/** The cross-cutting edits, each gated on the answer that makes it necessary. */
 function wiringActions(root: string, answers: Answers): PlopTypes.ActionType[] {
   return [
     ...(answers.tests
@@ -312,7 +298,6 @@ function wiringActions(root: string, answers: Answers): PlopTypes.ActionType[] {
   ];
 }
 
-/** The residual the generator leaves by design; see the how-to. */
 function nextSteps({ name, tests }: Answers): string {
   const steps = [
     'run `pnpm install`',
@@ -325,9 +310,8 @@ function nextSteps({ name, tests }: Answers): string {
 }
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
-  // `turbo gen` runs plop with the repository root as its destination base,
-  // whichever workspace the command was invoked from. Unlike the `turbo` object
-  // plop hands to templates, this is already resolved when prompts validate.
+  // `turbo gen` sets the destination base to the repository root, whichever
+  // workspace the command ran from.
   const root = plop.getDestBasePath();
 
   plop.setHelper('currentYear', () => String(new Date().getFullYear()));

--- a/turbo/generators/templates/eslint.config.js.hbs
+++ b/turbo/generators/templates/eslint.config.js.hbs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: {{ currentYear }} Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import genshinConfig from '@genshin/eslint-config';
+
+export default genshinConfig(import.meta.dirname);

--- a/turbo/generators/templates/index.ts.hbs
+++ b/turbo/generators/templates/index.ts.hbs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: {{ currentYear }} Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+export {};

--- a/turbo/generators/templates/tsconfig.build.json.hbs
+++ b/turbo/generators/templates/tsconfig.build.json.hbs
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/turbo/generators/templates/tsconfig.json.hbs
+++ b/turbo/generators/templates/tsconfig.json.hbs
@@ -1,0 +1,8 @@
+{
+  "extends": "@genshin/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/turbo/generators/templates/vitest.config.ts.hbs
+++ b/turbo/generators/templates/vitest.config.ts.hbs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: {{ currentYear }} Alex Brandt <alunduil@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['dist/**', 'node_modules/**'],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+    },
+  },
+});


### PR DESCRIPTION
Closes #938

`pnpm exec turbo gen package` writes a `packages/<name>` and the cross-cutting
edits that fail quietly when skipped: the Codecov upload pair, the Codecov flag
and component, and the `apps/api/Dockerfile` COPY lines. The how-to keeps only
the residual the generator can't own.

## Gotchas

**Nothing touches `ci.yml`.** The issue asked for a matrix entry, but a79826f
removed that matrix — the `workspace` job is unfiltered and turbo picks a new
package up from `pnpm-workspace.yaml`. The per-package CI wiring that remains
is `.github/actions/codecov-upload/action.yml`. The issue body and its
acceptance criteria were corrected before any code was written.

**Dev dependency versions are read from `packages/validation/package.json` at
run time, not literalised in a template.** Neither Renovate nor syncpack
reaches into a `.hbs`, so a pinned version would start rotting the day it
landed.

**Both injection helpers throw when their anchor stops matching.** Plop's
`modify` delegates to `String.replace`, which no-ops silently — the omission
this generator exists to prevent, one level deeper. Verified by stripping the
`COPY packages/` lines and confirming the run fails.

**A generated package that declares tests is red until its first test exists.**
`vitest run` exits non-zero with no test files. A stub test would be theatre,
so the generator names it as a next step instead.

**`turbo/generators/config.ts` is neither typechecked nor linted.** Both hooks
run through `turbo run`, which only reaches workspaces. That matches
`scripts/check-vscode-extensions.ts`; say so if you'd rather the root got a
tsconfig and a flat config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaHVhkpWNbrW7RPB5D1Ks2
