### PR TITLE
fix(ci): poll version.json for the deployed SHA

### DIFF
--- a/apps/web/scripts/verify-deployment.sh
+++ b/apps/web/scripts/verify-deployment.sh
@@ -16,17 +16,14 @@ SLEEP_SECONDS="${SLEEP_SECONDS:-3}"
 VERSION_URL="$DOMAIN/version.json"
 CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 
-# Empty when the edge answers with no SHA at all. Mid-propagation a request can
-# 404, which is a stale edge rather than a failed deploy, so it has to compare
-# unequal and be retried instead of aborting the script.
+# A 404 mid-propagation is a stale edge, not a failed deploy. Answering empty
+# keeps it in the retry loop.
 deployed_sha() {
   curl -fsSL "$VERSION_URL" | jq -r '.sha' || true
 }
 
 # Firebase reports a release complete before every CDN edge serves it, so the
-# first read of version.json can still carry the previous deploy's SHA. Poll
-# until the expected SHA appears rather than calling propagation lag a failed
-# deploy.
+# first read can still carry the previous deploy's SHA.
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   [ "$attempt" -eq 1 ] || sleep "$SLEEP_SECONDS"
 

--- a/apps/web/scripts/verify-deployment.sh
+++ b/apps/web/scripts/verify-deployment.sh
@@ -10,7 +10,7 @@ REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
 DOMAIN="${1:?Error: domain URL is required as first argument}"
 
-MAX_ATTEMPTS="${MAX_ATTEMPTS:-20}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-10}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-3}"
 
 VERSION_URL="$DOMAIN/version.json"

--- a/apps/web/scripts/verify-deployment.sh
+++ b/apps/web/scripts/verify-deployment.sh
@@ -13,7 +13,15 @@ DOMAIN="${1:?Error: domain URL is required as first argument}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-20}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-3}"
 
+VERSION_URL="$DOMAIN/version.json"
 CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
+
+# Empty when the edge answers with no SHA at all. Mid-propagation a request can
+# 404, which is a stale edge rather than a failed deploy, so it has to compare
+# unequal and be retried instead of aborting the script.
+deployed_sha() {
+  curl -fsSL "$VERSION_URL" | jq -r '.sha' || true
+}
 
 # Firebase reports a release complete before every CDN edge serves it, so the
 # first read of version.json can still carry the previous deploy's SHA. Poll
@@ -22,12 +30,12 @@ CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   [ "$attempt" -eq 1 ] || sleep "$SLEEP_SECONDS"
 
-  DEPLOYED=$(curl -fsSL "$DOMAIN/version.json" | jq -r '.sha') || DEPLOYED=''
+  DEPLOYED_SHA=$(deployed_sha)
 
-  if [ "$CURRENT_SHA" = "$DEPLOYED" ]; then
+  if [ "$CURRENT_SHA" = "$DEPLOYED_SHA" ]; then
     exit 0
   fi
 done
 
-echo "SHA mismatch after $MAX_ATTEMPTS attempts: deployed=${DEPLOYED:-} current=$CURRENT_SHA" >&2
+echo "SHA mismatch after $MAX_ATTEMPTS attempts: deployed=${DEPLOYED_SHA:-} current=$CURRENT_SHA" >&2
 exit 1

--- a/apps/web/scripts/verify-deployment.sh
+++ b/apps/web/scripts/verify-deployment.sh
@@ -10,10 +10,24 @@ REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
 DOMAIN="${1:?Error: domain URL is required as first argument}"
 
-CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
-DEPLOYED=$(curl -fsSL "$DOMAIN/version.json" | jq -r '.sha')
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-20}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-3}"
 
-[ "$CURRENT_SHA" = "$DEPLOYED" ] || {
-  echo "SHA mismatch: deployed=$DEPLOYED current=$CURRENT_SHA" >&2
-  exit 1
-}
+CURRENT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
+
+# Firebase reports a release complete before every CDN edge serves it, so the
+# first read of version.json can still carry the previous deploy's SHA. Poll
+# until the expected SHA appears rather than calling propagation lag a failed
+# deploy.
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  [ "$attempt" -eq 1 ] || sleep "$SLEEP_SECONDS"
+
+  DEPLOYED=$(curl -fsSL "$DOMAIN/version.json" | jq -r '.sha') || DEPLOYED=''
+
+  if [ "$CURRENT_SHA" = "$DEPLOYED" ]; then
+    exit 0
+  fi
+done
+
+echo "SHA mismatch after $MAX_ATTEMPTS attempts: deployed=${DEPLOYED:-} current=$CURRENT_SHA" >&2
+exit 1


### PR DESCRIPTION
Closes #947

The Web deploy job's `Verify` step read `version.json` once, sub-second after Firebase said "release complete", so any CDN edge still serving the previous release failed the job on a deploy that had succeeded. It now polls until the expected SHA shows up, on the same `MAX_ATTEMPTS`/`SLEEP_SECONDS` defaults as `apps/api/scripts/verify-deployment.ts`.

## Gotchas

**`curl --retry` can't express this.** It retries transient transport and status errors only — timeout, FTP 4xx, HTTP 408/429/500/502/503/504. The failure here is a **200** carrying a stale SHA, which no flag combination reaches. Hence the hand-rolled loop.

**A failed read no longer aborts.** `deployed_sha()` swallows a non-zero `curl` so an edge that 404s mid-propagation compares unequal and gets retried instead of killing the script. The trade: a domain that is permanently broken, or a missing `jq`, now burns the full window before reporting, and reports as a SHA mismatch with an empty `deployed=`.

**Attempt-bounded, not deadline-bounded.** `scripts/verify-dev.sh` polls with a `TIMEOUT_SECONDS` deadline and would have been the other house pattern to copy. This script pairs with the API's deploy verification rather than with the dev smoke test, so it keeps the attempt/sleep vocabulary; worth knowing the repo now has both shapes.

**DSGEP-002 needs no edit.** Its verification section says the script "compares deployed `version.json` SHA to `git rev-parse --short HEAD`", which polling doesn't falsify.
