### PR TITLE
fix(devcontainer): install google-cloud-cli

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -16,12 +16,12 @@ step "Installing pnpm via corepack"
 corepack enable
 corepack install
 
-step "Installing Google Cloud SDK"
+step "Installing Google Cloud CLI"
 
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/cloud.google.gpg &&
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list &&
   sudo DEBIAN_FRONTEND=noninteractive apt-get update &&
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y google-cloud-sdk
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y google-cloud-cli
 
 step "Installing project dependencies"
 


### PR DESCRIPTION
## Summary

Devcontainers can be created again. The cloud-sdk apt repository dropped the transitional `google-cloud-sdk` package, so `postCreateCommand.sh` failed at `apt-get install`. Every `Devcontainer` run since 2026-08-27 has been red, on `develop` and on all ten open Renovate branches. Closes #1461.

## Gotchas

- The sources.list filename stays `google-cloud-sdk.list`. It reads like a missed rename, but it's the name Google's own install documentation uses, and renaming it would leave an already-provisioned container with two files pointing at one repository.
- The full image build isn't verified locally. `Verify toolchain` on this PR is the first end-to-end proof, and it runs because `.devcontainer/**` is in that workflow's paths gate.
- Anything touching `package.json` or `pnpm-lock.yaml` trips the same check, so ten open pull requests unrelated to this one need a rebase onto it to go green.

## Verification

- Ran the script's apt block verbatim in a clean `debian:bookworm-slim` container: `google-cloud-cli` installed and `gcloud` resolved to `/usr/bin/gcloud`, reporting SDK 582.0.0.
- Checked the repository rather than trusting the error message: `dists/cloud-sdk/Release` serves 200, and the `binary-amd64` index carries 48 `google-cloud-cli` entries and no `google-cloud-sdk`. The source line and its `cloud-sdk` component stay as they are.
- `pre-commit run --files .devcontainer/postCreateCommand.sh` passed, shellcheck and shfmt included.
