### PR TITLE
docs: version REST out of band, not in the body

### DIFF
--- a/docs/explanation/dsgep-003-json-schema-strategy.md
+++ b/docs/explanation/dsgep-003-json-schema-strategy.md
@@ -311,8 +311,8 @@ app.get('/schemas/:module/:name.json', async (c) => {
 ## References
 
 - [`rest-api-conventions.md`](../reference/rest-api-conventions.md): Principle 4, predictable representation shapes
-- [`schema-versioning.md`](../reference/schema-versioning.md): How the `profile` parameter serves as the REST acceptor set, alongside the in-band stamps other boundaries use
-- [Understanding schema versioning](understanding-schema-versioning.md): The two-role model this negotiation mechanism realises for HTTP
+- [`schema-versioning.md`](../reference/schema-versioning.md): Where each boundary carries its version, including this one
+- [Understanding schema versioning](understanding-schema-versioning.md): The two-role model behind them
 - [JSON Schema 2020-12](https://json-schema.org/draft/2020-12): Schema vocabulary
 
 <!-- vale alex.Condescending = NO -->

--- a/docs/explanation/dsgep-003-json-schema-strategy.md
+++ b/docs/explanation/dsgep-003-json-schema-strategy.md
@@ -311,6 +311,8 @@ app.get('/schemas/:module/:name.json', async (c) => {
 ## References
 
 - [`rest-api-conventions.md`](../reference/rest-api-conventions.md): Principle 4, predictable representation shapes
+- [`schema-versioning.md`](../reference/schema-versioning.md): How the `profile` parameter serves as the REST acceptor set, alongside the in-band stamps other boundaries use
+- [Understanding schema versioning](understanding-schema-versioning.md): The two-role model this negotiation mechanism realises for HTTP
 - [JSON Schema 2020-12](https://json-schema.org/draft/2020-12): Schema vocabulary
 
 <!-- vale alex.Condescending = NO -->

--- a/docs/explanation/dsgep-005-schema-direction-segment.md
+++ b/docs/explanation/dsgep-005-schema-direction-segment.md
@@ -154,6 +154,7 @@ This DSGEP formalizes the convention already implemented in the codebase. Issue 
 ## References
 
 - [DSGEP-003: JSON Schema presentation and discovery strategy](dsgep-003-json-schema-strategy.md): The base decision this DSGEP amends
+- [`schema-versioning.md`](../reference/schema-versioning.md): How `v{n}` in these paths relates to the repository's wider versioning model
 - [Issue #479](https://github.com/dungeon-studio/genshin.dungeon.studio/issues/479): Schema paths include request/response direction segment
 - [PR #478 discussion](https://github.com/dungeon-studio/genshin.dungeon.studio/pull/478#discussion_r2935894001): Where the ambiguity was identified
 

--- a/docs/explanation/understanding-schema-versioning.md
+++ b/docs/explanation/understanding-schema-versioning.md
@@ -27,12 +27,13 @@ shape. Old payloads stay readable without weakening the write type.
 
 The strict write type and the union read type are distinct—don't share them.
 
-How the version reaches the reader is the boundary's choice. A stored payload
-carries it in band, as a field the reader looks at first. HTTP carries it out
-of band, in the `profile` media type parameter, and the acceptor set is the
-list of versions each route negotiates over—see
-[DSGEP-003](dsgep-003-json-schema-strategy.md) for why the body holds no
-metadata. Both are the same two roles.
+How the version reaches the reader is the boundary's choice, and neither role
+changes with it. A stored payload carries it in band, because the medium holds
+nothing but the payload. HTTP carries it out of band, in a media type
+parameter, because the protocol already negotiates representations and an
+inline schema reference would mix data with metadata—see
+[DSGEP-003](dsgep-003-json-schema-strategy.md). Which boundary does which is in
+[Schema versioning conventions](../reference/schema-versioning.md).
 
 ---
 

--- a/docs/explanation/understanding-schema-versioning.md
+++ b/docs/explanation/understanding-schema-versioning.md
@@ -32,8 +32,7 @@ changes with it. A stored payload carries it in band, because the medium holds
 nothing but the payload. HTTP carries it out of band, in a media type
 parameter, because the protocol already negotiates representations and an
 inline schema reference would mix data with metadata—see
-[DSGEP-003](dsgep-003-json-schema-strategy.md). Which boundary does which is in
-[Schema versioning conventions](../reference/schema-versioning.md).
+[DSGEP-003](dsgep-003-json-schema-strategy.md).
 
 ---
 

--- a/docs/explanation/understanding-schema-versioning.md
+++ b/docs/explanation/understanding-schema-versioning.md
@@ -18,14 +18,21 @@ version, see [Add a schema version](../how-tos/add-schema-version.md).
 ## The two-role model
 
 **Writers are strict.** Emit only the current schema version. Never emit a
-superset shaped by historical compatibility. Every payload carries a version
-stamp; if the shape changes, the stamp changes.
+superset shaped by historical compatibility. Every payload declares its
+version; if the shape changes, the declared version changes.
 
-**Readers accept the union of all supported writers.** Detect the stamped
+**Readers accept the union of all supported writers.** Determine the payload's
 version, validate against that version's schema, and migrate to the current
 shape. Old payloads stay readable without weakening the write type.
 
 The strict write type and the union read type are distinct—don't share them.
+
+How the version reaches the reader is the boundary's choice. A stored payload
+carries it in band, as a field the reader looks at first. HTTP carries it out
+of band, in the `profile` media type parameter, and the acceptor set is the
+list of versions each route negotiates over—see
+[DSGEP-003](dsgep-003-json-schema-strategy.md) for why the body holds no
+metadata. Both are the same two roles.
 
 ---
 

--- a/docs/reference/schema-versioning.md
+++ b/docs/reference/schema-versioning.md
@@ -12,20 +12,17 @@ For the steps, see [Add a schema version](../how-tos/add-schema-version.md).
 
 ## Boundary taxonomy
 
-| Boundary            | Shared medium          | Skew window                                     |
-| ------------------- | ---------------------- | ----------------------------------------------- |
-| Firestore documents | Database collection    | Until all documents are backfilled              |
-| Local storage       | Browser origin storage | Until the user clears it or a build migrates it |
-| REST API            | HTTP                   | Until all clients are updated                   |
-| Queue / event bus   | Message broker         | Until all consumers drain the queue             |
-| Cache               | Redis / Memcache / CDN | Until TTL expires or cache is flushed           |
+| Boundary            | Shared medium          | Version travels                             | Skew window                                     |
+| ------------------- | ---------------------- | ------------------------------------------- | ----------------------------------------------- |
+| Firestore documents | Database collection    | In band, `version` field                    | Until all documents are backfilled              |
+| Local storage       | Browser origin storage | In band, `persist` version                  | Until the user clears it or a build migrates it |
+| REST API            | HTTP                   | Out of band, `profile` media type parameter | Until all clients are updated                   |
+| Queue / event bus   | Message broker         | In band, `version` field                    | Until all consumers drain the queue             |
+| Cache               | Redis / Memcache / CDN | In band, `version` field                    | Until TTL expires or cache is flushed           |
 
-The skew window determines how many old writer versions the reader must tolerate.
-
-Where the version travels differs by boundary. Firestore documents, local
-storage, queue payloads, and cache entries stamp it in the payload. REST
-carries it out of band, in the `profile` media type parameter, because HTTP
-already has a negotiation mechanism and the body stays free of metadata.
+The skew window determines how many old writer versions the reader must
+tolerate. For why REST alone versions out of band, see
+[Understanding schema versioning](../explanation/understanding-schema-versioning.md#the-two-role-model).
 
 ---
 
@@ -75,29 +72,27 @@ real loss.
 
 ## Implementation: REST API
 
-REST bodies carry no `version` field. The version travels out of band, in the
-`profile` media type parameter on `Content-Type` and `Accept`, naming a JSON
-Schema served at its own URL. See
-[DSGEP-003](../explanation/dsgep-003-json-schema-strategy.md) for the
-discovery mechanism and the rationale for keeping metadata out of the body,
-and [DSGEP-005](../explanation/dsgep-005-schema-direction-segment.md) for the
-`{method}-{direction}-v{n}` schema path convention.
+The `profile` media type parameter on `Content-Type` and `Accept` carries the
+version, naming a JSON Schema served at its own URL.
+[DSGEP-003](../explanation/dsgep-003-json-schema-strategy.md) decides that
+mechanism; [DSGEP-005](../explanation/dsgep-005-schema-direction-segment.md)
+decides the `{method}-{direction}-v{n}` schema paths under
+`apps/api/src/profiles/json-schema/{module}/`.
 
-The acceptor set is declared per route, as the profile list passed to
+A route declares its **acceptor set** as the profile list passed to
 `negotiateContent([...])` for responses and `negotiateRequestSchema([...])`
-for request bodies. Adding a version to a list widens what that route accepts;
-removing one narrows it. A client that sends no `profile` gets the first entry,
-so the current version leads the list.
+for request bodies. Adding a version to that list widens what the route
+accepts; removing one narrows it. A client that names no `profile` gets the
+first entry, so the current version leads the list.
 
-The strict-write / union-read split holds at the handler types.
-`validateRequestBody()` validates the body against whichever version the
-client negotiated, so a handler's body type is the union over the versions its
-route accepts. Serialisation emits the current version alone—a response shape
-is never a superset assembled from several versions.
+The strict write type and the union read type land on the handler.
+`validateRequestBody()` validates against whichever version the client
+negotiated, so a handler's body type is the union over its route's acceptor
+set. Serialisation emits the current version alone.
 
-Retiring a version means withdrawing it from the route's list and from the
-schema endpoints, which is the major version transition process in
-[DSGEP-003](../explanation/dsgep-003-json-schema-strategy.md#major-version-transition-process).
+Retiring a version withdraws it from every acceptor set and from the schema
+endpoints, following DSGEP-003's [major version transition
+process](../explanation/dsgep-003-json-schema-strategy.md#major-version-transition-process).
 
 ---
 

--- a/docs/reference/schema-versioning.md
+++ b/docs/reference/schema-versioning.md
@@ -22,6 +22,11 @@ For the steps, see [Add a schema version](../how-tos/add-schema-version.md).
 
 The skew window determines how many old writer versions the reader must tolerate.
 
+Where the version travels differs by boundary. Firestore documents, local
+storage, queue payloads, and cache entries stamp it in the payload. REST
+carries it out of band, in the `profile` media type parameter, because HTTP
+already has a negotiation mechanism and the body stays free of metadata.
+
 ---
 
 ## Implementation: Firestore
@@ -68,10 +73,38 @@ real loss.
 
 ---
 
+## Implementation: REST API
+
+REST bodies carry no `version` field. The version travels out of band, in the
+`profile` media type parameter on `Content-Type` and `Accept`, naming a JSON
+Schema served at its own URL. See
+[DSGEP-003](../explanation/dsgep-003-json-schema-strategy.md) for the
+discovery mechanism and the rationale for keeping metadata out of the body,
+and [DSGEP-005](../explanation/dsgep-005-schema-direction-segment.md) for the
+`{method}-{direction}-v{n}` schema path convention.
+
+The acceptor set is declared per route, as the profile list passed to
+`negotiateContent([...])` for responses and `negotiateRequestSchema([...])`
+for request bodies. Adding a version to a list widens what that route accepts;
+removing one narrows it. A client that sends no `profile` gets the first entry,
+so the current version leads the list.
+
+The strict-write / union-read split holds at the handler types.
+`validateRequestBody()` validates the body against whichever version the
+client negotiated, so a handler's body type is the union over the versions its
+route accepts. Serialisation emits the current version alone—a response shape
+is never a superset assembled from several versions.
+
+Retiring a version means withdrawing it from the route's list and from the
+schema endpoints, which is the major version transition process in
+[DSGEP-003](../explanation/dsgep-003-json-schema-strategy.md#major-version-transition-process).
+
+---
+
 ## Implementation: Other boundaries
 
-REST bodies, queue payloads, and cache entries don't yet use this pattern.
-When those boundaries are introduced: stamp every payload with a `version`
-field, keep one `schemas/v{n}.ts` file per version, write a strict serializer
-and a union deserializer, use the same `V{n}ConceptSchema` / `V{n}Concept`
-naming convention.
+Queue payloads and cache entries don't yet use this pattern. Both are in-band
+boundaries like Firestore: when they're introduced, stamp every payload with a
+`version` field, keep one `schemas/v{n}.ts` file per version, write a strict
+serializer and a union deserializer, use the same `V{n}ConceptSchema` /
+`V{n}Concept` naming convention.

--- a/docs/reference/schema-versioning.md
+++ b/docs/reference/schema-versioning.md
@@ -20,9 +20,7 @@ For the steps, see [Add a schema version](../how-tos/add-schema-version.md).
 | Queue / event bus   | Message broker         | In band, `version` field                    | Until all consumers drain the queue             |
 | Cache               | Redis / Memcache / CDN | In band, `version` field                    | Until TTL expires or cache is flushed           |
 
-The skew window determines how many old writer versions the reader must
-tolerate. For why REST alone versions out of band, see
-[Understanding schema versioning](../explanation/understanding-schema-versioning.md#the-two-role-model).
+The skew window determines how many old writer versions the reader must tolerate.
 
 ---
 
@@ -76,19 +74,17 @@ The `profile` media type parameter on `Content-Type` and `Accept` carries the
 version, naming a JSON Schema served at its own URL.
 [DSGEP-003](../explanation/dsgep-003-json-schema-strategy.md) decides that
 mechanism; [DSGEP-005](../explanation/dsgep-005-schema-direction-segment.md)
-decides the `{method}-{direction}-v{n}` schema paths under
-`apps/api/src/profiles/json-schema/{module}/`.
+decides the schema paths.
 
 A route declares its **acceptor set** as the profile list passed to
 `negotiateContent([...])` for responses and `negotiateRequestSchema([...])`
 for request bodies. Adding a version to that list widens what the route
-accepts; removing one narrows it. A client that names no `profile` gets the
-first entry, so the current version leads the list.
+accepts; removing one narrows it. Order the list current version first—a
+client that names no `profile` gets the first entry.
 
-The strict write type and the union read type land on the handler.
-`validateRequestBody()` validates against whichever version the client
-negotiated, so a handler's body type is the union over its route's acceptor
-set. Serialisation emits the current version alone.
+The strict write type and the union read type land on the handler: its body
+type is the union over its route's acceptor set, and serialisation emits the
+current version alone.
 
 Retiring a version withdraws it from every acceptor set and from the schema
 endpoints, following DSGEP-003's [major version transition


### PR DESCRIPTION
## Summary

`schema-versioning.md` told REST to stamp an in-body `version` field while
DSGEP-003 decided the version rides the `profile` media type parameter. The
taxonomy table now carries a "Version travels" column naming the mechanism per
boundary, REST gets an implementation section describing the acceptor set a
route declares and where the strict-write / union-read split lands, and the
three docs cross-reference each other for that boundary.

## Gotchas

- **No tracker links in the reference doc**, though #943's scope asks for #920
  and #566. Nothing under `docs/reference/` or `docs/how-tos/` links issues
  (only DSGEPs do), and #566 already shipped. The "REST is greenfield" framing
  goes away by describing the negotiation that exists and pointing at
  DSGEP-003's major version transition process instead.
- **`understanding-schema-versioning.md` changed too**, one step past #943's
  stated scope: its two-role model asserted "every payload carries a version
  stamp", which is the same contradiction one doc up. It now holds only the
  *why*, with the per-boundary *what* left to the reference table.
- **Three commits, narrowing.** The first states the rule, the second
  consolidates it into the taxonomy table and settles on one term ("acceptor
  set"), the third cuts sentences that restate a linked doc or narrate what a
  middleware docstring already says. Squash-merged they read as one change.

Closes #943
