### PR TITLE
docs: note the dev-server restart after a lockfile change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ writing tests.
 - Declare every direct import explicitly, even when the same package exists at the root. Enforced by `import-x/no-extraneous-dependencies` in every workspace `eslint.config.js`; `devDependencies` may appear in test files (`*.test.ts`, `**/test/**`) and tooling configs (`eslint.config.js`, `*.config.{ts,js}`) but never in production source.
 - Classify packages correctly: `dependencies` for runtime code shipped to production, `devDependencies` for build tools, plugins, type definitions, and local tooling.
 - `pnpm-workspace.yaml` declares workspace package globs and engine constraints only; don't use it for version overrides.
-- Run `pnpm install` and commit `pnpm-lock.yaml` after dependency changes. Use `pnpm why <package>` to detect duplicate transitive versions. Restart any running dev server too: Vite caches module resolution at startup, so a stale server throws misleading `Cannot find module` errors.
+- Run `pnpm install` and commit `pnpm-lock.yaml` after dependency changes. Use `pnpm why <package>` to detect duplicate transitive versions. Restart any running dev server too, for the reason in [Quick start commands](CONTRIBUTING.md#quick-start-commands).
 - New workspace packages should match the root `package.json` metadata fields (`description`, `keywords`, `author`, `homepage`, `bugs`, `license`).
 - ESLint uses flat config via workspace-local `eslint.config.js` files; configure ignore patterns with `ignores`, not `.eslintignore`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,11 @@ pnpm dev
 > [Configure Firestore credentials](docs/how-tos/configure-firestore-credentials.md)
 > for setup instructions.
 
+After a `pnpm-lock.yaml` change, whether yours or one you pulled, run
+`pnpm install` and restart any dev server you already have running. Vite reads
+module resolution once at startup, so a running server reports
+`Cannot find module` for the new dependency until you restart it.
+
 ### What your pull request has to pass
 
 - Every pre-commit hook. Run `pre-commit install` once, and the same hooks run on each commit that CI runs over the whole tree—so a clean commit is a clean build. The first commit afterward builds each hook's environment and can take several minutes. `pre-commit run --all-files` reproduces CI exactly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ pnpm install
 pnpm dev
 ```
 
-After a `pnpm-lock.yaml` change, whether yours or one you pulled, run
-`pnpm install` and restart any dev server that's already running. Vite reads
-module resolution once at startup, so a server left running reports
+After a `pnpm-lock.yaml` change, restart any dev server that's already running.
+Vite reads module resolution once at startup, so a server left running reports
 `Cannot find module` for the new dependency.
 
 > **Note:** The API starts without Google Cloud credentials. Routes that don't

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,17 +58,17 @@ pnpm install
 pnpm dev
 ```
 
+After a `pnpm-lock.yaml` change, whether yours or one you pulled, run
+`pnpm install` and restart any dev server that's already running. Vite reads
+module resolution once at startup, so a server left running reports
+`Cannot find module` for the new dependency.
+
 > **Note:** The API starts without Google Cloud credentials. Routes that don't
 > use Firestore (health check, schemas) work immediately. Routes that read or
 > write Firestore (profiles, teams, characters, weapons) return 500 until you
 > configure credentials. See
 > [Configure Firestore credentials](docs/how-tos/configure-firestore-credentials.md)
 > for setup instructions.
-
-After a `pnpm-lock.yaml` change, whether yours or one you pulled, run
-`pnpm install` and restart any dev server you already have running. Vite reads
-module resolution once at startup, so a running server reports
-`Cannot find module` for the new dependency until you restart it.
 
 ### What your pull request has to pass
 


### PR DESCRIPTION
## Summary

Contributors who pull a lockfile change now find out from `CONTRIBUTING.md` that a
dev server already running has to be restarted, instead of chasing a
`Cannot find module` error that reinstalling doesn't fix. The explanation lands in
`CONTRIBUTING.md` because the documentation strategy in
[Code conventions](docs/reference/code-conventions.md) ranks it above `AGENTS.md`
for human workflow guidance; `AGENTS.md` keeps the imperative and links to the why
rather than holding a second copy of it.

## Gotchas

- The caveat deliberately doesn't tell contributors to reinstall. pnpm 11 defaults
  `verifyDepsBeforeRun` to `install` and re-checks on every `pnpm run`, and this
  repo doesn't override it, so the only step pnpm can't take for you is the
  restart.
- The caveat is plain prose sitting above the Firestore callout rather than a
  matching `> **Note:**`: markdownlint's `MD028` rejects two blockquotes separated
  by a blank line.
- `AGENTS.md` is loaded on every agent turn and `CONTRIBUTING.md` isn't, so an
  agent now follows a link for the reasoning. The actionable half of the rule
  ("restart any running dev server too") stays inline.

Closes #959
