### PR TITLE
docs: reconcile REST conventions with the API

### DIFF
--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -37,7 +37,7 @@ See [JSONSchema2020-12]: <https://json-schema.org/draft/2020-12>
 
 #### `profile` parameter negotiation
 
-Clients select a representation version with the `profile` parameter on `Accept`, naming the schema URI they expect. The API echoes the schema it used in the response `Content-Type`:
+Clients name the schema URI they expect in a `profile` parameter, on `Accept` for the response and on `Content-Type` for a request body. The API echoes the schema it served in the response `Content-Type`:
 
 ```http
 GET /health HTTP/1.1
@@ -47,26 +47,22 @@ HTTP/1.1 200 OK
 Content-Type: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/health/get-response-v1.json"
 ```
 
-Response negotiation rules:
-
-- **Profile omitted**: serves the latest representation version.
-- **Profile matches a supported version**: responds with that representation.
-- **Profile matches no supported version**: responds `406 Not Acceptable` in the RFC 9457 error format.
-- **`Accept` excludes `application/json`** (and any wildcard): responds `406 Not Acceptable`.
-
-A request body carries the same parameter on its `Content-Type`, naming the schema the endpoint validates it against:
-
 ```http
 PUT /characters/amber HTTP/1.1
 Content-Type: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/characters/put-request-v1.json"
 ```
 
-Request negotiation rules:
+The parameter reads the same way in both headers, and only its failure differs:
 
-- **Profile omitted**: validates against the latest request schema version.
-- **Profile matches a supported version**: validates against that schema.
-- **Profile matches no supported version**: responds `415 Unsupported Media Type`, because the server understood the header and can't honor it.
-- **`Content-Type` doesn't parse**: responds `400 Bad Request`.
+| The parameter             | On `Accept`               | On `Content-Type`             |
+| ------------------------- | ------------------------- | ----------------------------- |
+| Omitted                   | Serves the latest version | Validates against the latest  |
+| Names a supported version | Serves that version       | Validates against that schema |
+| Names no supported one    | `406 Not Acceptable`      | `415 Unsupported Media Type`  |
+
+That last split is deliberate. An `Accept` the API can't satisfy leaves it nothing to send, while an unsupported `Content-Type` names a schema it understood and won't take.
+
+Two failures sit outside the parameter. An `Accept` excluding `application/json` and every wildcard draws `406`, and a `Content-Type` that doesn't parse draws `400 Bad Request`.
 
 ### 5. Consistent error contract
 

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -47,12 +47,26 @@ HTTP/1.1 200 OK
 Content-Type: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/health/get-response-v1.json"
 ```
 
-Negotiation rules:
+Response negotiation rules:
 
 - **Profile omitted**: serves the latest representation version.
 - **Profile matches a supported version**: responds with that representation.
 - **Profile matches no supported version**: responds `406 Not Acceptable` in the RFC 9457 error format.
 - **`Accept` excludes `application/json`** (and any wildcard): responds `406 Not Acceptable`.
+
+A request body carries the same parameter on its `Content-Type`, naming the schema the endpoint validates it against:
+
+```http
+PUT /characters/amber HTTP/1.1
+Content-Type: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/characters/put-request-v1.json"
+```
+
+Request negotiation rules:
+
+- **Profile omitted**: validates against the latest request schema version.
+- **Profile matches a supported version**: validates against that schema.
+- **Profile matches no supported version**: responds `415 Unsupported Media Type`, because the server understood the header and can't honor it.
+- **`Content-Type` doesn't parse**: responds `400 Bad Request`.
 
 ### 5. Consistent error contract
 
@@ -88,21 +102,15 @@ See [RFC6750]: <https://www.rfc-editor.org/rfc/rfc6750>
 
 Encode API timestamps as ISO 8601 UTC strings.
 
-### 9. Profile field ownership
+### 9. Server-managed field ownership
 
-Resources combining data from multiple authorities assign each field to exactly one authority at the type level, and the API enforces that boundary on writes.
+A field the server owns appears in no request schema. Every request schema sets `additionalProperties: false`, so sending one draws `422 Unprocessable Content` with the `/problems/validation/additional-properties` type rather than a silent discard.
 
-| Category       | Authority                        | API behavior                                   | Example fields                  |
-| -------------- | -------------------------------- | ---------------------------------------------- | ------------------------------- |
-| Identity       | Firebase Auth (`DecodedIdToken`) | Read-only; projected from the decoded ID token | `uid`, `email`, `emailVerified` |
-| Profile        | Firestore                        | Mutable via `PATCH`                            | `name`                          |
-| System-managed | Firestore                        | Set automatically; rejected in `PATCH` input   | `createdAt`, `updatedAt`        |
-
-`PATCH` endpoints use `additionalProperties: false` in their JSON Schema to reject fields outside the mutable set.
+`createdAt` and `updatedAt` are server-managed on every resource, as is the owning account, which the verified token names instead of the body.
 
 ### 10. Field naming
 
-All API response fields are camelCase. Normalize casing at the translation boundary when projecting from upstream types that use other conventions (for example, `DecodedIdToken.email_verified`).
+All API response fields are camelCase. Normalize casing at the translation boundary when projecting from an upstream type that uses another convention, rather than letting it reach a response.
 
 ### 11. Validation status codes
 

--- a/docs/reference/rest-api-conventions.md
+++ b/docs/reference/rest-api-conventions.md
@@ -37,7 +37,7 @@ See [JSONSchema2020-12]: <https://json-schema.org/draft/2020-12>
 
 #### `profile` parameter negotiation
 
-Clients name the schema URI they expect in a `profile` parameter, on `Accept` for the response and on `Content-Type` for a request body. The API echoes the schema it served in the response `Content-Type`:
+Clients name the schema URI they expect in a `profile` parameter: on `Accept` for the response, on `Content-Type` for a request body. A response echoes the schema the API served.
 
 ```http
 GET /health HTTP/1.1
