### PR TITLE
docs: leave only unenforceable conventions in code-conventions.md

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -110,6 +110,16 @@ export default defineConfig([
       // A `renderHook` wrapper closes over per-test state and never remounts on
       // a parent re-render, so the rule's premise does not hold.
       '@eslint-react/no-nested-component-definitions': 'off',
+      'testing-library/prefer-user-event': 'error',
+      // A snapshot passes on whatever the component rendered, so it detects
+      // change rather than asserting behavior.
+      'vitest/no-restricted-matchers': [
+        'error',
+        {
+          toMatchSnapshot: 'Assert on behavior and accessible roles instead.',
+          toMatchInlineSnapshot: 'Assert on behavior and accessible roles instead.',
+        },
+      ],
     },
   },
 ]);

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -15,6 +15,12 @@ import globals from 'globals';
 const SHADCN_SCAFFOLDS = ['src/components/ui/**/*.{ts,tsx}'];
 
 /**
+ * A snapshot passes on whatever the component rendered, so it detects change
+ * rather than asserting behavior.
+ */
+const SNAPSHOT_REFUSAL = 'Assert on behavior and accessible roles instead.';
+
+/**
  * `@eslint-react` and `eslint-plugin-react-hooks` both implement these.
  * react-hooks is first-party and compiler-backed, so it keeps them; enabling
  * both reports every hook violation twice.
@@ -111,14 +117,9 @@ export default defineConfig([
       // a parent re-render, so the rule's premise does not hold.
       '@eslint-react/no-nested-component-definitions': 'off',
       'testing-library/prefer-user-event': 'error',
-      // A snapshot passes on whatever the component rendered, so it detects
-      // change rather than asserting behavior.
       'vitest/no-restricted-matchers': [
         'error',
-        {
-          toMatchSnapshot: 'Assert on behavior and accessible roles instead.',
-          toMatchInlineSnapshot: 'Assert on behavior and accessible roles instead.',
-        },
+        { toMatchSnapshot: SNAPSHOT_REFUSAL, toMatchInlineSnapshot: SNAPSHOT_REFUSAL },
       ],
     },
   },

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Code conventions
 
-Conventions for how code in this repository is named, organized, and documented. Every convention stated here is a judgment call no tool can make. A convention a linter, formatter, or type checker can decide lives in that tool's configuration instead, and this page points at the gate rather than restating the rule. For the contribution workflow itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+Conventions for how code in this repository is named, organized, and documented. Everything here is a judgment no tool can make. What a tool can decide lives in that tool's configuration, and this page points there. For the contribution workflow itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ---
 
@@ -44,21 +44,21 @@ A rule holding for more than one tool belongs in `AGENTS.md`.
 
 ## Naming conventions
 
-Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`. [`.ls-lint.yml`](../../.ls-lint.yml) settles casing, one pattern per extension.
+Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`. [`.ls-lint.yml`](../../.ls-lint.yml) settles casing.
 
 ## Shared types
 
-Branded types in `packages/domain/` each get their own file (for example, `uuid.ts`, `iso-timestamp.ts`). Keep the guard that narrows to the brand in that same file, so a caller reaching for the type finds the check beside it.
+Branded types in `packages/domain/` each get their own file (for example, `uuid.ts`, `iso-timestamp.ts`). Keep the guard that narrows to the brand in that same file, so the check travels with the type.
 
-Rules about whether a value is legal, rather than whether it's well-formed, go in a sibling `*-validation.ts`: `artifact-plan.ts` holds the guard, `artifact-plan-validation.ts` the composition rules.
+Rules about whether a value is legal, rather than whether it's well-formed, go in a sibling `*-validation.ts`.
 
 ## React components
 
-[`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settles how a component is declared: a function declaration everywhere, with `React.forwardRef` left to the checked-in `shadcn/ui` kit.
+[`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settles how a component is declared.
 
 Colocate a small helper component in the same file as its only caller, as a private function that isn't exported. Promote it to its own file when a second caller appears.
 
-Apply Tailwind utility classes directly rather than inline `style` objects, and merge conditional class names with `cn()` from `@/lib/utils`. A value only the browser can compute—a measured offset, a percentage from live data—is the exception, which is why no rule forbids `style` outright.
+Apply Tailwind utility classes directly rather than inline `style` objects, and merge conditional class names with `cn()` from `@/lib/utils`. A value only the browser can compute—a measured offset, a percentage from live data—is the exception.
 
 ## Tests
 
@@ -72,17 +72,17 @@ Component tests query the way a user finds things—by accessible role or label 
 
 Mock network calls at the fetch or adapter boundary, not inside library internals.
 
-The Vitest, testing-library, and jest-dom rule sets in [`packages/eslint-config`](../../packages/eslint-config/index.js) and [`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settle which test function to call, which event API to drive, and which assertions to avoid.
+[`packages/eslint-config`](../../packages/eslint-config/index.js) and [`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settle the mechanics: which function declares a test, which API drives an interaction, which assertions to avoid.
 
 For what to assert, see the testing principles in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Test utilities
 
-Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The path is load-bearing: [`apps/api/tsconfig.build.json`](../../apps/api/tsconfig.build.json) excludes the directory from the build, and the shared ESLint config keys its test-file rules and its `devDependencies` allowance off the same `test/` segment.
+Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The directory name is load-bearing: [`apps/api/tsconfig.build.json`](../../apps/api/tsconfig.build.json) and the shared ESLint config both key off the `test/` segment, so renaming it changes what ships in the build and which rules apply.
 
 ## Platform compatibility
 
-This project runs on Windows, macOS, and Linux. Every check runs on Linux, so a hardcoded separator or an OS-specific environment variable surfaces on a contributor's machine rather than in a job.
+This project runs on Windows, macOS, and Linux. CI doesn't: every runner is Linux.
 
 - Use Node.js `path` module for paths, not hardcoded `/` or `\`
 - Use cross-platform approaches for file operations

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Code conventions
 
-Conventions for how code in this repository is named, organized, and documented. Everything here is a judgment no tool can make. What a tool can decide lives in that tool's configuration, and this page points there. For the contribution workflow itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+Conventions for how code in this repository is named, organized, and documented. Everything here is a judgment no tool can make. What a tool can decide lives in that tool's configuration, not on this page. For the contribution workflow and the checks a pull request has to pass, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ---
 
@@ -44,7 +44,7 @@ A rule holding for more than one tool belongs in `AGENTS.md`.
 
 ## Naming conventions
 
-Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`. [`.ls-lint.yml`](../../.ls-lint.yml) settles casing.
+Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`.
 
 ## Shared types
 
@@ -53,8 +53,6 @@ Branded types in `packages/domain/` each get their own file (for example, `uuid.
 Rules about whether a value is legal, rather than whether it's well-formed, go in a sibling `*-validation.ts`.
 
 ## React components
-
-[`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settles how a component is declared.
 
 Colocate a small helper component in the same file as its only caller, as a private function that isn't exported. Promote it to its own file when a second caller appears.
 
@@ -71,8 +69,6 @@ Structure:
 Component tests query the way a user finds things—by accessible role or label (`screen.getByRole('heading')`, `screen.getByLabelText('Email')`). Reach for a test ID only when no accessible query works.
 
 Mock network calls at the fetch or adapter boundary, not inside library internals.
-
-[`packages/eslint-config`](../../packages/eslint-config/index.js) and [`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settle the mechanics: which function declares a test, which API drives an interaction, which assertions to avoid.
 
 For what to assert, see the testing principles in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Code conventions
 
-Conventions for how code in this repository is named, organized, and documented. For the contribution workflow itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+Conventions for how code in this repository is named, organized, and documented. Every convention stated here is a judgment call no tool can make. A convention a linter, formatter, or type checker can decide lives in that tool's configuration instead, and this page points at the gate rather than restating the rule. For the contribution workflow itself, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ---
 
@@ -38,44 +38,47 @@ Avoid duplicating the same guidance across multiple locations. Place it once at 
 
 ## Naming conventions
 
-Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`.
+Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`. Casing is mechanical: [`.ls-lint.yml`](../../.ls-lint.yml) holds the pattern each extension has to match.
 
 ## Shared types
 
-Branded types in `packages/domain/` each get their own file (for example, `uuid.ts`, `iso-timestamp.ts`). Export both the type and any related validation functions from the same file.
+Branded types in `packages/domain/` each get their own file (for example, `uuid.ts`, `iso-timestamp.ts`). Keep the guard that narrows to the brand in that same file, so a caller reaching for the type finds the check beside it.
+
+Rules about whether a value is legal, rather than whether it's well-formed, go in a sibling `*-validation.ts`: `artifact-plan.ts` holds the guard, `artifact-plan-validation.ts` the composition rules.
 
 ## React components
 
-Page and layout components use function declarations (`export function CharactersPage()`). Reserve `const` with `React.forwardRef` for `shadcn/ui` primitives.
+[`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settles how a component is declared: a function declaration everywhere, with `React.forwardRef` left to the checked-in `shadcn/ui` kit.
 
 Colocate a small helper component in the same file as its only caller, as a private function that isn't exported. Promote it to its own file when a second caller appears.
 
-Apply Tailwind utility classes directly rather than inline `style` objects, and merge conditional class names with `cn()` from `@/lib/utils`.
+Apply Tailwind utility classes directly rather than inline `style` objects, and merge conditional class names with `cn()` from `@/lib/utils`. A value only the browser can compute—a measured offset, a percentage from live data—is the exception, which is why no rule forbids `style` outright.
 
 ## Tests
 
 Structure:
 
 - `describe` blocks mirror the module or component under test.
-- Use `it`, not `test`.
-- Name tests as plain-English sentences starting with a verb: `it('returns characters filtered by element')`.
+- Name tests as plain-English sentences starting with a verb: `it('returns characters filtered by element')`. A title opening on an acronym or a constant keeps its case: `it('PUTs the requested level')`.
 - Follow Arrange, Act, Assert within each test.
 
-Component tests query the way a user finds things—by accessible role or label (`screen.getByRole('heading')`, `screen.getByLabelText('Email')`). Reach for a test ID only when no accessible query works. Drive interactions with `userEvent` rather than `fireEvent`, and avoid snapshot tests for components; assert on behavior and accessible roles instead.
+Component tests query the way a user finds things—by accessible role or label (`screen.getByRole('heading')`, `screen.getByLabelText('Email')`). Reach for a test ID only when no accessible query works.
 
 Mock network calls at the fetch or adapter boundary, not inside library internals.
+
+The mechanical half of these conventions—`it` over `test`, `userEvent` over `fireEvent`, no component snapshots, awaited async queries—comes from the Vitest, testing-library, and jest-dom rule sets in [`packages/eslint-config`](../../packages/eslint-config/index.js) and [`apps/web/eslint.config.js`](../../apps/web/eslint.config.js).
 
 For what to assert, see the testing principles in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Test utilities
 
-Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The build excludes this directory via `tsconfig.build.json`.
+Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The path is load-bearing, not decorative: [`apps/api/tsconfig.build.json`](../../apps/api/tsconfig.build.json) excludes the directory from the build, and the shared ESLint config keys its test-file rules and its `devDependencies` allowance off the same `test/` segment.
 
 ---
 
 ## Platform compatibility
 
-This project runs on Windows, macOS, and Linux.
+This project runs on Windows, macOS, and Linux. Every check runs on Linux, so a hardcoded separator or an OS-specific environment variable surfaces on a contributor's machine rather than in a job.
 
 - Use Node.js `path` module for paths, not hardcoded `/` or `\`
 - Use cross-platform approaches for file operations

--- a/docs/reference/code-conventions.md
+++ b/docs/reference/code-conventions.md
@@ -44,7 +44,7 @@ A rule holding for more than one tool belongs in `AGENTS.md`.
 
 ## Naming conventions
 
-Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`. Casing is mechanical: [`.ls-lint.yml`](../../.ls-lint.yml) holds the pattern each extension has to match.
+Use descriptive, specific names for files and modules. Avoid generic names like "helpers." For example, name a shared test auth module `auth-requests.ts`, not `helpers.ts`. [`.ls-lint.yml`](../../.ls-lint.yml) settles casing, one pattern per extension.
 
 ## Shared types
 
@@ -72,15 +72,13 @@ Component tests query the way a user finds things—by accessible role or label 
 
 Mock network calls at the fetch or adapter boundary, not inside library internals.
 
-The mechanical half of these conventions—`it` over `test`, `userEvent` over `fireEvent`, no component snapshots, awaited async queries—comes from the Vitest, testing-library, and jest-dom rule sets in [`packages/eslint-config`](../../packages/eslint-config/index.js) and [`apps/web/eslint.config.js`](../../apps/web/eslint.config.js).
+The Vitest, testing-library, and jest-dom rule sets in [`packages/eslint-config`](../../packages/eslint-config/index.js) and [`apps/web/eslint.config.js`](../../apps/web/eslint.config.js) settle which test function to call, which event API to drive, and which assertions to avoid.
 
 For what to assert, see the testing principles in [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Test utilities
 
-Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The path is load-bearing, not decorative: [`apps/api/tsconfig.build.json`](../../apps/api/tsconfig.build.json) excludes the directory from the build, and the shared ESLint config keys its test-file rules and its `devDependencies` allowance off the same `test/` segment.
-
----
+Shared API test utilities live in `apps/api/src/test/` with descriptive file names. The path is load-bearing: [`apps/api/tsconfig.build.json`](../../apps/api/tsconfig.build.json) excludes the directory from the build, and the shared ESLint config keys its test-file rules and its `devDependencies` allowance off the same `test/` segment.
 
 ## Platform compatibility
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -49,6 +49,9 @@ const DEV_DEPENDENCY_FILES = [
 const VITEST_CONVENTIONS = {
   files: VITEST_FILES,
   extends: [vitest.configs.recommended],
+  rules: {
+    'vitest/consistent-test-it': ['error', { fn: 'it' }],
+  },
 };
 
 /**


### PR DESCRIPTION
Closes #950

`docs/reference/code-conventions.md` holds only judgments no tool can make. Three conventions it stated but nothing checked — `it` over `test`, `userEvent` over `fireEvent`, no component snapshots — are lint rules now. The rest of what a tool decides left the page rather than becoming a pointer at it: the introduction states the contract once, and `CONTRIBUTING.md` already answers which checks a change has to pass.

## Gotchas

- **Acceptance criterion 2 is deliberately unmet.** It asked enforced conventions to point at the enforcing gate; the page ended up with no pointers at all. `AGENTS.md` already documents `.ls-lint.yml`, so that one was duplication of the kind #1417 had just finished removing. The criterion needs amending at close-out.
- **Two sentences still name a config file.** Neither is a leftover pointer. `apps/api/src/test/` is load-bearing for both the build exclusion and the ESLint test globs, and every CI runner is Linux, so nothing exercises the platforms the compatibility rules exist for.
- **The shared-types section changed meaning, not just shape.** It claimed a branded type and its validation functions share a file; composition rules actually live in a sibling `*-validation.ts`.
- **The three rules land in two configs.** `consistent-test-it` is shared, so every workspace gets it. `prefer-user-event` needs testing-library, and the snapshot ban stays web-scoped on purpose — an inline snapshot of a serialized wire format is a defensible API test.
- **#1417's commits are in the diff.** It merged into `develop` mid-branch and edits the same file. The merge was clean.

## Verification

- Wrote a file violating all three new rules and linted it; each reported. No file in the repo violates them, so a passing lint alone wouldn't distinguish a live rule from an inert one.
- Diffed `eslint --print-config` before and after extracting `SNAPSHOT_REFUSAL`; rule entries identical.