### PR TITLE
test(web): source roster fixtures from @genshin/game-data

### DIFF
--- a/apps/web/src/components/summaries/character-summary.test.tsx
+++ b/apps/web/src/components/summaries/character-summary.test.tsx
@@ -22,8 +22,7 @@ describe('CharacterSummary', () => {
 
     const images = screen.getAllByAltText(AMBER.element);
     expect(images).toHaveLength(2);
-    // Spelled out rather than read back from `getElementIconPath`: these two
-    // assertions are the only coverage of the element-to-file mapping.
+    // The only coverage of the element-to-file mapping, so the paths stay literal.
     expect(images[0]).toHaveAttribute('src', '/elements/pyro-light.png');
     expect(images[1]).toHaveAttribute('src', '/elements/pyro-dark.png');
   });

--- a/apps/web/src/components/summaries/character-summary.test.tsx
+++ b/apps/web/src/components/summaries/character-summary.test.tsx
@@ -1,22 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Character } from '@genshin/game-data';
+import { CHARACTERS } from '@genshin/game-data';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { CharacterSummary } from './character-summary';
 
-const AMBER = {
-  id: 'amber',
-  name: 'Amber',
-  element: 'Pyro',
-  weaponType: 'Bow',
-  rarity: 4,
-  region: 'Mondstadt',
-  version: '1.0',
-  releaseDate: '2020-09-28',
-} satisfies Character;
+const { amber: AMBER } = CHARACTERS;
 
 describe('CharacterSummary', () => {
   it('renders placeholder when no character is provided', () => {
@@ -29,8 +20,10 @@ describe('CharacterSummary', () => {
   it('renders the element icon with correct src path', () => {
     render(<CharacterSummary character={AMBER} />);
 
-    const images = screen.getAllByAltText('Pyro');
+    const images = screen.getAllByAltText(AMBER.element);
     expect(images).toHaveLength(2);
+    // Spelled out rather than read back from `getElementIconPath`: these two
+    // assertions are the only coverage of the element-to-file mapping.
     expect(images[0]).toHaveAttribute('src', '/elements/pyro-light.png');
     expect(images[1]).toHaveAttribute('src', '/elements/pyro-dark.png');
   });
@@ -38,7 +31,7 @@ describe('CharacterSummary', () => {
   it('applies dimmed styling when dimmed prop is true', () => {
     render(<CharacterSummary character={AMBER} dimmed />);
 
-    const images = screen.getAllByAltText('Pyro');
+    const images = screen.getAllByAltText(AMBER.element);
     expect(images[0]).toHaveClass('opacity-30');
     expect(images[1]).toHaveClass('opacity-30');
   });

--- a/apps/web/src/components/summaries/weapon-summary.test.tsx
+++ b/apps/web/src/components/summaries/weapon-summary.test.tsx
@@ -33,8 +33,7 @@ describe('WeaponSummary', () => {
     const images = typeIconsFor(<WeaponSummary weapon={AMOS_BOW} />);
 
     expect(images).toHaveLength(2);
-    // Spelled out rather than read back from `getWeaponTypeIconPath`: these two
-    // assertions are the only coverage of the type-to-file mapping.
+    // The only coverage of the type-to-file mapping, so the paths stay literal.
     expect(images[0]).toHaveAttribute('src', '/weapon-types/bow-light.png');
     expect(images[1]).toHaveAttribute('src', '/weapon-types/bow-dark.png');
   });

--- a/apps/web/src/components/summaries/weapon-summary.test.tsx
+++ b/apps/web/src/components/summaries/weapon-summary.test.tsx
@@ -1,21 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 // SPDX-License-Identifier: MIT
 
-import type { Weapon } from '@genshin/game-data';
+import { WEAPONS } from '@genshin/game-data';
 import { render, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { describe, expect, it } from 'vitest';
 
 import { WeaponSummary } from './weapon-summary';
 
-const AMOS_BOW = {
-  id: 'amos-bow',
-  name: "Amos' Bow",
-  type: 'Bow',
-  rarity: 5,
-  baseATK: 46,
-  version: '1.0',
-} satisfies Weapon;
+const { 'amos-bow': AMOS_BOW } = WEAPONS;
 
 /**
  * The type icons restate the name beside them, so they render `alt=""`. That
@@ -40,6 +33,8 @@ describe('WeaponSummary', () => {
     const images = typeIconsFor(<WeaponSummary weapon={AMOS_BOW} />);
 
     expect(images).toHaveLength(2);
+    // Spelled out rather than read back from `getWeaponTypeIconPath`: these two
+    // assertions are the only coverage of the type-to-file mapping.
     expect(images[0]).toHaveAttribute('src', '/weapon-types/bow-light.png');
     expect(images[1]).toHaveAttribute('src', '/weapon-types/bow-dark.png');
   });

--- a/apps/web/src/features/collection/characters/filtering.test.ts
+++ b/apps/web/src/features/collection/characters/filtering.test.ts
@@ -8,9 +8,8 @@ import { describe, expect, it } from 'vitest';
 import type { CharacterFilterState } from './filtering';
 import { filterCharacters, initialFilterState } from './filtering';
 
-// Indexing the roster keys the sample to real game data, so a field added to
-// `Character` reaches these tests without an edit. A missing ID is a `tsc`
-// error, unlike `getCharacterById`, which answers `undefined`.
+// The sample tracks the generated roster, so a field added to `Character`
+// needs no edit here.
 const {
   amber: AMBER,
   ganyu: GANYU,
@@ -20,9 +19,9 @@ const {
   zhongli: ZHONGLI,
 } = CHARACTERS;
 
-// Two Pyro, two 5-star, two owned, and no two of those groups hold the same
-// pair: each filter halves the sample, and the combined case can still tell an
-// `and` from an `or`.
+// Two Pyro, two 5-star, two owned, and no two of those groups name the same
+// pair. Where they coincide, a filter case passes on another's result and the
+// combined case cannot separate `and` from `or`.
 const SAMPLE = [AMBER, GANYU, XIANGLING, ZHONGLI];
 const OWNED_IDS = new Set([AMBER.id, GANYU.id]);
 
@@ -30,7 +29,6 @@ function idsOf(characters: readonly Character[]): string[] {
   return characters.map((c) => c.id);
 }
 
-/** Membership, for the filter cases; ordering is the sort cases' concern. */
 function idSetOf(characters: readonly Character[]): Set<string> {
   return new Set(idsOf(characters));
 }
@@ -97,10 +95,9 @@ describe('filterCharacters', () => {
   });
 
   it('orders same-version characters by their release date', () => {
-    // The pair only exercises the date comparison while it shares a version.
+    // The pair exercises the date comparison only while it shares a version.
     expect(NEUVILLETTE.version).toBe(WRIOTHESLEY.version);
 
-    // The one case off the shared sample: its own pair, nothing owned.
     const result = filterCharacters(
       [WRIOTHESLEY, NEUVILLETTE],
       { ...initialFilterState(), sortField: 'release', sortDirection: 'asc' },

--- a/apps/web/src/features/collection/characters/filtering.test.ts
+++ b/apps/web/src/features/collection/characters/filtering.test.ts
@@ -2,93 +2,69 @@
 // SPDX-License-Identifier: MIT
 
 import type { Character } from '@genshin/game-data';
+import { CHARACTERS } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
 import { filterCharacters, initialFilterState } from './filtering';
 
-const CHARACTERS: Character[] = [
-  {
-    id: 'amber',
-    name: 'Amber',
-    element: 'Pyro',
-    weaponType: 'Bow',
-    rarity: 4,
-    region: 'Mondstadt',
-    version: '1.0',
-    releaseDate: '2020-09-28',
-  },
-  {
-    id: 'ganyu',
-    name: 'Ganyu',
-    element: 'Cryo',
-    weaponType: 'Bow',
-    rarity: 5,
-    region: 'Liyue',
-    version: '1.2',
-    releaseDate: '2021-01-12',
-  },
-  {
-    id: 'xiangling',
-    name: 'Xiangling',
-    element: 'Pyro',
-    weaponType: 'Polearm',
-    rarity: 4,
-    region: 'Liyue',
-    version: '1.0',
-    releaseDate: '2020-09-28',
-  },
-  {
-    id: 'zhongli',
-    name: 'Zhongli',
-    element: 'Geo',
-    weaponType: 'Polearm',
-    rarity: 5,
-    region: 'Liyue',
-    version: '1.1',
-    releaseDate: '2020-12-01',
-  },
-];
+// Indexing the roster keys the sample to real game data, so a field added to
+// `Character` reaches these tests without an edit. A missing ID is a `tsc`
+// error, unlike `getCharacterById`, which answers `undefined`.
+const {
+  amber: AMBER,
+  ganyu: GANYU,
+  neuvillette: NEUVILLETTE,
+  wriothesley: WRIOTHESLEY,
+  xiangling: XIANGLING,
+  zhongli: ZHONGLI,
+} = CHARACTERS;
+
+// Two Pyro, two 5-star, two owned: every filter under test splits it in half.
+const SAMPLE = [AMBER, GANYU, XIANGLING, ZHONGLI];
+
+function idsOf(characters: readonly Character[]): string[] {
+  return characters.map((c) => c.id);
+}
 
 describe('filterCharacters', () => {
-  const ownedIds = new Set(['amber', 'xiangling']);
+  const ownedIds = new Set([AMBER.id, XIANGLING.id]);
 
   it('returns all characters with default filters', () => {
-    const result = filterCharacters(CHARACTERS, initialFilterState(), ownedIds);
+    const result = filterCharacters(SAMPLE, initialFilterState(), ownedIds);
 
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(SAMPLE.length);
   });
 
   it('filters by search text (case-insensitive)', () => {
-    const filters = { ...initialFilterState(), search: 'gan' };
+    const filters = { ...initialFilterState(), search: GANYU.name.slice(0, 3).toUpperCase() };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('ganyu');
+    expect(idsOf(result)).toEqual([GANYU.id]);
   });
 
   it('filters by element', () => {
-    const filters = { ...initialFilterState(), elements: new Set<Character['element']>(['Pyro']) };
+    const filters = { ...initialFilterState(), elements: new Set([AMBER.element]) };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
-    expect(result.every((c) => c.element === 'Pyro')).toBe(true);
+    expect(result.every((c) => c.element === AMBER.element)).toBe(true);
   });
 
   it('filters by rarity', () => {
-    const filters = { ...initialFilterState(), rarities: new Set<Character['rarity']>([5]) };
+    const filters = { ...initialFilterState(), rarities: new Set([GANYU.rarity]) };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
-    expect(result.every((c) => c.rarity === 5)).toBe(true);
+    expect(result.every((c) => c.rarity === GANYU.rarity)).toBe(true);
   });
 
   it('filters by ownership: owned', () => {
     const filters = { ...initialFilterState(), ownership: 'owned' as const };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
     expect(result.every((c) => ownedIds.has(c.id))).toBe(true);
@@ -97,7 +73,7 @@ describe('filterCharacters', () => {
   it('filters by ownership: unowned', () => {
     const filters = { ...initialFilterState(), ownership: 'unowned' as const };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
     expect(result.every((c) => !ownedIds.has(c.id))).toBe(true);
@@ -106,11 +82,11 @@ describe('filterCharacters', () => {
   it('combines multiple filters', () => {
     const filters = {
       ...initialFilterState(),
-      elements: new Set<Character['element']>(['Pyro']),
+      elements: new Set([AMBER.element]),
       ownership: 'owned' as const,
     };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
   });
@@ -122,17 +98,17 @@ describe('filterCharacters', () => {
       sortDirection: 'asc' as const,
     };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
-    expect(result[0].name).toBe('Amber');
-    expect(result[result.length - 1].name).toBe('Zhongli');
+    expect(result.map((c) => c.name)).toEqual(
+      [AMBER, GANYU, XIANGLING, ZHONGLI].map((c) => c.name),
+    );
   });
 
   it('sorts by release descending (default)', () => {
-    const result = filterCharacters(CHARACTERS, initialFilterState(), ownedIds);
+    const result = filterCharacters(SAMPLE, initialFilterState(), ownedIds);
 
-    // Version 1.2 should come first in desc order
-    expect(result[0].id).toBe('ganyu');
+    expect(idsOf(result)).toEqual(idsOf([GANYU, ZHONGLI, XIANGLING, AMBER]));
   });
 
   it('sorts by release ascending', () => {
@@ -142,43 +118,22 @@ describe('filterCharacters', () => {
       sortDirection: 'asc' as const,
     };
 
-    const result = filterCharacters(CHARACTERS, filters, ownedIds);
+    const result = filterCharacters(SAMPLE, filters, ownedIds);
 
-    // Version 1.0 characters should come first
-    expect(result[0].version).toBe('1.0');
+    expect(idsOf(result)).toEqual(idsOf([AMBER, XIANGLING, ZHONGLI, GANYU]));
   });
 
   it('orders same-version characters by their release date', () => {
-    const sameVersion: Character[] = [
-      {
-        id: 'wriothesley',
-        name: 'Wriothesley',
-        element: 'Cryo',
-        weaponType: 'Catalyst',
-        rarity: 5,
-        region: 'Fontaine',
-        version: '4.1',
-        releaseDate: '2023-10-17',
-      },
-      {
-        id: 'neuvillette',
-        name: 'Neuvillette',
-        element: 'Hydro',
-        weaponType: 'Catalyst',
-        rarity: 5,
-        region: 'Fontaine',
-        version: '4.1',
-        releaseDate: '2023-09-27',
-      },
-    ];
+    // The pair only exercises the date comparison while it shares a version.
+    expect(NEUVILLETTE.version).toBe(WRIOTHESLEY.version);
     const filters = {
       ...initialFilterState(),
       sortField: 'release' as const,
       sortDirection: 'asc' as const,
     };
 
-    const result = filterCharacters(sameVersion, filters, new Set<string>());
+    const result = filterCharacters([WRIOTHESLEY, NEUVILLETTE], filters, new Set<string>());
 
-    expect(result.map((c) => c.id)).toEqual(['neuvillette', 'wriothesley']);
+    expect(idsOf(result)).toEqual(idsOf([NEUVILLETTE, WRIOTHESLEY]));
   });
 });

--- a/apps/web/src/features/collection/characters/filtering.test.ts
+++ b/apps/web/src/features/collection/characters/filtering.test.ts
@@ -5,6 +5,7 @@ import type { Character } from '@genshin/game-data';
 import { CHARACTERS } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
+import type { CharacterFilterState } from './filtering';
 import { filterCharacters, initialFilterState } from './filtering';
 
 // Indexing the roster keys the sample to real game data, so a field added to
@@ -19,106 +20,78 @@ const {
   zhongli: ZHONGLI,
 } = CHARACTERS;
 
-// Two Pyro, two 5-star, two owned: every filter under test splits it in half.
+// Two Pyro, two 5-star, two owned, and no two of those groups hold the same
+// pair: each filter halves the sample, and the combined case can still tell an
+// `and` from an `or`.
 const SAMPLE = [AMBER, GANYU, XIANGLING, ZHONGLI];
+const OWNED_IDS = new Set([AMBER.id, GANYU.id]);
 
 function idsOf(characters: readonly Character[]): string[] {
   return characters.map((c) => c.id);
 }
 
+/** Membership, for the filter cases; ordering is the sort cases' concern. */
+function idSetOf(characters: readonly Character[]): Set<string> {
+  return new Set(idsOf(characters));
+}
+
+function filtered(overrides: Partial<CharacterFilterState> = {}): Character[] {
+  return filterCharacters(SAMPLE, { ...initialFilterState(), ...overrides }, OWNED_IDS);
+}
+
 describe('filterCharacters', () => {
-  const ownedIds = new Set([AMBER.id, XIANGLING.id]);
-
   it('returns all characters with default filters', () => {
-    const result = filterCharacters(SAMPLE, initialFilterState(), ownedIds);
-
-    expect(result).toHaveLength(SAMPLE.length);
+    expect(idSetOf(filtered())).toEqual(idSetOf(SAMPLE));
   });
 
   it('filters by search text (case-insensitive)', () => {
-    const filters = { ...initialFilterState(), search: GANYU.name.slice(0, 3).toUpperCase() };
-
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
+    const result = filtered({ search: GANYU.name.slice(0, 3).toUpperCase() });
 
     expect(idsOf(result)).toEqual([GANYU.id]);
   });
 
   it('filters by element', () => {
-    const filters = { ...initialFilterState(), elements: new Set([AMBER.element]) };
+    const result = filtered({ elements: new Set([AMBER.element]) });
 
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((c) => c.element === AMBER.element)).toBe(true);
+    expect(idSetOf(result)).toEqual(idSetOf([AMBER, XIANGLING]));
   });
 
   it('filters by rarity', () => {
-    const filters = { ...initialFilterState(), rarities: new Set([GANYU.rarity]) };
+    const result = filtered({ rarities: new Set([GANYU.rarity]) });
 
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((c) => c.rarity === GANYU.rarity)).toBe(true);
+    expect(idSetOf(result)).toEqual(idSetOf([GANYU, ZHONGLI]));
   });
 
   it('filters by ownership: owned', () => {
-    const filters = { ...initialFilterState(), ownership: 'owned' as const };
+    const result = filtered({ ownership: 'owned' });
 
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((c) => ownedIds.has(c.id))).toBe(true);
+    expect(idSetOf(result)).toEqual(OWNED_IDS);
   });
 
   it('filters by ownership: unowned', () => {
-    const filters = { ...initialFilterState(), ownership: 'unowned' as const };
+    const result = filtered({ ownership: 'unowned' });
 
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((c) => !ownedIds.has(c.id))).toBe(true);
+    expect(idSetOf(result)).toEqual(idSetOf([XIANGLING, ZHONGLI]));
   });
 
   it('combines multiple filters', () => {
-    const filters = {
-      ...initialFilterState(),
-      elements: new Set([AMBER.element]),
-      ownership: 'owned' as const,
-    };
+    const result = filtered({ elements: new Set([AMBER.element]), ownership: 'owned' });
 
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
+    expect(idSetOf(result)).toEqual(idSetOf([AMBER]));
   });
 
   it('sorts by name ascending', () => {
-    const filters = {
-      ...initialFilterState(),
-      sortField: 'name' as const,
-      sortDirection: 'asc' as const,
-    };
+    const result = filtered({ sortField: 'name', sortDirection: 'asc' });
 
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
-
-    expect(result.map((c) => c.name)).toEqual(
-      [AMBER, GANYU, XIANGLING, ZHONGLI].map((c) => c.name),
-    );
+    expect(idsOf(result)).toEqual(idsOf([AMBER, GANYU, XIANGLING, ZHONGLI]));
   });
 
   it('sorts by release descending (default)', () => {
-    const result = filterCharacters(SAMPLE, initialFilterState(), ownedIds);
-
-    expect(idsOf(result)).toEqual(idsOf([GANYU, ZHONGLI, XIANGLING, AMBER]));
+    expect(idsOf(filtered())).toEqual(idsOf([GANYU, ZHONGLI, XIANGLING, AMBER]));
   });
 
   it('sorts by release ascending', () => {
-    const filters = {
-      ...initialFilterState(),
-      sortField: 'release' as const,
-      sortDirection: 'asc' as const,
-    };
-
-    const result = filterCharacters(SAMPLE, filters, ownedIds);
+    const result = filtered({ sortField: 'release', sortDirection: 'asc' });
 
     expect(idsOf(result)).toEqual(idsOf([AMBER, XIANGLING, ZHONGLI, GANYU]));
   });
@@ -126,13 +99,13 @@ describe('filterCharacters', () => {
   it('orders same-version characters by their release date', () => {
     // The pair only exercises the date comparison while it shares a version.
     expect(NEUVILLETTE.version).toBe(WRIOTHESLEY.version);
-    const filters = {
-      ...initialFilterState(),
-      sortField: 'release' as const,
-      sortDirection: 'asc' as const,
-    };
 
-    const result = filterCharacters([WRIOTHESLEY, NEUVILLETTE], filters, new Set<string>());
+    // The one case off the shared sample: its own pair, nothing owned.
+    const result = filterCharacters(
+      [WRIOTHESLEY, NEUVILLETTE],
+      { ...initialFilterState(), sortField: 'release', sortDirection: 'asc' },
+      new Set<string>(),
+    );
 
     expect(idsOf(result)).toEqual(idsOf([NEUVILLETTE, WRIOTHESLEY]));
   });

--- a/apps/web/src/features/collection/weapons/filtering.test.ts
+++ b/apps/web/src/features/collection/weapons/filtering.test.ts
@@ -8,9 +8,8 @@ import { describe, expect, it } from 'vitest';
 import type { WeaponFilterState } from './filtering';
 import { filterWeapons, initialFilterState } from './filtering';
 
-// Indexing the roster keys the sample to real game data, so a field added to
-// `Weapon` reaches these tests without an edit. A missing ID is a `tsc` error,
-// unlike `getWeaponById`, which answers `undefined`.
+// The sample tracks the generated roster, so a field added to `Weapon` needs
+// no edit here.
 const {
   'amos-bow': AMOS_BOW,
   'favonius-sword': FAVONIUS_SWORD,
@@ -18,8 +17,8 @@ const {
   'the-catch': THE_CATCH,
 } = WEAPONS;
 
-// Two Polearms, two 5-star, two owned, and no two of those groups hold the
-// same pair: each filter halves the sample along a different seam.
+// Two Polearms, two 5-star, two owned, and no two of those groups name the
+// same pair. Where they coincide, a filter case passes on another's result.
 const SAMPLE = [FAVONIUS_SWORD, AMOS_BOW, STAFF_OF_HOMA, THE_CATCH];
 const OWNED_IDS = new Set([AMOS_BOW.id, THE_CATCH.id]);
 
@@ -27,7 +26,6 @@ function idsOf(weapons: readonly Weapon[]): string[] {
   return weapons.map((w) => w.id);
 }
 
-/** Membership, for the filter cases; ordering is the sort cases' concern. */
 function idSetOf(weapons: readonly Weapon[]): Set<string> {
   return new Set(idsOf(weapons));
 }
@@ -74,8 +72,8 @@ describe('filterWeapons', () => {
   it('sorts by name ascending', () => {
     const result = filtered({ sortField: 'name', sortDirection: 'asc' });
 
-    // `The Catch` leads because its canonical name carries the quotation marks
-    // the game prints around it, and `localeCompare` orders those before letters.
+    // `The Catch` leads: its canonical name carries the quotation marks the game
+    // prints around it, and `localeCompare` orders those before letters.
     expect(idsOf(result)).toEqual(idsOf([THE_CATCH, AMOS_BOW, FAVONIUS_SWORD, STAFF_OF_HOMA]));
   });
 

--- a/apps/web/src/features/collection/weapons/filtering.test.ts
+++ b/apps/web/src/features/collection/weapons/filtering.test.ts
@@ -5,6 +5,7 @@ import type { Weapon } from '@genshin/game-data';
 import { WEAPONS } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
+import type { WeaponFilterState } from './filtering';
 import { filterWeapons, initialFilterState } from './filtering';
 
 // Indexing the roster keys the sample to real game data, so a field added to
@@ -17,88 +18,68 @@ const {
   'the-catch': THE_CATCH,
 } = WEAPONS;
 
-// Two Polearms, two 5-star, two owned: every filter under test splits it in half.
+// Two Polearms, two 5-star, two owned, and no two of those groups hold the
+// same pair: each filter halves the sample along a different seam.
 const SAMPLE = [FAVONIUS_SWORD, AMOS_BOW, STAFF_OF_HOMA, THE_CATCH];
+const OWNED_IDS = new Set([AMOS_BOW.id, THE_CATCH.id]);
 
 function idsOf(weapons: readonly Weapon[]): string[] {
   return weapons.map((w) => w.id);
 }
 
+/** Membership, for the filter cases; ordering is the sort cases' concern. */
+function idSetOf(weapons: readonly Weapon[]): Set<string> {
+  return new Set(idsOf(weapons));
+}
+
+function filtered(overrides: Partial<WeaponFilterState> = {}): Weapon[] {
+  return filterWeapons(SAMPLE, { ...initialFilterState(), ...overrides }, OWNED_IDS);
+}
+
 describe('filterWeapons', () => {
-  const ownedIds = new Set([AMOS_BOW.id, THE_CATCH.id]);
-
   it('returns all weapons with default filters', () => {
-    const result = filterWeapons(SAMPLE, initialFilterState(), ownedIds);
-
-    expect(result).toHaveLength(SAMPLE.length);
+    expect(idSetOf(filtered())).toEqual(idSetOf(SAMPLE));
   });
 
   it('filters by search text (case-insensitive)', () => {
-    const filters = {
-      ...initialFilterState(),
-      search: STAFF_OF_HOMA.name.slice(0, 3).toUpperCase(),
-    };
-
-    const result = filterWeapons(SAMPLE, filters, ownedIds);
+    const result = filtered({ search: STAFF_OF_HOMA.name.slice(0, 3).toUpperCase() });
 
     expect(idsOf(result)).toEqual([STAFF_OF_HOMA.id]);
   });
 
   it('filters by weapon type', () => {
-    const filters = { ...initialFilterState(), weaponTypes: new Set([THE_CATCH.type]) };
+    const result = filtered({ weaponTypes: new Set([THE_CATCH.type]) });
 
-    const result = filterWeapons(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((w) => w.type === THE_CATCH.type)).toBe(true);
+    expect(idSetOf(result)).toEqual(idSetOf([STAFF_OF_HOMA, THE_CATCH]));
   });
 
   it('filters by rarity', () => {
-    const filters = { ...initialFilterState(), rarities: new Set([AMOS_BOW.rarity]) };
+    const result = filtered({ rarities: new Set([AMOS_BOW.rarity]) });
 
-    const result = filterWeapons(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((w) => w.rarity === AMOS_BOW.rarity)).toBe(true);
+    expect(idSetOf(result)).toEqual(idSetOf([AMOS_BOW, STAFF_OF_HOMA]));
   });
 
   it('filters by ownership: owned', () => {
-    const filters = { ...initialFilterState(), ownership: 'owned' as const };
+    const result = filtered({ ownership: 'owned' });
 
-    const result = filterWeapons(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((w) => ownedIds.has(w.id))).toBe(true);
+    expect(idSetOf(result)).toEqual(OWNED_IDS);
   });
 
   it('filters by ownership: unowned', () => {
-    const filters = { ...initialFilterState(), ownership: 'unowned' as const };
+    const result = filtered({ ownership: 'unowned' });
 
-    const result = filterWeapons(SAMPLE, filters, ownedIds);
-
-    expect(result).toHaveLength(2);
-    expect(result.every((w) => !ownedIds.has(w.id))).toBe(true);
+    expect(idSetOf(result)).toEqual(idSetOf([FAVONIUS_SWORD, STAFF_OF_HOMA]));
   });
 
   it('sorts by name ascending', () => {
-    const filters = {
-      ...initialFilterState(),
-      sortField: 'name' as const,
-      sortDirection: 'asc' as const,
-    };
-
-    const result = filterWeapons(SAMPLE, filters, ownedIds);
+    const result = filtered({ sortField: 'name', sortDirection: 'asc' });
 
     // `The Catch` leads because its canonical name carries the quotation marks
     // the game prints around it, and `localeCompare` orders those before letters.
-    expect(result.map((w) => w.name)).toEqual(
-      [THE_CATCH, AMOS_BOW, FAVONIUS_SWORD, STAFF_OF_HOMA].map((w) => w.name),
-    );
+    expect(idsOf(result)).toEqual(idsOf([THE_CATCH, AMOS_BOW, FAVONIUS_SWORD, STAFF_OF_HOMA]));
   });
 
   it('sorts by release descending (default)', () => {
-    const result = filterWeapons(SAMPLE, initialFilterState(), ownedIds);
-
-    expect(idsOf(result)).toEqual(idsOf([THE_CATCH, STAFF_OF_HOMA, FAVONIUS_SWORD, AMOS_BOW]));
+    expect(idsOf(filtered())).toEqual(idsOf([THE_CATCH, STAFF_OF_HOMA, FAVONIUS_SWORD, AMOS_BOW]));
   });
 });

--- a/apps/web/src/features/collection/weapons/filtering.test.ts
+++ b/apps/web/src/features/collection/weapons/filtering.test.ts
@@ -2,74 +2,70 @@
 // SPDX-License-Identifier: MIT
 
 import type { Weapon } from '@genshin/game-data';
+import { WEAPONS } from '@genshin/game-data';
 import { describe, expect, it } from 'vitest';
 
 import { filterWeapons, initialFilterState } from './filtering';
 
-const WEAPONS: Weapon[] = [
-  {
-    id: 'favonius-sword',
-    name: 'Favonius Sword',
-    type: 'Sword',
-    rarity: 4,
-    baseATK: 41,
-    version: '1.0',
-  },
-  { id: 'amos-bow', name: "Amos' Bow", type: 'Bow', rarity: 5, baseATK: 46, version: '1.0' },
-  {
-    id: 'staff-of-homa',
-    name: 'Staff of Homa',
-    type: 'Polearm',
-    rarity: 5,
-    baseATK: 46,
-    version: '1.3',
-  },
-  { id: 'the-catch', name: 'The Catch', type: 'Polearm', rarity: 4, baseATK: 42, version: '2.1' },
-];
+// Indexing the roster keys the sample to real game data, so a field added to
+// `Weapon` reaches these tests without an edit. A missing ID is a `tsc` error,
+// unlike `getWeaponById`, which answers `undefined`.
+const {
+  'amos-bow': AMOS_BOW,
+  'favonius-sword': FAVONIUS_SWORD,
+  'staff-of-homa': STAFF_OF_HOMA,
+  'the-catch': THE_CATCH,
+} = WEAPONS;
+
+// Two Polearms, two 5-star, two owned: every filter under test splits it in half.
+const SAMPLE = [FAVONIUS_SWORD, AMOS_BOW, STAFF_OF_HOMA, THE_CATCH];
+
+function idsOf(weapons: readonly Weapon[]): string[] {
+  return weapons.map((w) => w.id);
+}
 
 describe('filterWeapons', () => {
-  const ownedIds = new Set(['amos-bow', 'the-catch']);
+  const ownedIds = new Set([AMOS_BOW.id, THE_CATCH.id]);
 
   it('returns all weapons with default filters', () => {
-    const result = filterWeapons(WEAPONS, initialFilterState(), ownedIds);
+    const result = filterWeapons(SAMPLE, initialFilterState(), ownedIds);
 
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(SAMPLE.length);
   });
 
   it('filters by search text (case-insensitive)', () => {
-    const filters = { ...initialFilterState(), search: 'homa' };
+    const filters = {
+      ...initialFilterState(),
+      search: STAFF_OF_HOMA.name.slice(0, 3).toUpperCase(),
+    };
 
-    const result = filterWeapons(WEAPONS, filters, ownedIds);
+    const result = filterWeapons(SAMPLE, filters, ownedIds);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('staff-of-homa');
+    expect(idsOf(result)).toEqual([STAFF_OF_HOMA.id]);
   });
 
   it('filters by weapon type', () => {
-    const filters = {
-      ...initialFilterState(),
-      weaponTypes: new Set<Weapon['type']>(['Polearm']),
-    };
+    const filters = { ...initialFilterState(), weaponTypes: new Set([THE_CATCH.type]) };
 
-    const result = filterWeapons(WEAPONS, filters, ownedIds);
+    const result = filterWeapons(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
-    expect(result.every((w) => w.type === 'Polearm')).toBe(true);
+    expect(result.every((w) => w.type === THE_CATCH.type)).toBe(true);
   });
 
   it('filters by rarity', () => {
-    const filters = { ...initialFilterState(), rarities: new Set<Weapon['rarity']>([5]) };
+    const filters = { ...initialFilterState(), rarities: new Set([AMOS_BOW.rarity]) };
 
-    const result = filterWeapons(WEAPONS, filters, ownedIds);
+    const result = filterWeapons(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
-    expect(result.every((w) => w.rarity === 5)).toBe(true);
+    expect(result.every((w) => w.rarity === AMOS_BOW.rarity)).toBe(true);
   });
 
   it('filters by ownership: owned', () => {
     const filters = { ...initialFilterState(), ownership: 'owned' as const };
 
-    const result = filterWeapons(WEAPONS, filters, ownedIds);
+    const result = filterWeapons(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
     expect(result.every((w) => ownedIds.has(w.id))).toBe(true);
@@ -78,7 +74,7 @@ describe('filterWeapons', () => {
   it('filters by ownership: unowned', () => {
     const filters = { ...initialFilterState(), ownership: 'unowned' as const };
 
-    const result = filterWeapons(WEAPONS, filters, ownedIds);
+    const result = filterWeapons(SAMPLE, filters, ownedIds);
 
     expect(result).toHaveLength(2);
     expect(result.every((w) => !ownedIds.has(w.id))).toBe(true);
@@ -91,16 +87,18 @@ describe('filterWeapons', () => {
       sortDirection: 'asc' as const,
     };
 
-    const result = filterWeapons(WEAPONS, filters, ownedIds);
+    const result = filterWeapons(SAMPLE, filters, ownedIds);
 
-    expect(result[0].name).toBe("Amos' Bow");
-    expect(result[result.length - 1].name).toBe('The Catch');
+    // `The Catch` leads because its canonical name carries the quotation marks
+    // the game prints around it, and `localeCompare` orders those before letters.
+    expect(result.map((w) => w.name)).toEqual(
+      [THE_CATCH, AMOS_BOW, FAVONIUS_SWORD, STAFF_OF_HOMA].map((w) => w.name),
+    );
   });
 
   it('sorts by release descending (default)', () => {
-    const result = filterWeapons(WEAPONS, initialFilterState(), ownedIds);
+    const result = filterWeapons(SAMPLE, initialFilterState(), ownedIds);
 
-    // Version 2.1 should come first
-    expect(result[0].id).toBe('the-catch');
+    expect(idsOf(result)).toEqual(idsOf([THE_CATCH, STAFF_OF_HOMA, FAVONIUS_SWORD, AMOS_BOW]));
   });
 });


### PR DESCRIPTION
## Summary

The collection filtering and item summary suites drew `Character`/`Weapon`
fixtures from hand-written literals, so #944 had to edit four files to add one
field and the values could silently diverge from the generated roster. They now
index `CHARACTERS`/`WEAPONS` by ID, and the two filtering suites collapse onto a
single `filtered(overrides)` helper so each case is one statement.

## Gotchas

- **The weapon name-sort order changed.** `The Catch` is stored as
  `'"The Catch"'` — the game prints quotation marks around it, and
  `localeCompare` sorts those ahead of letters. The old literal dropped them, so
  the fixture had been sorting in a position the real roster never produces.
- **`combines multiple filters` was vacuous and the sample changed to fix it.**
  The character suite owned exactly its two Pyro entries, so the combined case
  asserted the set an `or` would also return. Owning Ganyu instead of Xiangling
  separates the groups; the case now expects one entry, not two. This is a
  behaviour change to a test, not a refactoring — called out rather than folded
  in silently.
- **The two filtering suites stay separate** despite being near-identical in
  shape. Extracting a shared parameterized suite is the same call as #612, which
  is not-planned until a third collection type lands.
- **Indexing the record, not `getCharacterById`.** The issue suggested the
  lookup helpers; they answer `Character | undefined`, which costs every fixture
  a non-null assertion. `CHARACTERS.amber` is non-optional and a bad ID is a
  `tsc` error.
- **The icon `src` literals stay spelled out** in both summary suites. Nothing
  else covers the element/weapon-type to filename mapping, so reading them back
  through `getElementIconPath` would assert the helper against itself. Those two
  files carry no other change beyond one trimmed comment — their duplicated
  `render`-then-query pair is two occurrences, under the rule of three.

## Verification

- `pnpm vitest run` in `apps/web`: 290 passed, same 19 cases across the two
  filtering suites as before the refactor. Under `pnpm turbo run test` five
  unrelated suites (`filter-bar`, `footer`, `teams-page`, `artifact-planner`)
  hit their 5s/30s timeouts from host contention; they pass when web runs alone.

Closes #945