@@ -52,17 +52,15 @@ PUT /characters/amber HTTP/1.1
 Content-Type: application/json; profile="https://api.genshin.dungeon.studio/profiles/json-schema/characters/put-request-v1.json"
 ```
 
-The parameter reads the same way in both headers, and only its failure differs:
+| The parameter                | On `Accept`               | On `Content-Type`                   |
+| ---------------------------- | ------------------------- | ----------------------------------- |
+| Omitted                      | Serves the latest version | Validates against the latest schema |
+| Names a supported version    | Serves that version       | Validates against that schema       |
+| Names an unsupported version | `406 Not Acceptable`      | `415 Unsupported Media Type`        |
 
-| The parameter             | On `Accept`               | On `Content-Type`             |
-| ------------------------- | ------------------------- | ----------------------------- |
-| Omitted                   | Serves the latest version | Validates against the latest  |
-| Names a supported version | Serves that version       | Validates against that schema |
-| Names no supported one    | `406 Not Acceptable`      | `415 Unsupported Media Type`  |
+An `Accept` the API can't satisfy leaves it nothing to send. An unsupported `Content-Type` names a schema the API understood and won't take.
 
-That last split is deliberate. An `Accept` the API can't satisfy leaves it nothing to send, while an unsupported `Content-Type` names a schema it understood and won't take.
-
-Two failures sit outside the parameter. An `Accept` excluding `application/json` and every wildcard draws `406`, and a `Content-Type` that doesn't parse draws `400 Bad Request`.
+Outside the parameter, an `Accept` excluding `application/json` and every wildcard draws `406`, and a `Content-Type` that doesn't parse draws `400 Bad Request`.
 
 ### 5. Consistent error contract
 
@@ -98,15 +96,15 @@ See [RFC6750]: <https://www.rfc-editor.org/rfc/rfc6750>
 
 Encode API timestamps as ISO 8601 UTC strings.
 
-### 9. Server-managed field ownership
+### 9. Server-managed fields
 
 A field the server owns appears in no request schema. Every request schema sets `additionalProperties: false`, so sending one draws `422 Unprocessable Content` with the `/problems/validation/additional-properties` type rather than a silent discard.
 
-`createdAt` and `updatedAt` are server-managed on every resource, as is the owning account, which the verified token names instead of the body.
+`createdAt` and `updatedAt` are server-managed on every resource. So is the owning account, which the verified token names.
 
 ### 10. Field naming
 
-All API response fields are camelCase. Normalize casing at the translation boundary when projecting from an upstream type that uses another convention, rather than letting it reach a response.
+All API response fields are camelCase. Normalize casing at the translation boundary when projecting from an upstream type that uses another convention.
 
 ### 11. Validation status codes
 


### PR DESCRIPTION
Closes #957

## Summary

`docs/reference/rest-api-conventions.md` describes the API at HEAD again. An audit of all fourteen principles found ten accurate, two already filed against the code, and two describing the user-profile resource deleted in `984724f`. Principle 4 also gains the request half of profile negotiation — `Content-Type`'s `profile` parameter, with its 415 and 400 — live since the schema profiles landed and never written down.

## Gotchas

- **Principles 6 and 12 stay wrong on purpose.** Pagination is unimplemented (#1176), and `GET /` really serves nine links: five profile documents, two of them colliding on the last-segment key so three routes vanish (#1432, filed from this audit). Each principle is the contract the code has to meet.
- **Principle 4 still doesn't mention Collection+JSON**, the live media type for three routes. #777 retires it and owns this file's update.
- **The two `400`s differ.** Principle 4's is an unparseable `Content-Type`; principle 11's is a non-JSON body.

## Verification

- Booted the app under vitest and probed `GET /`, `OPTIONS` on every route, an unmatched path, and a rejected `Accept` — the `Allow` headers, `application/problem+json`, and the 404/406 bodies match principles 5, 12, 13, and 14.
