### PR TITLE
docs: make AGENTS.md the canonical agent instructions

### DIFF
--- a/.claude/commands/new-issue.md
+++ b/.claude/commands/new-issue.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Bash, Grep, Glob
 # New GitHub issue
 
 Follow the workflow guardrails in
-[`copilot-instructions.md`](../../.github/copilot-instructions.md).
+[`AGENTS.md`](../../AGENTS.md).
 
 Input: **$ARGUMENTS**
 

--- a/.claude/commands/update-game-data.md
+++ b/.claude/commands/update-game-data.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 # Update game data
 
 Follow the conventions in
-[`copilot-instructions.md`](../../.github/copilot-instructions.md).
+[`AGENTS.md`](../../AGENTS.md).
 
 Add or update game data in `packages/game-data`. Characters and weapons are
 generated from `genshin-db`; their how-tos below cover regeneration. For

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -64,5 +64,6 @@ ignore:
   - CHANGELOG.md
   - LICENSE
   - CONTRIBUTING.md
+  - AGENTS.md
   - CLAUDE.md
   - pnpm-lock.yaml

--- a/.vale.ini
+++ b/.vale.ini
@@ -28,5 +28,5 @@ alex.ProfanityUnlikely = NO
 
 # AI instruction files: spelling and terminology, no voice rules. BasedOnStyles
 # replaces the inherited list rather than extending it, so no opt-outs needed.
-[{CLAUDE.md,.github/copilot-instructions.md,.claude/commands/*.md}]
+[{AGENTS.md,CLAUDE.md,.claude/commands/*.md}]
 BasedOnStyles = Vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -28,5 +28,7 @@ alex.ProfanityUnlikely = NO
 
 # AI instruction files: spelling and terminology, no voice rules. BasedOnStyles
 # replaces the inherited list rather than extending it, so no opt-outs needed.
+# A new instruction file belongs in this glob; left to the default it lints for
+# prose voice, and the findings won't say why.
 [{AGENTS.md,CLAUDE.md,.claude/commands/*.md}]
 BasedOnStyles = Vale

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ same shape — point here, then carry nothing but its own specifics.
 - `packages/domain`: Shared domain model: types, invariants, and wire format representations.
 - `packages/collection-json`, `packages/validation`: Wire format and schema validation.
 - `tools/game-data-codegen`: CLI that generates `game-data` sources like `weapons.generated.ts` from `genshin-db`. Never hand-edit generated files.
+- `tools/e2e`: Playwright end-to-end specs.
 - `infrastructure`: Terraform.
 - `docs`: Diátaxis-organized how-tos, references, and explanations.
 
@@ -55,6 +56,11 @@ pnpm reuse:check  # SPDX license compliance check
 - Never leave `console.log` in production code; use structured logging or remove it.
 - Use zustand for UI state, TanStack Query for server state, and `@genshin/game-data` helpers for static game data. Don't put async or fetch logic in a zustand store.
 - For comments, documentation strings, naming, React components, and test structure, follow [Code conventions](docs/reference/code-conventions.md).
+
+## Secrets
+
+Never hard-code a secret anywhere in the repository — source, shell script,
+Terraform, or workflow. Read it from an environment variable.
 
 ## Build and CI rules
 
@@ -131,18 +137,16 @@ writing tests.
   - Case corrections and preference enforcement (`firebase` to `Firebase`, `npm` to `pnpm`): add to `reject.txt` as substitution rules.
 - Don't modify third-party Vale styles generated under `.styles/`, except `.styles/config/`.
 
-## Changelog rules
+## Changelog
 
-- `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with sections relative to the previous release rather than the previous commit.
-- Write entries from the user's perspective: what someone using the app can see or do. One bullet per user-visible change.
-- Leave out infrastructure, CI/CD, developer tooling, dependency updates, refactors, and internal package changes. Those are invisible to users.
-- Don't name technology choices such as "zustand store" or "TanStack Query" unless the user interacts with that technology directly.
-- Before the first release, only **Added** applies; the other sections need a released baseline to compare against.
+Which changes earn an entry, and how to word one, is in the changelog section
+of [`CONTRIBUTING.md`](CONTRIBUTING.md); the layout the entries sit in is
+described by the [`CHANGELOG.md`](CHANGELOG.md) header itself. Read both before
+adding a line.
 
 ## Workflow guardrails
 
 - Never bypass pre-commit with `--no-verify`; fix root causes.
-- Run `pnpm typecheck` manually because it's not part of local pre-commit hooks.
 - Never use `git commit --amend` or `git push --force`.
 - At session start, check `git status` for pre-existing modified files outside the task's scope; don't attribute their breakage to the current change.
 - Commit message format is in [`CONTRIBUTING.md`](CONTRIBUTING.md); the pull request title carries it, since squash merge makes that title the commit.
@@ -156,7 +160,6 @@ writing tests.
 
 - Start Bash scripts with `set -euo pipefail` and `set -x`.
 - Use `curl -fsSL` for network fetches.
-- Never hard-code secrets; use environment variables.
 - Quote `${{ inputs.* }}` expansions in GitHub Actions composite action `run` steps to prevent shell word-splitting.
 
 ## DevContainer rules
@@ -177,7 +180,7 @@ is configured in `.vscode/mcp.json`.
 - Apply environment labels on creation with `gcloud alpha projects update --update-labels=environment=VALUE`.
 - Enable Google Cloud APIs on demand when required by active work.
 - The Terraform version is set once per workflow as the `TERRAFORM_VERSION` environment variable. When changing it, keep every workflow that declares it aligned.
-- Terraform files need SPDX headers using `#` comment syntax. Never hard-code secrets; use environment variables.
+- Terraform files need SPDX headers using `#` comment syntax.
 
 ## Docker rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@ AI decision rules, canonical for every coding agent. Human contribution
 guidance lives in [`CONTRIBUTING.md`](CONTRIBUTING.md) and
 [`docs/reference/`](docs/reference/); linters cover everything else.
 
-Keep this filename. Copilot, Cursor, Codex, and Gemini CLI read `AGENTS.md`
-directly; Claude Code doesn't, so [`CLAUDE.md`](CLAUDE.md) imports this file
-and adds only what's true of Claude Code alone. A new tool config follows the
-same shape — point here, then carry nothing but its own specifics.
+Keep this filename: it's the path coding agents look for. Claude Code is the
+exception and reads [`CLAUDE.md`](CLAUDE.md), which imports this file. Adding a
+config for another tool follows the pattern in
+[Code conventions](docs/reference/code-conventions.md).
 
 ## Snapshot
 
@@ -140,9 +140,8 @@ writing tests.
 ## Changelog
 
 Which changes earn an entry, and how to word one, is in the changelog section
-of [`CONTRIBUTING.md`](CONTRIBUTING.md); the layout the entries sit in is
-described by the [`CHANGELOG.md`](CHANGELOG.md) header itself. Read both before
-adding a line.
+of [`CONTRIBUTING.md`](CONTRIBUTING.md). The [`CHANGELOG.md`](CHANGELOG.md)
+header describes the layout they sit in. Read both before adding a line.
 
 ## Workflow guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,16 @@
 <!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
 <!-- SPDX-License-Identifier: MIT -->
 
-# GitHub Copilot instructions for genshin.dungeon.studio
+# Agent instructions for genshin.dungeon.studio
 
-AI decision rules. Human contribution guidance lives in
-[`CONTRIBUTING.md`](../CONTRIBUTING.md) and
-[`docs/reference/`](../docs/reference/); linters cover everything else.
+AI decision rules, canonical for every coding agent. Human contribution
+guidance lives in [`CONTRIBUTING.md`](CONTRIBUTING.md) and
+[`docs/reference/`](docs/reference/); linters cover everything else.
 
-Keep this filename. GitHub Copilot reads this exact path, and root
-[`CLAUDE.md`](../CLAUDE.md) points here for detailed conventions. It's the only
-per-repository instruction file either tool loads.
+Keep this filename. Copilot, Cursor, Codex, and Gemini CLI read `AGENTS.md`
+directly; Claude Code doesn't, so [`CLAUDE.md`](CLAUDE.md) imports this file
+and adds only what's true of Claude Code alone. A new tool config follows the
+same shape — point here, then carry nothing but its own specifics.
 
 ## Snapshot
 
@@ -22,11 +23,26 @@ per-repository instruction file either tool loads.
 
 ## Repository map
 
-- `apps/web`: Frontend app.
-- `apps/api`: API server.
+- `apps/web`: Frontend app. Vite dev server on port 5173.
+- `apps/api`: API server. Hono on port 8080.
 - `packages/game-data`: Source of truth for static game data; use exported helpers, never hard-code.
 - `packages/domain`: Shared domain model: types, invariants, and wire format representations.
+- `packages/collection-json`, `packages/validation`: Wire format and schema validation.
 - `tools/game-data-codegen`: CLI that generates `game-data` sources like `weapons.generated.ts` from `genshin-db`. Never hand-edit generated files.
+- `infrastructure`: Terraform.
+- `docs`: Diátaxis-organized how-tos, references, and explanations.
+
+## Commands
+
+```bash
+pnpm dev          # Start all dev servers + Firebase emulators
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+pnpm format
+pnpm reuse:check  # SPDX license compliance check
+```
 
 ## Core coding rules
 
@@ -38,7 +54,7 @@ per-repository instruction file either tool loads.
 - Use ISO 8601 strings for timestamps such as `createdAt` and `updatedAt`, not `Date` objects.
 - Never leave `console.log` in production code; use structured logging or remove it.
 - Use zustand for UI state, TanStack Query for server state, and `@genshin/game-data` helpers for static game data. Don't put async or fetch logic in a zustand store.
-- For comments, documentation strings, naming, React components, and test structure, follow [Code conventions](../docs/reference/code-conventions.md).
+- For comments, documentation strings, naming, React components, and test structure, follow [Code conventions](docs/reference/code-conventions.md).
 
 ## Build and CI rules
 
@@ -50,7 +66,7 @@ per-repository instruction file either tool loads.
 
 ## API design rules
 
-- Use the [REST API conventions reference](../docs/reference/rest-api-conventions.md) for route shape, methods, status codes, error format, pagination, and auth handling.
+- Use the [REST API conventions reference](docs/reference/rest-api-conventions.md) for route shape, methods, status codes, error format, pagination, and auth handling.
 - All error responses use RFC 9457 Problem Details (`application/problem+json`) via `apps/api/src/http/problem.ts`. Always include a `detail` field, even for generic errors, to keep a stable schema for clients.
 - List endpoints use cursor-based pagination (`limit` and `cursor`).
 - Prefer explicit types over type munging. For example, define `ProfileUpdate` rather than using `Partial<Pick<UserProfile, 'name'>>` inline.
@@ -60,15 +76,15 @@ per-repository instruction file either tool loads.
 
 - Define each JSON Schema as a typed TypeScript module in `apps/api/src/profiles/json-schema/{module}/`, not a `.json` file.
 - Export a single `const` using `as const satisfies JsonSchemaProfile` from `@/profiles/json-schema/json-schema-profile.js`.
-- Name files `{method}-{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). `{method}` is the lowercase HTTP method and `{direction}` is `request` or `response`. The serving path mirrors the filename: `/profiles/json-schema/{module}/{method}-{direction}-v{n}.json`. See [DSGEP-005](../docs/explanation/dsgep-005-schema-direction-segment.md).
+- Name files `{method}-{direction}-v{n}.ts` (for example, `get-response-v1.ts`, `put-request-v1.ts`). `{method}` is the lowercase HTTP method and `{direction}` is `request` or `response`. The serving path mirrors the filename: `/profiles/json-schema/{module}/{method}-{direction}-v{n}.json`. See [DSGEP-005](docs/explanation/dsgep-005-schema-direction-segment.md).
 - Register every schema module in `apps/api/src/profiles/json-schema/registry.ts`. The registry completeness test discovers files on disk and asserts the registry contains each one.
 - The schema route stamps `$id` from the request origin at serve time. Don't declare `$id` in schema modules.
 
 ## Testing
 
 Test alongside code. What to assert is in the testing principles in
-[`CONTRIBUTING.md`](../CONTRIBUTING.md); how to shape a test is in
-[Code conventions](../docs/reference/code-conventions.md). Read both before
+[`CONTRIBUTING.md`](CONTRIBUTING.md); how to shape a test is in
+[Code conventions](docs/reference/code-conventions.md). Read both before
 writing tests.
 
 ## Frontend rules
@@ -90,15 +106,15 @@ writing tests.
 - Declare every direct import explicitly, even when the same package exists at the root. Enforced by `import-x/no-extraneous-dependencies` in every workspace `eslint.config.js`; `devDependencies` may appear in test files (`*.test.ts`, `**/test/**`) and tooling configs (`eslint.config.js`, `*.config.{ts,js}`) but never in production source.
 - Classify packages correctly: `dependencies` for runtime code shipped to production, `devDependencies` for build tools, plugins, type definitions, and local tooling.
 - `pnpm-workspace.yaml` declares workspace package globs and engine constraints only; don't use it for version overrides.
-- Run `pnpm install` and commit `pnpm-lock.yaml` after dependency changes. Use `pnpm why <package>` to detect duplicate transitive versions.
+- Run `pnpm install` and commit `pnpm-lock.yaml` after dependency changes. Use `pnpm why <package>` to detect duplicate transitive versions. Restart any running dev server too: Vite caches module resolution at startup, so a stale server throws misleading `Cannot find module` errors.
 - New workspace packages should match the root `package.json` metadata fields (`description`, `keywords`, `author`, `homepage`, `bugs`, `license`).
 - ESLint uses flat config via workspace-local `eslint.config.js` files; configure ignore patterns with `ignores`, not `.eslintignore`.
 
 ## Documentation rules
 
-- Place guidance at the highest-priority location that fits, following the documentation strategy in [Code conventions](../docs/reference/code-conventions.md). Don't duplicate guidance across files; link to the canonical source.
+- Place guidance at the highest-priority location that fits, following the documentation strategy in [Code conventions](docs/reference/code-conventions.md). Don't duplicate guidance across files; link to the canonical source.
 - Keep docs accurate to `HEAD`: verify dependencies, command availability, and feature status. State plans explicitly as planned or not yet implemented.
-- Every source file needs SPDX headers. For files without comment syntax, declare them in `REUSE.toml`; see [How to add SPDX headers to new files](../docs/how-tos/add-spdx-headers.md).
+- Every source file needs SPDX headers. For files without comment syntax, declare them in `REUSE.toml`; see [How to add SPDX headers to new files](docs/how-tos/add-spdx-headers.md).
 - Wrap file and directory paths in backticks in prose and YAML metadata (for example, `apps/web`, `packages/game-data/src/index.ts`). Markdown link targets don't need backticks.
 - When adding features, keep these descriptions in sync: `package.json` `description`, `README.md` tagline or summary, and `CONTRIBUTING.md` references to commands or scripts.
 
@@ -128,6 +144,8 @@ writing tests.
 - Never bypass pre-commit with `--no-verify`; fix root causes.
 - Run `pnpm typecheck` manually because it's not part of local pre-commit hooks.
 - Never use `git commit --amend` or `git push --force`.
+- At session start, check `git status` for pre-existing modified files outside the task's scope; don't attribute their breakage to the current change.
+- Commit message format is in [`CONTRIBUTING.md`](CONTRIBUTING.md); the pull request title carries it, since squash merge makes that title the commit.
 - Fixes after hook failures should be new commits; squash merge handles cleanup.
 - Track issue dependencies only with native GitHub issue relationships (`blocked by` and `is blocking`), not issue body text or comments.
 - Prefer filing follow-up issues for out-of-scope concerns over expanding a pull request.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,71 +3,17 @@ SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 
-# genshin.dungeon.studio
+# Claude Code instructions for genshin.dungeon.studio
 
-AI-powered team building companion for Genshin Impact.
+Claude Code doesn't read `AGENTS.md`, so this file imports it. Add a rule here
+only when it's false for every other agent; everything else belongs in
+[`AGENTS.md`](AGENTS.md).
 
-## Stack
+@AGENTS.md
 
-Turborepo + pnpm monorepo. TypeScript strict mode throughout. Versions live
-in `package.json` files.
+## Claude Code only
 
-- **Web**: React, Vite, Tailwind, shadcn/ui, zustand, TanStack Query, react-router-dom
-- **API**: Hono + Node.js, Firestore, Firebase Auth, Vitest
-
-## Repository structure
-
-- `apps/web/` --- Frontend (Vite dev server, port 5173)
-- `apps/api/` --- API server (Hono, port 8080)
-- `packages/domain/` --- Shared domain model and branded types
-- `packages/game-data/` --- Static game data; use exported helpers, never hard-code
-- `packages/collection-json/`, `packages/validation/`
-- `tools/game-data-codegen/` --- generates `game-data` sources from `genshin-db`
-- `infrastructure/` --- Terraform IaC
-- `docs/` --- Diátaxis-organized how-tos, references, explanations
-
-## Commands
-
-```bash
-pnpm dev          # Start all dev servers + Firebase emulators
-pnpm build
-pnpm typecheck    # not in pre-commit; run manually
-pnpm test
-pnpm lint
-pnpm format
-pnpm reuse:check  # SPDX license compliance check
-```
-
-Always use `pnpm turbo run <task>` for `build`, `typecheck`, and `test`. Never
-use raw `pnpm --filter <pkg> <task>` because pnpm doesn't automatically build
-workspace dependencies first. Turbo handles dependency ordering via `^build`.
-
-## Key rules
-
-- Every source file needs SPDX headers. See `docs/how-tos/add-spdx-headers.md`.
-  For files without comment syntax, declare them in `REUSE.toml`.
-- Conventional commits, gated on the PR title only: `feat:`, `fix:`, `docs:`,
-  `style:`, `refactor:`, `perf:`, `test:`, `build:`, `ci:`, `chore:`,
-  `revert:`; subject lowercase, no trailing period.
-- Never bypass pre-commit with `--no-verify`; fix root causes.
-- Never use `git commit --amend` or `git push --force`.
-- Fixes after hook failures should be new commits; squash merge handles cleanup.
-- At session start, check `git status` for pre-existing `M` files outside your
-  task's scope; don't attribute their breakage to your changes.
-- After changing `pnpm-lock.yaml`, run `pnpm install` and restart any running
-  dev server. Vite caches module resolution at startup, so a stale server throws
-  misleading `Cannot find module` errors.
 - Sessions run on the host, not in the project's container, so pnpm, Firebase
-  CLI, pre-commit, Vale, REUSE, and Playwright may be absent. Check availability
-  before relying on a tool; note it as missing rather than failing.
-- Run `pre-commit run vale --all-files` for Vale, not `vale .`. Vale has no
-  directory-ignore and scans `node_modules`.
-- API error responses use RFC 9457 Problem Details, `application/problem+json`.
-- Testing: follow the Testing section in `CONTRIBUTING.md` (test behavior not
-  values, `satisfies` for fixtures, one schema assertion per route test then a
-  spot check).
-
-## Detailed coding rules
-
-See `.github/copilot-instructions.md` for comprehensive conventions covering API
-design, frontend patterns, schema modules, infrastructure, Docker, and more.
+  CLI, pre-commit, Vale, REUSE, and Playwright may be absent. Check
+  availability before relying on a tool; report it as missing rather than
+  failing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,12 @@ SPDX-License-Identifier: MIT
 
 # Claude Code instructions for genshin.dungeon.studio
 
-Claude Code doesn't read `AGENTS.md`, so this file imports it. Add a rule here
-only when it's false for every other agent; everything else belongs in
-[`AGENTS.md`](AGENTS.md).
+Claude Code reads this file and not `AGENTS.md`, so the import below pulls the
+repository's agent rules in. Add a rule here only when it's false for every
+other agent.
 
 @AGENTS.md
 
-## Claude Code only
-
-- Sessions run on the host, not in the project's container, so pnpm, Firebase
-  CLI, pre-commit, Vale, REUSE, and Playwright may be absent. Check
-  availability before relying on a tool; report it as missing rather than
-  failing.
+Sessions run on the host, not in the project's container, so pnpm, Firebase
+CLI, pre-commit, Vale, REUSE, and Playwright may be absent. Check availability
+before relying on a tool; report it as missing rather than failing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,11 +162,6 @@ When a commit needs a body, separate it from the subject with a blank line, wrap
 
 1. Address feedback completely
 2. Batch related fixes when possible
-3. Pre-commit hooks verify formatting and linting. For type checking, run:
-
-   ```bash
-   pnpm typecheck
-   ```
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ When a commit needs a body, separate it from the subject with a blank line, wrap
 
 When your pull request changes something a user of the deployed app would notice—a new or removed feature, a change to existing behavior, a user-facing bug fix, or a security fix—add a line under `### Added` in the `[Unreleased]` section, one bullet per change. Skip internal refactors, test-only changes, dependency bumps users don't perceive, and documentation fixes. The test is whether a user would notice or care. The [CHANGELOG.md](CHANGELOG.md) header describes the entry layout before and after the first release.
 
-Write the entry from the user's side of the screen. Name a technology—"zustand store," "TanStack Query"—only when the user interacts with that technology directly.
+Name a technology—"zustand store," "TanStack Query"—only when the user interacts with that technology directly.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,9 @@ When a commit needs a body, separate it from the subject with a blank line, wrap
 
 [CHANGELOG.md](CHANGELOG.md) is hand-curated and follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). It's a separate artifact from the GitHub Release notes that [Release Drafter](.github/release-drafter.yml) aggregates from merged pull requests: the release notes stay pull-request-centric for GitHub readers, while the changelog stays curated for humans.
 
-When your pull request changes something a user of the deployed app would notice—a new or removed feature, a change to existing behavior, a user-facing bug fix, or a security fix—add a line under `### Added` in the `[Unreleased]` section. Skip internal refactors, test-only changes, dependency bumps users don't perceive, and documentation fixes. The test is whether a user would notice or care. The [CHANGELOG.md](CHANGELOG.md) header describes the entry layout before and after the first release.
+When your pull request changes something a user of the deployed app would notice—a new or removed feature, a change to existing behavior, a user-facing bug fix, or a security fix—add a line under `### Added` in the `[Unreleased]` section, one bullet per change. Skip internal refactors, test-only changes, dependency bumps users don't perceive, and documentation fixes. The test is whether a user would notice or care. The [CHANGELOG.md](CHANGELOG.md) header describes the entry layout before and after the first release.
+
+Write the entry from the user's side of the screen. Name a technology—"zustand store," "TanStack Query"—only when the user interacts with that technology directly.
 
 ---
 

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -42,11 +42,6 @@ Avoid duplicating the same guidance across multiple locations. Place it once at 
 
 A rule holding for more than one tool belongs in `AGENTS.md`.
 
-A new root-level instruction file needs two entries before it passes the gate:
-
-- An ignore in [`.ls-lint.yml`](../../.ls-lint.yml), which otherwise rejects the upper-case name.
-- A section in [`.vale.ini`](../../.vale.ini), so Vale checks it mechanically instead of for prose voice.
-
 ## Naming conventions
 
 Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`.

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -38,11 +38,14 @@ Avoid duplicating the same guidance across multiple locations. Place it once at 
 
 ### AI tool configuration files
 
-`AGENTS.md` is the canonical home for AI decision rules, and every tool config reduces to a pointer at it. Copilot, Cursor, Codex, and Gemini CLI read `AGENTS.md` directly, so they need no file of their own. Claude Code reads only `CLAUDE.md`, so [`CLAUDE.md`](../../CLAUDE.md) imports `AGENTS.md` with `@AGENTS.md` and adds nothing beyond what's false for every other agent.
+`AGENTS.md` holds the AI decision rules. A tool that reads `AGENTS.md` needs no file of its own. A tool that reads only its own path gets a file pointing at `AGENTS.md`, carrying nothing but behavior specific to that tool. Claude Code is the second case today: [`CLAUDE.md`](../../CLAUDE.md) imports `AGENTS.md` and adds only rules that are false for every other agent.
 
-Add a config for a new tool the same way: point it at `AGENTS.md` if the tool can't read that path itself, and put only tool-specific behavior in the new file. A rule that holds for more than one tool belongs in `AGENTS.md` instead.
+A rule holding for more than one tool belongs in `AGENTS.md`.
 
-A new root-level instruction file also needs an ignore entry in [`.ls-lint.yml`](../../.ls-lint.yml), which otherwise rejects the upper-case name, and a section entry in [`.vale.ini`](../../.vale.ini) so Vale checks it mechanically rather than for prose voice.
+A new root-level instruction file needs two entries before it passes the gate:
+
+- An ignore in [`.ls-lint.yml`](../../.ls-lint.yml), which otherwise rejects the upper-case name.
+- A section in [`.vale.ini`](../../.vale.ini), so Vale checks it mechanically instead of for prose voice.
 
 ## Naming conventions
 

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -32,9 +32,17 @@ When documenting decisions or conventions, prefer the highest-priority location 
 2. **Documentation strings**: explain module or function purpose when the name isn't sufficient.
 3. **`docs/`**: task-specific how-tos, references, and explanations following the [Diátaxis](https://diataxis.fr/) framework.
 4. **`CONTRIBUTING.md`**: high-level human workflow guidance and project conventions.
-5. **`.github/copilot-instructions.md`**: AI-specific decision rules.
+5. **`AGENTS.md`**: AI-specific decision rules.
 
 Avoid duplicating the same guidance across multiple locations. Place it once at the most appropriate level and link to it from others.
+
+### AI tool configuration files
+
+`AGENTS.md` is the canonical home for AI decision rules, and every tool config reduces to a pointer at it. Copilot, Cursor, Codex, and Gemini CLI read `AGENTS.md` directly, so they need no file of their own. Claude Code reads only `CLAUDE.md`, so [`CLAUDE.md`](../../CLAUDE.md) imports `AGENTS.md` with `@AGENTS.md` and adds nothing beyond what's false for every other agent.
+
+Add a config for a new tool the same way: point it at `AGENTS.md` if the tool can't read that path itself, and put only tool-specific behavior in the new file. A rule that holds for more than one tool belongs in `AGENTS.md` instead.
+
+A new root-level instruction file also needs an ignore entry in [`.ls-lint.yml`](../../.ls-lint.yml), which otherwise rejects the upper-case name, and a section entry in [`.vale.ini`](../../.vale.ini) so Vale checks it mechanically rather than for prose voice.
 
 ## Naming conventions
 

--- a/tools/e2e/playwright.config.ts
+++ b/tools/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ import { defineConfig, devices } from '@playwright/test';
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 
 // Artifacts land outside the workspace so no gitignore entry has to keep pace
-// with them; see .github/copilot-instructions.md.
+// with them; see AGENTS.md.
 const artifactRoot = '/tmp/genshin-e2e';
 
 // Ports match apps/api/src/main.ts and vite.config.ts. The host has to be


### PR DESCRIPTION
Closes #877

`AGENTS.md` is the canonical home for AI decision rules. `CLAUDE.md` imports it with `@AGENTS.md` and keeps one rule; `.github/copilot-instructions.md` is deleted. Two of #877's scope bullets were already done by #1197 and #949.

## Gotchas

- **#1197's reason for duplicating the repository map was wrong.** It kept a copy in both files because "only the latter auto-loads for Copilot and only the former for Claude." [GitHub's docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions) list `CLAUDE.md` among the files Copilot's cloud agent reads. Dropping that duplication — plus the repeated stack snapshot, `turbo run` rule, SPDX, Vale, and workflow guardrails — is most of the line reduction.
- **Deleting the Copilot file loses no coverage.** Copilot reads `AGENTS.md` with no repo config, and was already unused here: absent from `.vscode/extensions.json` and every workflow. `CLAUDE.md` survives only because Claude Code reads that path and not `AGENTS.md`; [its docs](https://code.claude.com/docs/en/memory#agents-md) prescribe the import.
- **One rule was false at HEAD.** "Run `pnpm typecheck` manually because it's not in pre-commit" outlived #1379, which made it a hook with `always_run: true`. Putting the two files side by side is what exposed it. A second copy in `CONTRIBUTING.md` went with it.
- **Deleted rules moved rather than vanished.** The changelog section now points at `CONTRIBUTING.md` and the `CHANGELOG.md` header; the one rule stated nowhere else moved into `CONTRIBUTING.md`. #1419 tracks the rest of that file, which fails the same test.
